### PR TITLE
Fixed incorrect RemoteTouchScreen.php filename in __init__.php on line 76

### DIFF
--- a/lib/__init__.php
+++ b/lib/__init__.php
@@ -73,7 +73,7 @@ require_once('support/events/EventFiringWebElement.php');
 
 // touch
 require_once('interactions/WebDriverTouchScreen.php');
-require_once('remote/RemoteTouch.php');
+require_once('remote/RemoteTouchScreen.php');
 require_once('interactions/WebDriverTouchActions.php');
 require_once('interactions/touch/WebDriverTouchAction.php');
 require_once('interactions/touch/WebDriverDoubleTapAction.php');


### PR DESCRIPTION
It looks like the filename for remote/RemoteTouchScreen.php was recently changed from remote/RemoteTouch.php, but was never updated in **init**.php.
