### PR TITLE
Do not hardcode CURL's request timeout, added ability to set custom timeout

### DIFF
--- a/lib/remote/HttpCommandExecutor.php
+++ b/lib/remote/HttpCommandExecutor.php
@@ -133,24 +133,37 @@ class HttpCommandExecutor implements WebDriverCommandExecutor {
         'Accept: application/json',
       )
     );
-    curl_setopt($this->curl, CURLOPT_TIMEOUT_MS, 300000);
+
+    $this->setRequestTimeout(300000);
     $this->setConnectionTimeout(300000);
   }
 
   /**
-   * @param int $timeout
+   * Set timeout for the connect phase
+   *
+   * @param int $timeout_in_ms Timeout in milliseconds
    * @return HttpCommandExecutor
    */
-  public function setConnectionTimeout($timeout) {
+  public function setConnectionTimeout($timeout_in_ms) {
     // There is a PHP bug in some versions which didn't define the constant.
-    curl_setopt($this->curl, /* CURLOPT_CONNECTTIMEOUT_MS */ 156, $timeout);
+    curl_setopt($this->curl, /* CURLOPT_CONNECTTIMEOUT_MS */ 156, $timeout_in_ms);
+    return $this;
+  }
+
+  /**
+   * Set maximum time the request is allowed to take
+   *
+   * @param int $timeout_in_ms Timeout in milliseconds
+   * @return HttpCommandExecutor
+   */
+  public function setRequestTimeout($timeout_in_ms)
+  {
+    curl_setopt($this->curl, CURLOPT_TIMEOUT_MS, $timeout_in_ms);
     return $this;
   }
 
   /**
    * @param WebDriverCommand $command
-   * @param array $curl_opts An array of curl options.
-   *
    * @return mixed
    */
   public function execute(WebDriverCommand $command) {

--- a/lib/remote/RemoteWebDriver.php
+++ b/lib/remote/RemoteWebDriver.php
@@ -64,6 +64,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
 
     $executor = new HttpCommandExecutor($url);
     $executor->setConnectionTimeout($timeout_in_ms);
+    $executor->setRequestTimeout($timeout_in_ms);
 
     $command = new WebDriverCommand(
       null,


### PR DESCRIPTION
Commit https://github.com/facebook/php-webdriver/commit/f666d1d41aebc9b663ed20a2ffe748d9a34a29f5 hardcoded curl's request request timeout to 300 seconds. 

But if you use Selenium in grid mode and have a long queue of waiting requests, it could take much longer than 5 minutes until the session create request is finished on the Selenium hub and the sessionId is acquired.  So you have to overwrite the timeout to something more reasonable than 300 seconds, what is now impossible in current master.
