### PR TITLE
making sure that binary is a string

### DIFF
--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -59,7 +59,7 @@ class ChromeOptions
      */
     public function setBinary($path)
     {
-        $this->binary = $path;
+        $this->binary = (string) $path;
 
         return $this;
     }


### PR DESCRIPTION
it's possible to set NULL as binary and you'll get

```
Could not open connection: invalid argument: entry 0 of 'firstMatch' is invalid
from invalid argument: cannot parse capability: goog:chromeOptions
from invalid argument: cannot parse binary
from invalid argument: must be a string
```