### PR TITLE
Support of custom http WebDriver commands

### DIFF
--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -145,6 +145,8 @@ class DriverCommand
     // Mobile API
     const GET_NETWORK_CONNECTION = 'getNetworkConnection';
     const SET_NETWORK_CONNECTION = 'setNetworkConnection';
+    // Custom command
+    const CUSTOM_COMMAND = 'customCommand';
 
     // W3C specific
     const ACTIONS = 'actions';

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -143,6 +143,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::TOUCH_MOVE => ['method' => 'POST', 'url' => '/session/:sessionId/touch/move'],
         DriverCommand::TOUCH_SCROLL => ['method' => 'POST', 'url' => '/session/:sessionId/touch/scroll'],
         DriverCommand::TOUCH_UP => ['method' => 'POST', 'url' => '/session/:sessionId/touch/up'],
+        DriverCommand::CUSTOM_COMMAND => false,
     ];
     /**
      * @var array Will be merged with $commands
@@ -274,21 +275,10 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
      */
     public function execute(WebDriverCommand $command)
     {
-        $commandName = $command->getName();
-        if (!isset(self::$commands[$commandName])) {
-            if ($this->isW3cCompliant && !isset(self::$w3cCompliantCommands[$commandName])) {
-                throw new InvalidArgumentException($command->getName() . ' is not a valid command.');
-            }
-        }
+        $http_options = $this->getCommandHttpOptions($command);
+        $http_method = $http_options['method'];
+        $url = $http_options['url'];
 
-        if ($this->isW3cCompliant) {
-            $raw = self::$w3cCompliantCommands[$command->getName()];
-        } else {
-            $raw = self::$commands[$command->getName()];
-        }
-
-        $http_method = $raw['method'];
-        $url = $raw['url'];
         $url = str_replace(':sessionId', $command->getSessionID(), $url);
         $params = $command->getParameters();
         foreach ($params as $name => $value) {
@@ -411,5 +401,37 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
     public function getAddressOfRemoteServer()
     {
         return $this->url;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getCommandHttpOptions(WebDriverCommand $command)
+    {
+        $commandName = $command->getName();
+        if (!isset(self::$commands[$commandName])) {
+            if ($this->isW3cCompliant && !isset(self::$w3cCompliantCommands[$commandName])) {
+                throw new InvalidArgumentException($command->getName() . ' is not a valid command.');
+            }
+        }
+
+        if ($this->isW3cCompliant) {
+            $raw = self::$w3cCompliantCommands[$command->getName()];
+        } else {
+            $raw = self::$commands[$command->getName()];
+        }
+
+        if ($raw === false) {
+            $url = $command->getCustomUrl();
+            $method = $command->getCustomMethod();
+        } else {
+            $url = $raw['url'];
+            $method = $raw['method'];
+        }
+
+        return [
+            'url' => $url,
+            'method' => $method,
+        ];
     }
 }

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -603,6 +603,31 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     }
 
     /**
+     * @param string $url
+     * @param string $method
+     * @param array $params
+     * @return mixed|null
+     */
+    public function executeCustomCommand($url, $method = 'GET', $params = [])
+    {
+        $command = new WebDriverCommand(
+            $this->sessionID,
+            DriverCommand::CUSTOM_COMMAND,
+            $params
+        );
+
+        $command->setCustomRequestParameters($url, $method);
+
+        if ($this->executor) {
+            $response = $this->executor->execute($command);
+
+            return $response->getValue();
+        }
+
+        return null;
+    }
+
+    /**
      * @internal
      * @return bool
      */

--- a/lib/Remote/WebDriverCommand.php
+++ b/lib/Remote/WebDriverCommand.php
@@ -15,14 +15,22 @@
 
 namespace Facebook\WebDriver\Remote;
 
+use Facebook\WebDriver\Exception\WebDriverException;
+
 class WebDriverCommand
 {
+    const METHOD_GET = 'GET';
+    const METHOD_POST = 'POST';
     /** @var string */
     private $sessionID;
     /** @var string */
     private $name;
     /** @var array */
     private $parameters;
+    /** @var string */
+    private $customUrl;
+    /** @var string */
+    private $customMethod;
 
     /**
      * @param string $session_id
@@ -59,5 +67,49 @@ class WebDriverCommand
     public function getParameters()
     {
         return $this->parameters;
+    }
+
+    /**
+     * @param string $custom_url
+     * @param string $custom_method
+     * @throws WebDriverException
+     */
+    public function setCustomRequestParameters($custom_url, $custom_method)
+    {
+        if (!in_array($custom_method, [static::METHOD_GET, static::METHOD_POST])) {
+            throw new WebDriverException('Invalid custom method');
+        }
+        $this->customMethod = $custom_method;
+
+        if (mb_substr($custom_url, 0, 1) !== '/') {
+            throw new WebDriverException('Custom url should start with /');
+        }
+        $this->customUrl = $custom_url;
+    }
+
+    /**
+     * @throws WebDriverException
+     * @return string
+     */
+    public function getCustomUrl()
+    {
+        if ($this->customUrl === null) {
+            throw new WebDriverException('Custom url is not set');
+        }
+
+        return $this->customUrl;
+    }
+
+    /**
+     * @throws WebDriverException
+     * @return string
+     */
+    public function getCustomMethod()
+    {
+        if ($this->customUrl === null) {
+            throw new WebDriverException('Custom url is not set');
+        }
+
+        return $this->customMethod;
     }
 }

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -37,15 +37,24 @@ class HttpCommandExecutorTest extends TestCase
      * @param bool $shouldResetExpectHeader
      * @param string $expectedUrl
      * @param string $expectedPostData
+     * @param null|array $customCommandParameters
      */
     public function testShouldSendRequestToAssembledUrl(
         $command,
         array $params,
         $shouldResetExpectHeader,
         $expectedUrl,
-        $expectedPostData
+        $expectedPostData,
+        $customCommandParameters = null
     ) {
         $command = new WebDriverCommand('foo-123', $command, $params);
+
+        if ($customCommandParameters !== null) {
+            $command->setCustomRequestParameters(
+                $customCommandParameters['url'],
+                $customCommandParameters['method']
+            );
+        }
 
         $curlSetoptMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
         $curlSetoptMock->expects($this->at(0))
@@ -118,6 +127,28 @@ class HttpCommandExecutorTest extends TestCase
                 false,
                 'http://localhost:4444/sessions',
                 null,
+            ],
+            'Custom GET command' => [
+                DriverCommand::CUSTOM_COMMAND,
+                [':someParameter' => 'someValue'],
+                false,
+                'http://localhost:4444/session/foo-123/custom-command/someValue',
+                null,
+                [
+                    'url' => '/session/:sessionId/custom-command/:someParameter',
+                    'method' => 'GET',
+                ],
+            ],
+            'Custom POST command' => [
+                DriverCommand::CUSTOM_COMMAND,
+                ['someParameter' => 'someValue'],
+                true,
+                'http://localhost:4444/session/foo-123/custom-post-command/',
+                '{"someParameter":"someValue"}',
+                [
+                    'url' => '/session/:sessionId/custom-post-command/',
+                    'method' => 'POST',
+                ],
             ],
         ];
     }

