### PR TITLE
Fullscreen window

### DIFF
--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -138,6 +138,7 @@ class DriverCommand
     const GET_WINDOW_SIZE = 'getWindowSize';
     const GET_WINDOW_POSITION = 'getWindowPosition';
     const MAXIMIZE_WINDOW = 'maximizeWindow';
+    const FULLSCREEN_WINDOW = 'fullscreenWindow';
     // Logging API
     const GET_AVAILABLE_LOG_TYPES = 'getAvailableLogTypes';
     const GET_LOG = 'getLog';

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -153,6 +153,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::DISMISS_ALERT => ['method' => 'POST', 'url' => '/session/:sessionId/alert/dismiss'],
         DriverCommand::EXECUTE_ASYNC_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/async'],
         DriverCommand::EXECUTE_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/sync'],
+        DriverCommand::FULLSCREEN_WINDOW => ['method' => 'POST', 'url' => '/session/:sessionId/window/fullscreen'],
         DriverCommand::GET_ACTIVE_ELEMENT => ['method' => 'GET', 'url' => '/session/:sessionId/element/active'],
         DriverCommand::GET_ALERT_TEXT => ['method' => 'GET', 'url' => '/session/:sessionId/alert/text'],
         DriverCommand::GET_CURRENT_WINDOW_HANDLE => ['method' => 'GET', 'url' => '/session/:sessionId/window'],

--- a/lib/WebDriverWindow.php
+++ b/lib/WebDriverWindow.php
@@ -101,10 +101,14 @@ class WebDriverWindow
      */
     public function maximize()
     {
-        $this->executor->execute(
-            DriverCommand::MAXIMIZE_WINDOW,
-            [':windowHandle' => 'current']
-        );
+        if ($this->isW3cCompliant) {
+            $this->executor->execute(DriverCommand::MAXIMIZE_WINDOW, []);
+        } else {
+            $this->executor->execute(
+                DriverCommand::MAXIMIZE_WINDOW,
+                [':windowHandle' => 'current']
+            );
+        }
 
         return $this;
     }

--- a/lib/WebDriverWindow.php
+++ b/lib/WebDriverWindow.php
@@ -114,6 +114,22 @@ class WebDriverWindow
     }
 
     /**
+     * Makes the current window full screen.
+     *
+     * @return WebDriverWindow The instance.
+     */
+    public function fullscreen()
+    {
+        if (!$this->isW3cCompliant) {
+            throw new UnsupportedOperationException('The Fullscreen window command is only supported in W3C mode');
+        }
+
+        $this->executor->execute(DriverCommand::FULLSCREEN_WINDOW, []);
+
+        return $this;
+    }
+
+    /**
      * Set the size of the current window. This will change the outer window
      * dimension, not just the view port.
      *

--- a/tests/functional/WebDriverWindowTest.php
+++ b/tests/functional/WebDriverWindowTest.php
@@ -49,6 +49,30 @@ class WebDriverWindowTest extends WebDriverTestCase
     }
 
     /**
+     * @group exclude-edge
+     */
+    public function testShouldFullscreenWindow()
+    {
+        self::skipForJsonWireProtocol('"fullscreen" window is not supported in JsonWire protocol');
+
+        $this->driver->manage()
+            ->window()
+            ->setSize(new WebDriverDimension(400, 300));
+
+        $this->driver->manage()
+            ->window()
+            ->fullscreen();
+
+        $sizeAfter = $this->driver->manage()
+            ->window()
+            ->getSize();
+
+        // Note: Headless browsers see no effect.
+        $this->assertGreaterThanOrEqual(400, $sizeAfter->getWidth());
+        $this->assertGreaterThanOrEqual(300, $sizeAfter->getHeight());
+    }
+
+    /**
      * @group exclude-saucelabs
      * @group exclude-chrome
      * @see https://bugs.chromium.org/p/chromium/issues/detail?id=1038050


### PR DESCRIPTION
I've included an extra commit here because the W3C mode doesn't take any arguments but JSONWire does but we were still including the args still.