### PR TITLE
Fix: Opera returns a tag-name in uppercase.

### DIFF
--- a/lib/remote/RemoteWebElement.php
+++ b/lib/remote/RemoteWebElement.php
@@ -189,9 +189,11 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
    * @return string The tag name.
    */
   public function getTagName() {
-    return $this->executor->execute(
-      'getElementTagName',
-      array(':id' => $this->id)
+    return strtolower(
+      $this->executor->execute(
+        'getElementTagName',
+        array(':id' => $this->id)
+      )
     );
   }
 


### PR DESCRIPTION
Opera returns a tag-name in uppercase. It causes problems because comparison only with names in lowercase is used in code. For example, I could not create an instance of the WebDriverSelect class and received exception because "SELECT" != "select".
