### PR TITLE
Implement web storage (localStorage and sessionStorage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for current Firefox XPI extension format. Extensions could now be loaded into `FirefoxProfile` using `addExtension()` method.
 - `setProfile()` method to `FirefoxOptions`, which is now a preferred way to set Firefox Profile.
+- Local storage and session storage support via the new `RemoteWebDriver::storage()` method.
 
 ### Changed
 - Handle errors when taking screenshots. `WebDriverException` is thrown if WebDriver returns empty or invalid screenshot data.

--- a/lib/Html5/LocalStorageInterface.php
+++ b/lib/Html5/LocalStorageInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Facebook\WebDriver\Html5;
+
+/**
+ * Represents the local storage for the site currently opened in the browser.
+ */
+interface LocalStorageInterface
+{
+    /**
+     * Remove all of the items from the storage.
+     */
+    public function clear();
+
+    /**
+     * Retrieve an item from the storage.
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function getItem($key);
+
+    /**
+     * Get all the keys in storage.
+     *
+     * @return string[]
+     */
+    public function keySet();
+
+    /**
+     * Remove a single item from the storage.
+     *
+     * @param string $key
+     */
+    public function removeItem($key);
+
+    /**
+     * Set an item in the storage.
+     *
+     * @param string $key
+     * @param string $value
+     */
+    public function setItem($key, $value);
+
+    /**
+     * Get the number of keys in the storage.
+     *
+     * @return int
+     */
+    public function size();
+}

--- a/lib/Html5/SessionStorageInterface.php
+++ b/lib/Html5/SessionStorageInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Facebook\WebDriver\Html5;
+
+/**
+ * Represents the session storage for the site currently opened in the browser.
+ */
+interface SessionStorageInterface
+{
+    /**
+     * Remove all of the items from the storage.
+     */
+    public function clear();
+
+    /**
+     * Retrieve an item from the storage.
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function getItem($key);
+
+    /**
+     * Get all the keys in storage.
+     *
+     * @return string[]
+     */
+    public function keySet();
+
+    /**
+     * Remove a single item from the storage.
+     *
+     * @param string $key
+     */
+    public function removeItem($key);
+
+    /**
+     * Set an item in the storage.
+     *
+     * @param string $key
+     * @param string $value
+     */
+    public function setItem($key, $value);
+
+    /**
+     * Get the number of keys in the storage.
+     *
+     * @return int
+     */
+    public function size();
+}

--- a/lib/Html5/WebStorageInterface.php
+++ b/lib/Html5/WebStorageInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Facebook\WebDriver\Html5;
+
+/**
+ * Represents browser storage for the current site.
+ */
+interface WebStorageInterface
+{
+    /**
+     * Get the local storage for the site currently opened in the browser.
+     *
+     * @return LocalStorageInterface
+     */
+    public function getLocalStorage();
+
+    /**
+     * Get the session storage for the site currently opened in the browser.
+     *
+     * @return SessionStorageInterface
+     */
+    public function getSessionStorage();
+}

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -81,20 +81,6 @@ class DriverCommand
     const CLEAR_APP_CACHE = 'clearAppCache';
     const IS_BROWSER_ONLINE = 'isBrowserOnline';
     const SET_BROWSER_ONLINE = 'setBrowserOnline';
-    // Local storage
-    const GET_LOCAL_STORAGE_ITEM = 'getLocalStorageItem';
-    const GET_LOCAL_STORAGE_KEYS = 'getLocalStorageKeys';
-    const SET_LOCAL_STORAGE_ITEM = 'setLocalStorageItem';
-    const REMOVE_LOCAL_STORAGE_ITEM = 'removeLocalStorageItem';
-    const CLEAR_LOCAL_STORAGE = 'clearLocalStorage';
-    const GET_LOCAL_STORAGE_SIZE = 'getLocalStorageSize';
-    // Session storage
-    const GET_SESSION_STORAGE_ITEM = 'getSessionStorageItem';
-    const GET_SESSION_STORAGE_KEYS = 'getSessionStorageKey';
-    const SET_SESSION_STORAGE_ITEM = 'setSessionStorageItem';
-    const REMOVE_SESSION_STORAGE_ITEM = 'removeSessionStorageItem';
-    const CLEAR_SESSION_STORAGE = 'clearSessionStorage';
-    const GET_SESSION_STORAGE_SIZE = 'getSessionStorageSize';
     // Screen orientation
     const SET_SCREEN_ORIENTATION = 'setScreenOrientation';
     const GET_SCREEN_ORIENTATION = 'getScreenOrientation';
@@ -133,16 +119,32 @@ class DriverCommand
     // Mobile API
     const GET_NETWORK_CONNECTION = 'getNetworkConnection';
     const SET_NETWORK_CONNECTION = 'setNetworkConnection';
+
     // Custom command
     const CUSTOM_COMMAND = 'customCommand';
+
+    // Local storage
+    const GET_LOCAL_STORAGE_ITEM = 'getLocalStorageItem';
+    const GET_LOCAL_STORAGE_KEYS = 'getLocalStorageKeys';
+    const SET_LOCAL_STORAGE_ITEM = 'setLocalStorageItem';
+    const REMOVE_LOCAL_STORAGE_ITEM = 'removeLocalStorageItem';
+    const CLEAR_LOCAL_STORAGE = 'clearLocalStorage';
+    const GET_LOCAL_STORAGE_SIZE = 'getLocalStorageSize';
+    // Session storage
+    const GET_SESSION_STORAGE_ITEM = 'getSessionStorageItem';
+    const GET_SESSION_STORAGE_KEYS = 'getSessionStorageKey';
+    const SET_SESSION_STORAGE_ITEM = 'setSessionStorageItem';
+    const REMOVE_SESSION_STORAGE_ITEM = 'removeSessionStorageItem';
+    const CLEAR_SESSION_STORAGE = 'clearSessionStorage';
+    const GET_SESSION_STORAGE_SIZE = 'getSessionStorageSize';
 
     // W3C specific
     const ACTIONS = 'actions';
     const GET_ELEMENT_PROPERTY = 'getElementProperty';
     const GET_NAMED_COOKIE = 'getNamedCookie';
+    const MINIMIZE_WINDOW = 'minimizeWindow';
     const NEW_WINDOW = 'newWindow';
     const TAKE_ELEMENT_SCREENSHOT = 'takeElementScreenshot';
-    const MINIMIZE_WINDOW = 'minimizeWindow';
 
     private function __construct()
     {

--- a/lib/Remote/Html5/RemoteLocalStorage.php
+++ b/lib/Remote/Html5/RemoteLocalStorage.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Html5;
+
+use Facebook\WebDriver\Html5\LocalStorageInterface;
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+
+/**
+ * Executes the commands to access HTML5 localStorage on the remote webdriver server.
+ */
+class RemoteLocalStorage implements LocalStorageInterface
+{
+    /**
+     * @var RemoteExecuteMethod
+     */
+    private $executor;
+
+    /**
+     * @param RemoteExecuteMethod $executor
+     */
+    public function __construct(RemoteExecuteMethod $executor)
+    {
+        $this->executor = $executor;
+    }
+
+    public function clear()
+    {
+        $this->executor->execute(DriverCommand::CLEAR_LOCAL_STORAGE);
+    }
+
+    public function getItem($key)
+    {
+        return $this->executor->execute(DriverCommand::GET_LOCAL_STORAGE_ITEM, [
+            ':key' => $key,
+        ]);
+    }
+
+    public function keySet()
+    {
+        return $this->executor->execute(DriverCommand::GET_LOCAL_STORAGE_KEYS);
+    }
+
+    public function removeItem($key)
+    {
+        $this->executor->execute(DriverCommand::REMOVE_LOCAL_STORAGE_ITEM, [
+            ':key' => $key,
+        ]);
+    }
+
+    public function setItem($key, $value)
+    {
+        $this->executor->execute(DriverCommand::SET_LOCAL_STORAGE_ITEM, [
+            'key' => $key,
+            'value' => $value,
+        ]);
+    }
+
+    public function size()
+    {
+        return $this->executor->execute(DriverCommand::GET_LOCAL_STORAGE_SIZE);
+    }
+}

--- a/lib/Remote/Html5/RemoteSessionStorage.php
+++ b/lib/Remote/Html5/RemoteSessionStorage.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Html5;
+
+use Facebook\WebDriver\Html5\SessionStorageInterface;
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+
+/**
+ * Executes the commands to access HTML5 sessionStorage on the remote webdriver server.
+ */
+class RemoteSessionStorage implements SessionStorageInterface
+{
+    /**
+     * @var RemoteExecuteMethod
+     */
+    private $executor;
+
+    /**
+     * @param RemoteExecuteMethod $executor
+     */
+    public function __construct(RemoteExecuteMethod $executor)
+    {
+        $this->executor = $executor;
+    }
+
+    public function clear()
+    {
+        $this->executor->execute(DriverCommand::CLEAR_SESSION_STORAGE);
+    }
+
+    public function getItem($key)
+    {
+        return $this->executor->execute(DriverCommand::GET_SESSION_STORAGE_ITEM, [
+            ':key' => $key,
+        ]);
+    }
+
+    public function keySet()
+    {
+        return $this->executor->execute(DriverCommand::GET_SESSION_STORAGE_KEYS);
+    }
+
+    public function removeItem($key)
+    {
+        $this->executor->execute(DriverCommand::REMOVE_SESSION_STORAGE_ITEM, [
+            ':key' => $key,
+        ]);
+    }
+
+    public function setItem($key, $value)
+    {
+        $this->executor->execute(DriverCommand::SET_SESSION_STORAGE_ITEM, [
+            'key' => $key,
+            'value' => $value,
+        ]);
+    }
+
+    public function size()
+    {
+        return $this->executor->execute(DriverCommand::GET_SESSION_STORAGE_SIZE);
+    }
+}

--- a/lib/Remote/Html5/RemoteWebStorage.php
+++ b/lib/Remote/Html5/RemoteWebStorage.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Html5;
+
+use Facebook\WebDriver\Html5\WebStorageInterface;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+
+/**
+ * Provides remote access to the WebStorage API.
+ */
+class RemoteWebStorage implements WebStorageInterface
+{
+    /**
+     * @var RemoteExecuteMethod
+     */
+    private $executor;
+
+    /**
+     * @param RemoteExecuteMethod $executor
+     */
+    public function __construct(RemoteExecuteMethod $executor)
+    {
+        $this->executor = $executor;
+    }
+
+    public function getLocalStorage()
+    {
+        return new RemoteLocalStorage($this->executor);
+    }
+
+    public function getSessionStorage()
+    {
+        return new RemoteSessionStorage($this->executor);
+    }
+}

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -18,6 +18,11 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         'Accept: application/json',
     ];
 
+    /** @internal */
+    const SESSION_STORAGE = '/session/:sessionId/session_storage';
+    /** @internal */
+    const LOCAL_STORAGE = '/session/:sessionId/local_storage';
+
     /**
      * @see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#command-reference
      */
@@ -130,7 +135,25 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::TOUCH_MOVE => ['method' => 'POST', 'url' => '/session/:sessionId/touch/move'],
         DriverCommand::TOUCH_SCROLL => ['method' => 'POST', 'url' => '/session/:sessionId/touch/scroll'],
         DriverCommand::TOUCH_UP => ['method' => 'POST', 'url' => '/session/:sessionId/touch/up'],
+
         DriverCommand::CUSTOM_COMMAND => [],
+
+        // Commands which are not part of W3C specification, but remote ends usually implements them
+        DriverCommand::CLEAR_LOCAL_STORAGE => ['method' => 'DELETE', 'url' => self::LOCAL_STORAGE],
+        DriverCommand::CLEAR_SESSION_STORAGE => ['method' => 'DELETE', 'url' => self::SESSION_STORAGE],
+        DriverCommand::GET_LOCAL_STORAGE_ITEM => ['method' => 'GET', 'url' => self::LOCAL_STORAGE . '/key/:key'],
+        DriverCommand::GET_LOCAL_STORAGE_KEYS => ['method' => 'GET', 'url' => self::LOCAL_STORAGE],
+        DriverCommand::GET_LOCAL_STORAGE_SIZE => ['method' => 'GET', 'url' => self::LOCAL_STORAGE . '/size'],
+        DriverCommand::GET_SESSION_STORAGE_ITEM => ['method' => 'GET', 'url' => self::SESSION_STORAGE . '/key/:key'],
+        DriverCommand::GET_SESSION_STORAGE_KEYS => ['method' => 'GET', 'url' => self::SESSION_STORAGE],
+        DriverCommand::GET_SESSION_STORAGE_SIZE => ['method' => 'GET', 'url' => self::SESSION_STORAGE . '/size'],
+        DriverCommand::REMOVE_LOCAL_STORAGE_ITEM => ['method' => 'DELETE', 'url' => self::LOCAL_STORAGE . '/key/:key'],
+        DriverCommand::REMOVE_SESSION_STORAGE_ITEM => [
+            'method' => 'DELETE',
+            'url' => self::SESSION_STORAGE . '/key/:key',
+        ],
+        DriverCommand::SET_LOCAL_STORAGE_ITEM => ['method' => 'POST', 'url' => self::LOCAL_STORAGE],
+        DriverCommand::SET_SESSION_STORAGE_ITEM => ['method' => 'POST', 'url' => self::SESSION_STORAGE],
     ];
     /**
      * @var array Will be merged with $commands

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -3,8 +3,10 @@
 namespace Facebook\WebDriver\Remote;
 
 use Facebook\WebDriver\Exception\UnknownErrorException;
+use Facebook\WebDriver\Html5\WebStorageInterface;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\JavaScriptExecutor;
+use Facebook\WebDriver\Remote\Html5\RemoteWebStorage;
 use Facebook\WebDriver\Support\ScreenshotHelper;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
@@ -440,6 +442,16 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     public function switchTo()
     {
         return new RemoteTargetLocator($this->getExecuteMethod(), $this, $this->isW3cCompliant);
+    }
+
+    /**
+     * An abstraction allowing the driver to access the browser's storage.
+     *
+     * @return WebStorageInterface
+     */
+    public function storage()
+    {
+        return new RemoteWebStorage($this->getExecuteMethod());
     }
 
     /**

--- a/lib/WebDriver.php
+++ b/lib/WebDriver.php
@@ -2,8 +2,6 @@
 
 namespace Facebook\WebDriver;
 
-use Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen;
-
 /**
  * The interface for WebDriver.
  */
