### PR TITLE
inTitle WebDriverExpectedCondition

### DIFF
--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -57,7 +57,7 @@ class WebDriverExpectedCondition {
   public static function titleContains($title) {
     return new WebDriverExpectedCondition(
       function ($driver) use ($title) {
-        return strpos($driver->getTitle(), $title) !== False;
+        return strpos($driver->getTitle(), $title) !== false;
       }
     );
   }


### PR DESCRIPTION
In addition to the titleIs Expected Condition which checks for an exact match, inTitle checks that the provided value is a substring of the page title.

Useful for dynamic asserts, or checking for dynamic title content when using a randomized testing environment.
