### PR TITLE
fix chrome driver php5.4 interface signatures

### DIFF
--- a/lib/chrome/ChromeDriver.php
+++ b/lib/chrome/ChromeDriver.php
@@ -41,11 +41,18 @@ class ChromeDriver extends RemoteWebDriver {
     $this->setSessionID($response->getSessionID());
   }
 
-  public static function create() {
+  public static function create(
+    $url = 'http://localhost:4444/wd/hub',
+    $desired_capabilities = null,
+    $timeout_in_ms = 300000
+  ) {
     throw new WebDriverException('Please use ChromeDriver::start() instead.');
   }
 
-  public static function createBySessionID() {
+  public static function createBySessionID(
+    $session_id,
+    $url = 'http://localhost:4444/wd/hub'
+  ) {
     throw new WebDriverException('Please use ChromeDriver::start() instead.');
   }
 }


### PR DESCRIPTION
Since php 5.4, to prevent conflicts with same method names from differents interfaces implemented, signatures must be identical. Otherwise, PHP will throw a fatal error ("Declaration must be compatible").

Even if these methods are deprecated, it would be great to don't have these PHP errors anymore.

Thank you.
