### PR TITLE
touch property not defined

### DIFF
--- a/lib/remote/RemoteWebDriver.php
+++ b/lib/remote/RemoteWebDriver.php
@@ -18,6 +18,7 @@ class RemoteWebDriver implements WebDriver {
   protected $executor;
   protected $mouse;
   protected $keyboard;
+  protected $touch;
 
   public function __construct(
       $url = 'http://localhost:4444/wd/hub',


### PR DESCRIPTION
```
1) WebDriverTest::testDoubleTap
ErrorException: Undefined property: RemoteWebDriver::$touch

vendor/facebook/webdriver/lib/remote/RemoteWebDriver.php(282)
vendor/facebook/webdriver/lib/interactions/WebDriverTouchActions.php(50)
```
