### PR TITLE
Better syntax support

### DIFF
--- a/WebDriverElement.php
+++ b/WebDriverElement.php
@@ -163,6 +163,7 @@ class WebDriverElement {
   public function sendKeys($value) {
     $params = array('value' => array((string)$value));
     $this->execute('sendKeysToElement', $params);
+    return $this;
   }
 
   /**


### PR DESCRIPTION
Please compare the following code:

``` php

$loginForm->findElement(WebDriverBy::xpath('//input[@name="email"]'))
    ->sendKeys('example@domain.com');
$passWordElement = $loginForm->findElement(WebDriverBy::xpath('//input[@name="password"]'));
$passWordElement->sendKeys('password');
Assert::same('password', $passWordElement->getAttribute('value'));

```

With the following pull is syntax simplier and nicer! :-)

``` php
$loginForm = $lightBox->findElement(WebDriverBy::id('frm-signInForm'));
$loginForm->findElement(WebDriverBy::xpath('//input[@name="email"]'))
    ->sendKeys('example@domain.com');
Assert::same('password', $loginForm->findElement(WebDriverBy::xpath('//input[@name="password"]'))
    ->sendKeys('password')
    ->getAttribute('value')
);
```
