### PR TITLE
Fix FirefoxProfile::encode() so FireFoxProfile works for Windows Users as well

### DIFF
--- a/lib/firefox/FirefoxProfile.php
+++ b/lib/firefox/FirefoxProfile.php
@@ -61,36 +61,35 @@ class FirefoxProfile {
 	$temp_dir = $this->createTempDirectory('WebDriverFirefoxProfile');
 
 	foreach ($this->extensions as $extension) {
-		$this->installExtension($extension, $temp_dir);
+      $this->installExtension($extension, $temp_dir);
 	}
 
 	$content = "";
 	foreach ($this->preferences as $key => $value) {
-		$content .= sprintf("user_pref(\"%s\", %s);\n", $key, $value);
+      $content .= sprintf("user_pref(\"%s\", %s);\n", $key, $value);
 	}
-	// We should name this prefs.js as these settings will be loaded in prefs.js anyway.
 	file_put_contents($temp_dir.'/user.js', $content);
 
-	$zip = new ZipArchive();
-	$temp_zip = tempnam('', 'WebDriverFirefoxProfileZip');
-	$zip->open($temp_zip, ZipArchive::CREATE);
+    $zip = new ZipArchive();
+    $temp_zip = tempnam('', 'WebDriverFirefoxProfileZip');
+    $zip->open($temp_zip, ZipArchive::CREATE);
 
 	$dir = new RecursiveDirectoryIterator($temp_dir);
 	$files = new RecursiveIteratorIterator($dir);
 	foreach ($files as $name => $object) {
-		if (is_dir($name)) {
-			continue;
-		}
-		if(strcmp(basename($name), "user.js") == 0) {
-			// addFromString is used instead for adding prefs.js as addFile fails on Windows machines
-			$zip->addFromString(basename($name), file_get_contents($name));
-		}
-		else {
-			// It seems that this function always returns null as a path on Windows?
-			// Should probably try to fix this preg_replace to work on Windows as well.
-			$path = preg_replace("#^{$temp_dir}/#", "", $name);
-			$zip->addFile($name, $path);
-		}
+      if (is_dir($name)) {
+        continue;
+      }
+      if(strcmp(basename($name), "user.js") == 0) {
+        // addFromString is used instead for adding users.js as addFile fails on Windows machines
+        $zip->addFromString(basename($name), file_get_contents($name));
+      }
+      else {
+        // It seems that this function always returns null as a path on Windows?
+        // Should probably try to fix this preg_replace to work on Windows as well.
+        $path = preg_replace("#^{$temp_dir}/#", "", $name);
+        $zip->addFile($name, $path);
+      }
 	}
 	$zip->close();
 


### PR DESCRIPTION
Some minor changes but this seems to have solved the issue that was raised in: https://github.com/facebook/php-webdriver/issues/165#.

There are some further possible improvements that can be made to encode() after extensive debugging of this function but I'll leave those open for another time. 
