### PR TITLE
Fixed remote's NullPointerException by adding 'Accept: application/json' in the request header

### DIFF
--- a/WebDriverBase.php
+++ b/WebDriverBase.php
@@ -133,7 +133,7 @@ abstract class WebDriverBase {
     $curl = curl_init($url);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_HTTPHEADER,
-                array('application/json;charset=UTF-8'));
+                array('application/json;charset=UTF-8', 'Accept: application/json'));
 
     if ($http_method === 'POST') {
       curl_setopt($curl, CURLOPT_POST, true);


### PR DESCRIPTION
Fix for this issue: https://github.com/facebook/php-webdriver/issues/9#issuecomment-3381300

Related: http://code.google.com/p/selenium/issues/detail?id=2091
