### PR TITLE
Add ChromeDriverService parameter in ChromeDriver constructor

### DIFF
--- a/lib/chrome/ChromeDriver.php
+++ b/lib/chrome/ChromeDriver.php
@@ -16,12 +16,13 @@
 class ChromeDriver extends RemoteWebDriver {
 
   public static function start(
-    DesiredCapabilities $desired_capabilities = null
+    DesiredCapabilities $desired_capabilities = null,
+    ChromeDriverService $service = null
   ) {
     if ($desired_capabilities === null) {
       $desired_capabilities = DesiredCapabilities::chrome();
     }
-    $service = ChromeDriverService::createDefaultService();
+    $service = $service ? $service : ChromeDriverService::createDefaultService();
     $executor = new DriverCommandExecutor($service);
     $driver = new static();
     $driver->setCommandExecutor($executor)


### PR DESCRIPTION
Hi,

Should be nice if like the Java client, we could provide a ChromeDriverService instance to the ChromeDriver constructor.
See : https://code.google.com/p/selenium/source/browse/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java#170
(order is not the same but keep it for compatibility).
It allow us to set our own port (--port) and arguments (--adb-port, --verbose, --silent, --log-path, etc).

Thanks !