@@ -97,6 +95,14 @@ interface WebDriver extends WebDriverSearchContext
      * @return WebDriverOptions
      */
     public function manage();
+
+    // TODO: Add in next major release (BC)
+    ///**
+    // * An abstraction allowing the driver to access the browser's storage.
+    // *
+    // * @return WebStorage
+    // */
+    //public function storage(): WebStorage;
 
     /**
      * An abstraction allowing the driver to access the browser's history and to

--- a/tests/unit/Remote/Html5/RemoteLocalStorageTest.php
+++ b/tests/unit/Remote/Html5/RemoteLocalStorageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Html5;
+
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Facebook\WebDriver\Remote\Html5\RemoteLocalStorage
+ */
+class RemoteLocalStorageTest extends TestCase
+{
+    /** @var RemoteExecuteMethod|\PHPUnit\Framework\MockObject\MockObject */
+    private $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = $this->getMockBuilder(RemoteExecuteMethod::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testShouldClearStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::CLEAR_LOCAL_STORAGE);
+
+        $storage = new RemoteLocalStorage($this->executor);
+
+        $storage->clear();
+    }
+
+    public function testShouldReturnItemByKeyFromStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::GET_LOCAL_STORAGE_ITEM, [':key' => 'thing-one'])
+            ->willReturn('value-of-thing-one');
+
+        $storage = new RemoteLocalStorage($this->executor);
+
+        $value = $storage->getItem('thing-one');
+        $this->assertSame('value-of-thing-one', $value);
+    }
+
+    public function testShouldReturnAllKeysInStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::GET_LOCAL_STORAGE_KEYS)
+            ->willReturn(['key1', 'key2', 'key3']);
+
+        $storage = new RemoteLocalStorage($this->executor);
+
+        $value = $storage->keySet();
+        $this->assertSame(['key1', 'key2', 'key3'], $value);
+    }
+
+    public function testShouldRemoveItemFromStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::REMOVE_LOCAL_STORAGE_ITEM);
+
+        $storage = new RemoteLocalStorage($this->executor);
+
+        $storage->removeItem('item2');
+    }
+
+    public function testShouldSetItemInStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::SET_LOCAL_STORAGE_ITEM, ['key' => 'key2', 'value' => 'value2']);
+
+        $storage = new RemoteLocalStorage($this->executor);
+
+        $storage->setItem('key2', 'value2');
+    }
+
+    public function testShouldReturnNumberOfItemsInStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::GET_LOCAL_STORAGE_SIZE)
+            ->willReturn(7);
+
+        $storage = new RemoteLocalStorage($this->executor);
+
+        $size = $storage->size();
+        $this->assertSame(7, $size);
+    }
+}

