### PR TITLE
Fix for creating a new session

### DIFF
--- a/lib/remote/HttpCommandExecutor.php
+++ b/lib/remote/HttpCommandExecutor.php
@@ -184,7 +184,13 @@ class HttpCommandExecutor implements WebDriverCommandExecutor {
     }
 
     curl_setopt($this->curl, CURLOPT_URL, $this->url . $url);
-    curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, $http_method);
+    switch ($command->getName()) {
+      case 'newSession':
+        curl_setopt($this->curl, CURLOPT_POST, 1);
+        break;
+      default:
+        curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, $http_method);
+    }
     $encoded_params = null;
     if ($http_method === 'POST' && $params && is_array($params)) {
       $encoded_params = json_encode($params);


### PR DESCRIPTION
New sessions should follow up a 300 level redirect with a GET instead of forcing another POST. Fixes #173