--- a/tests/unit/Remote/WebDriverCommandTest.php
+++ b/tests/unit/Remote/WebDriverCommandTest.php
@@ -15,6 +15,7 @@
 
 namespace Facebook\WebDriver\Remote;
 
+use Facebook\WebDriver\Exception\WebDriverException;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverCommandTest extends TestCase
@@ -26,5 +27,28 @@ class WebDriverCommandTest extends TestCase
         $this->assertSame('session-id-123', $command->getSessionID());
         $this->assertSame('bar-baz-name', $command->getName());
         $this->assertSame(['foo' => 'bar'], $command->getParameters());
+    }
+
+    public function testCustomCommandInit()
+    {
+        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
+        $command->setCustomRequestParameters('/some-url', 'POST');
+
+        $this->assertSame('/some-url', $command->getCustomUrl());
+        $this->assertSame('POST', $command->getCustomMethod());
+    }
+
+    public function testCustomCommandInvalidUrlExceptionInit()
+    {
+        $this->expectException(WebDriverException::class);
+        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
+        $command->setCustomRequestParameters('url-without-leading-slash', 'POST');
+    }
+
+    public function testCustomCommandInvalidMethodExceptionInit()
+    {
+        $this->expectException(WebDriverException::class);
+        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
+        $command->setCustomRequestParameters('/some-url', 'invalid-method');
     }
 }


### PR DESCRIPTION
This patch allows to send user-defined http-requests.

Can be used to send browser-specific commands or to work with selenium-compatible server, e.x. Appium.

Expects to solve #605.

Code example:

```
clipboard = 
  $driver->executeCustomCommand(
    '/session/:sessionId/appium/device/get_clipboard/',
    'POST'
  );
```