### PR TITLE
Fixed "must be an instance of string, string given" error in WebDriverEx...

### DIFF
--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -125,7 +125,7 @@ class WebDriverExpectedCondition {
    * @return bool Whether the text is presented.
    */
   public static function textToBePresentInElement(
-      WebDriverBy $by, string $text) {
+      WebDriverBy $by, $text) {
     return new WebDriverExpectedCondition(
       function ($driver) use ($by, $text) {
         try {
@@ -147,7 +147,7 @@ class WebDriverExpectedCondition {
    * @return bool Whether the text is presented.
    */
   public static function textToBePresentInElementValue(
-      WebDriverBy $by, string $text) {
+      WebDriverBy $by, $text) {
     return new WebDriverExpectedCondition(
       function ($driver) use ($by, $text) {
         try {
@@ -190,7 +190,7 @@ class WebDriverExpectedCondition {
    * @return bool Whether the text is found in the element located.
    */
   public static function invisibilityOfElementWithText(
-      WebDriverBy $by, string $text) {
+      WebDriverBy $by, $text) {
     return new WebDriverExpectedCondition(
       function ($driver) use ($by, $text) {
         try {


### PR DESCRIPTION
...pectedCondition.php

PHP type hinting does not work for strings.
