### PR TITLE
Error with some selenium servers and -1 content-length 

### DIFF
--- a/WebDriverBase.php
+++ b/WebDriverBase.php
@@ -132,23 +132,26 @@ abstract class WebDriverBase {
 
     $curl = curl_init($url);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt(
-      $curl,
-      CURLOPT_HTTPHEADER,
-      array(
+
+    $header = array(
         'Content-Type: application/json;charset=UTF-8',
-        'Accept: application/json'));
+        'Accept: application/json');
 
     if ($http_method === 'POST') {
       curl_setopt($curl, CURLOPT_POST, true);
       if ($params && is_array($params)) {
 	curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($params));
       } else {
-	curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-length: 0'));
+	$header[] = 'Content-length: 0';
       }
     } else if ($http_method == 'DELETE') {
       curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
     }
+
+    curl_setopt(
+      $curl,
+      CURLOPT_HTTPHEADER,
+      $header);
 
     foreach ($extra_opts as $option => $value) {
       curl_setopt($curl, $option, $value);


### PR DESCRIPTION
When sending a POST request, and not sending any data. Curl sets content-length to -1. This makes some selenium servers hang and makes the test fail.
This fix just sets the content-length to 0 if the request being built is of type POST and we are appending no post fields.

This is a little hacky. The real question is, is curl wrong for setting the content-length to -1 or is the server faulty for hanging on request with a -1 content-length.