--- a/tests/unit/Remote/Html5/RemoteSessionStorageTest.php
+++ b/tests/unit/Remote/Html5/RemoteSessionStorageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Html5;
+
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Facebook\WebDriver\Remote\Html5\RemoteSessionStorage
+ */
+class RemoteSessionStorageTest extends TestCase
+{
+    /** @var RemoteExecuteMethod|\PHPUnit\Framework\MockObject\MockObject */
+    private $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = $this->getMockBuilder(RemoteExecuteMethod::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testShouldClearStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::CLEAR_SESSION_STORAGE);
+
+        $storage = new RemoteSessionStorage($this->executor);
+
+        $storage->clear();
+    }
+
+    public function testShouldReturnItemByKeyFromStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::GET_SESSION_STORAGE_ITEM, [':key' => 'thing-one'])
+            ->willReturn('value-of-thing-one');
+
+        $storage = new RemoteSessionStorage($this->executor);
+
+        $value = $storage->getItem('thing-one');
+        $this->assertSame('value-of-thing-one', $value);
+    }
+
+    public function testShouldReturnAllKeysInStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::GET_SESSION_STORAGE_KEYS)
+            ->willReturn(['key1', 'key2', 'key3']);
+
+        $storage = new RemoteSessionStorage($this->executor);
+
+        $value = $storage->keySet();
+        $this->assertSame(['key1', 'key2', 'key3'], $value);
+    }
+
+    public function testShouldRemoveItemFromStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::REMOVE_SESSION_STORAGE_ITEM);
+
+        $storage = new RemoteSessionStorage($this->executor);
+
+        $storage->removeItem('item2');
+    }
+
+    public function testShouldSetItemInStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::SET_SESSION_STORAGE_ITEM, ['key' => 'key2', 'value' => 'value2']);
+
+        $storage = new RemoteSessionStorage($this->executor);
+
+        $storage->setItem('key2', 'value2');
+    }
+
+    public function testShouldReturnNumberOfItemsInStorage()
+    {
+        $this->executor->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::GET_SESSION_STORAGE_SIZE)
+            ->willReturn(7);
+
+        $storage = new RemoteSessionStorage($this->executor);
+
+        $size = $storage->size();
+        $this->assertSame(7, $size);
+    }
+}

