### PR TITLE
Type hint in WebDriverWait constructor

### DIFF
--- a/lib/WebDriverWait.php
+++ b/lib/WebDriverWait.php
@@ -26,7 +26,7 @@ class WebDriverWait {
 
   public function __construct(
       WebDriver $driver,
-      int $timeout_in_second = null) {
+      $timeout_in_second = null) {
     $this->driver = $driver;
     $this->timeout = ($timeout_in_second) ? $timeout_in_second : 30;
   }


### PR DESCRIPTION
Type hints can not be used with scalar types such as int or string. [[1](http://php.net/manual/en/language.oop5.typehinting.php)]
