### PR TITLE
Allow to extend RemoteWebDriver

### DIFF
--- a/lib/remote/RemoteWebDriver.php
+++ b/lib/remote/RemoteWebDriver.php
@@ -48,7 +48,7 @@ class RemoteWebDriver implements WebDriver {
       )
     );
 
-    $driver = new RemoteWebDriver();
+    $driver = new static();
     $executor = new HttpCommandExecutor(
       $url,
       $response['sessionId']
@@ -71,7 +71,7 @@ class RemoteWebDriver implements WebDriver {
     $session_id,
     $url = 'http://localhost:4444/wd/hub'
   ) {
-    $driver = new RemoteWebDriver();
+    $driver = new static();
     $driver->setCommandExecutor(new HttpCommandExecutor($url, $session_id));
     return $driver;
   }


### PR DESCRIPTION
New create*() methods always create instance of RemoteWebDriver which prevents from creating subclasses of this class. I think it is better to use `get_called_class()`