--- a/tests/unit/Remote/Html5/RemoteWebStorageTest.php
+++ b/tests/unit/Remote/Html5/RemoteWebStorageTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Html5;
+
+use Facebook\WebDriver\Html5\LocalStorageInterface;
+use Facebook\WebDriver\Html5\SessionStorageInterface;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Facebook\WebDriver\Remote\Html5\RemoteWebStorage
+ */
+class RemoteWebStorageTest extends TestCase
+{
+    /** @var RemoteExecuteMethod|\PHPUnit\Framework\MockObject\MockObject */
+    private $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = $this->getMockBuilder(RemoteExecuteMethod::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testShouldReturnLocalStorage()
+    {
+        $storage = new RemoteWebStorage($this->executor);
+
+        $local = $storage->getLocalStorage();
+        $this->assertInstanceOf(RemoteLocalStorage::class, $local);
+        $this->assertInstanceOf(LocalStorageInterface::class, $local);
+    }
+
+    public function testShouldReturnSessionStorage()
+    {
+        $storage = new RemoteWebStorage($this->executor);
+
+        $session = $storage->getSessionStorage();
+        $this->assertInstanceOf(RemoteSessionStorage::class, $session);
+        $this->assertInstanceOf(SessionStorageInterface::class, $session);
+    }
+}


### PR DESCRIPTION
This functionality is available via selenium, and the commands are already defined on `DriverCommand`, so this PR adds classes and methods to make them usable.

I've followed the upstream API as close as possible, the only deviation is how storage is initially accesses, which is via a simple `storage()` method on the `WebDriver` class.
http://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/html5/WebStorage.html