### PR TITLE
Throw exception when json_decode() of remote response fails

### DIFF
--- a/lib/remote/HttpCommandExecutor.php
+++ b/lib/remote/HttpCommandExecutor.php
@@ -211,6 +211,10 @@ class HttpCommandExecutor implements WebDriverCommandExecutor {
 
     $results = json_decode($raw_results, true);
 
+    if ($results === null && json_last_error() !== JSON_ERROR_NONE) {
+        throw new WebDriverException('JSON decoding of remote response failed. The response: \'' . $raw_results . '\'');
+    }
+
     $value = null;
     if (is_array($results) && array_key_exists('value', $results)) {
       $value = $results['value'];


### PR DESCRIPTION
When running tests against Saucelabs, error messages may appear in non-json format, such as `Invalid device name specified: iPhone`. This causes RemoteWebDriver->execute() to return `null` as the response value, which in turn causes errors downstream, such as (`[PHPUnit_Framework_Exception] Argument #2 (No Value) of PHPUnit_Framework_Assert::assertNotContains() must be a array, traversable or string`) when using RemoteWebDriver in Codeception/PHPUnit.

With this pr, the error message becomes much clearer:

```
 [WebDriverException]
 JSON decoding of response failed. The response: 'Invalid device name specified: iPhone'
```
