### PR TITLE
Add support for sending Chrome DevTools commands

### DIFF
--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -6,7 +6,6 @@ use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\DriverCommand;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
 use Facebook\WebDriver\Remote\WebDriverCommand;
 
 class ChromeDriver extends RemoteWebDriver
@@ -22,7 +21,7 @@ class ChromeDriver extends RemoteWebDriver
         if ($service === null) {
             $service = ChromeDriverService::createDefaultService();
         }
-        $executor = new DriverCommandExecutor($service);
+        $executor = new ChromeDriverCommandExecutor($service);
         $driver = new static($executor, null, $desired_capabilities);
         $driver->startSession($desired_capabilities);
 
@@ -90,5 +89,37 @@ class ChromeDriver extends RemoteWebDriver
         $request_timeout_in_ms = null
     ) {
         throw new WebDriverException('Please use ChromeDriver::start() instead.');
+    }
+
+    /**
+     * Executes a Chrome DevTools command
+     *
+     * @param string $command The DevTools command to execute
+     * @param array $parameters Optional parameters to the command
+     */
+    public function sendCommand($command, array $parameters = [])
+    {
+        $params = ['cmd' => $command, 'params' => (object) $parameters];
+        $this->execute(
+            ChromeDriverCommand::SEND_COMMAND,
+            $params
+        );
+    }
+
+    /**
+     * Executes a Chrome DevTools command and returns the result
+     *
+     * @param string $command The DevTools command to execute
+     * @param array $parameters Optional parameters to the command
+     * @return array The result of the command
+     */
+    public function sendCommandAndGetResult($command, array $parameters = [])
+    {
+        $params = ['cmd' => $command, 'params' => (object) $parameters];
+
+        return $this->execute(
+            ChromeDriverCommand::SEND_COMMAND_AND_GET_RESULT,
+            $params
+        );
     }
 }

--- a/lib/Chrome/ChromeDriverCommand.php
+++ b/lib/Chrome/ChromeDriverCommand.php
@@ -2,9 +2,18 @@
 
 namespace Facebook\WebDriver\Chrome;
 
+/**
+ * Constants defining chrome-specific commands
+ *
+ * @codeCoverageIgnore
+ */
 class ChromeDriverCommand
 {
     // Chrome DevTools API
     const SEND_COMMAND = 'sendCommand';
     const SEND_COMMAND_AND_GET_RESULT = 'sendCommandAndGetResult';
+
+    private function __construct()
+    {
+    }
 }

--- a/lib/Chrome/ChromeDriverCommand.php
+++ b/lib/Chrome/ChromeDriverCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Facebook\WebDriver\Chrome;
+
+class ChromeDriverCommand
+{
+    // Chrome DevTools API
+    const SEND_COMMAND = 'sendCommand';
+    const SEND_COMMAND_AND_GET_RESULT = 'sendCommandAndGetResult';
+}

--- a/lib/Chrome/ChromeDriverCommandExecutor.php
+++ b/lib/Chrome/ChromeDriverCommandExecutor.php
@@ -5,21 +5,26 @@ namespace Facebook\WebDriver\Chrome;
 use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
 use Facebook\WebDriver\Remote\Service\DriverService;
 
+/**
+ * Extend command executor by adding proprietary Chromium commands
+ */
 class ChromeDriverCommandExecutor extends DriverCommandExecutor
 {
+    protected static $chromeCommands = [
+        ChromeDriverCommand::SEND_COMMAND => [
+            'method' => 'POST',
+            'url' => '/session/:sessionId/chromium/send_command',
+        ],
+        ChromeDriverCommand::SEND_COMMAND_AND_GET_RESULT => [
+            'method' => 'POST',
+            'url' => '/session/:sessionId/chromium/send_command_and_get_result',
+        ],
+    ];
+
     public function __construct(DriverService $service)
     {
         parent::__construct($service);
 
-        self::$commands = array_merge(self::$commands, [
-            ChromeDriverCommand::SEND_COMMAND => [
-                'method' => 'POST',
-                'url' => '/session/:sessionId/chromium/send_command',
-            ],
-            ChromeDriverCommand::SEND_COMMAND_AND_GET_RESULT => [
-                'method' => 'POST',
-                'url' => '/session/:sessionId/chromium/send_command_and_get_result',
-            ],
-        ]);
+        self::$commands = array_merge(self::$commands, self::$chromeCommands);
     }
 }

--- a/lib/Chrome/ChromeDriverCommandExecutor.php
+++ b/lib/Chrome/ChromeDriverCommandExecutor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Facebook\WebDriver\Chrome;
+
+use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
+use Facebook\WebDriver\Remote\Service\DriverService;
+
+class ChromeDriverCommandExecutor extends DriverCommandExecutor
+{
+    public function __construct(DriverService $service)
+    {
+        parent::__construct($service);
+
+        self::$commands = array_merge(self::$commands, [
+            ChromeDriverCommand::SEND_COMMAND => [
+                'method' => 'POST',
+                'url' => '/session/:sessionId/chromium/send_command',
+            ],
+            ChromeDriverCommand::SEND_COMMAND_AND_GET_RESULT => [
+                'method' => 'POST',
+                'url' => '/session/:sessionId/chromium/send_command_and_get_result',
+            ],
+        ]);
+    }
+}

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -32,6 +32,34 @@ class ChromeDriverTest extends TestCase
 
     public function testShouldStartChromeDriver()
     {
+        $this->startChromedriver();
+
+        $this->assertInstanceOf(ChromeDriver::class, $this->driver);
+        $this->assertInstanceOf(DriverCommandExecutor::class, $this->driver->getCommandExecutor());
+
+        $this->driver->get('http://localhost:8000/');
+
+        $this->assertSame('http://localhost:8000/', $this->driver->getCurrentURL());
+
+        $this->driver->quit();
+    }
+
+    public function testShouldExecuteDevToolsCommands()
+    {
+        $this->startChromedriver();
+
+        $result = $this->driver->sendCommandAndGetResult('Runtime.evaluate', [
+            'returnByValue' => true,
+            'expression' => '42 + 1',
+        ]);
+        $this->assertSame('number', $result['result']['type']);
+        $this->assertSame(43, $result['result']['value']);
+
+        $this->driver->quit();
+    }
+
+    private function startChromedriver()
+    {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=' . getenv('CHROMEDRIVER_PATH'));
 
@@ -42,14 +70,5 @@ class ChromeDriverTest extends TestCase
         $desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
 
         $this->driver = ChromeDriver::start($desiredCapabilities);
-
-        $this->assertInstanceOf(ChromeDriver::class, $this->driver);
-        $this->assertInstanceOf(DriverCommandExecutor::class, $this->driver->getCommandExecutor());
-
-        $this->driver->get('http://localhost:8000/');
-
-        $this->assertSame('http://localhost:8000/', $this->driver->getCurrentURL());
-
-        $this->driver->quit();
     }
 }

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @group exclude-saucelabs
  * @covers \Facebook\WebDriver\Chrome\ChromeDriver
+ * @covers \Facebook\WebDriver\Chrome\ChromeDriverCommandExecutor
  */
 class ChromeDriverTest extends TestCase
 {


### PR DESCRIPTION
ChromeDriver has two endpoints for calling the DevTools API. This PR adds support for calling these endpoints (sending DevTools commands) using php-webdriver. 