### PR TITLE
Remove typehint string in `frameToBeAvailableAndSwitchToIt`

### DIFF
--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -192,8 +192,7 @@ class WebDriverExpectedCondition {
    * @return WebDriverExpectedCondition<WebDriver> object focused on new frame
    *         when frame is found bool false otherwise
    */
-  public static function frameToBeAvailableAndSwitchToIt(
-      string $frame_locator) {
+  public static function frameToBeAvailableAndSwitchToIt($frame_locator) {
     return new WebDriverExpectedCondition(
       function ($driver) use ($frame_locator) {
         try {


### PR DESCRIPTION
Type hints can not be used with scalar types such as int or string.

[See PHP documentation](http://www.php.net/manual/en/language.oop5.typehinting.php)
