### PR TITLE
Force lowercase of tag name as a temporary fix for opera driver

### DIFF
--- a/lib/remote/RemoteWebElement.php
+++ b/lib/remote/RemoteWebElement.php
@@ -220,10 +220,14 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
    * @return string The tag name.
    */
   public function getTagName() {
-    return $this->executor->execute(
+    // Force tag name to be lowercase as expected by protocol for Opera driver
+    // until this issue is not resolved :
+    // https://github.com/operasoftware/operadriver/issues/102
+    // Remove it when fixed to be consistent with the protocol.
+    return strtolower($this->executor->execute(
       DriverCommand::GET_ELEMENT_TAG_NAME,
       array(':id' => $this->id)
-    );
+    ));
   }
 
   /**


### PR DESCRIPTION
Hi,

First of all, sorry to revive an existing issue.
I know that this issue is coming from Opera driver https://github.com/operasoftware/operadriver/issues/102
and was already closed in this project https://github.com/facebook/php-webdriver/pull/134 for good reasons.
But the project seems to be really dead...

If we need to go ahead, we may force temporary lowercase and remove this work around as soon as it would be fixed to stay consistent with the protocol.

Anyway, I was wondering if we can do it or it is a bad idea to differ from original sources just for a driver which may be no more updated?

Thanks
