### PR TITLE
review TouchActions to be performed and compliant with java

### DIFF
--- a/lib/interactions/WebDriverTouchActions.php
+++ b/lib/interactions/WebDriverTouchActions.php
@@ -16,39 +16,16 @@
 /**
  * WebDriver action builder for touch events
  */
-class WebDriverTouchActions {
+class WebDriverTouchActions extends WebDriverActions {
 
   /**
    * @var WebDriverTouchScreen
    */
   protected $touchScreen;
 
-  /**
-   * @var WebDriver
-   */
-  protected $driver;
-
-  /**
-   * @var WebDriverKeyboard
-   */
-  protected $keyboard;
-
-  /**
-   * @var WebDriverMouse
-   */
-  protected $mouse;
-
-  /**
-   * @var WebDriverCompositeAction
-   */
-  protected $action;
-
   public function __construct(WebDriver $driver) {
-    $this->driver = $driver;
-    $this->keyboard = $driver->getKeyboard();
-    $this->mouse = $driver->getMouse();
+    parent::__construct($driver);
     $this->touchScreen = $driver->getTouch();
-    $this->action = new WebDriverCompositeAction();
   }
 
   /**


### PR DESCRIPTION
Java implementation here : 
- https://code.google.com/p/selenium/source/browse/java/client/src/org/openqa/selenium/interactions/touch/TouchActions.java#32

The Python implementation did an another approach, which is to just add a public method perform() to the TouchActions class : 
- https://code.google.com/p/selenium/source/browse/py/selenium/webdriver/common/touch_actions.py#24

But I prefer the Java approach because first, this is the reference and you can also play with the parent methods if you want.

Anyway, it needs a review because we can't perform actions with this actual class !
