### PR TITLE
Rename Packagist package to php-webdriver/webdriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - `takeElementScreenshot()` method of `RemoteWebElement` to do the obvious - take screenshot of the particular element.
 
 ### Changed
+- The repository was migrated to [`php-webdriver/php-webdriver`](https://github.com/php-webdriver/php-webdriver/).
+- The Packagist package was renamed to [`php-webdriver/webdriver`](https://packagist.org/packages/php-webdriver/webdriver) and the original [`facebook/webdriver`](https://packagist.org/packages/facebook/webdriver) was marked as abandoned.
 - Revert no longer needed workaround for Chromedriver bug [2943](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2943).
 - Allow installation of Symfony 5 components.
 - Rename environment variable used to pass path to ChromeDriver executable from `webdriver.chrome.driver` to `WEBDRIVER_CHROME_DRIVER`. However the old one also still works to keep backward compatibility

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # php-webdriver – Selenium WebDriver bindings for PHP
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/facebook/webdriver.svg?style=flat-square)](https://packagist.org/packages/facebook/webdriver)
+[![Latest Stable Version](https://img.shields.io/packagist/v/php-webdriver/webdriver.svg?style=flat-square)](https://packagist.org/packages/php-webdriver/webdriver)
 [![Travis Build](https://img.shields.io/travis/php-webdriver/php-webdriver/community.svg?style=flat-square)](https://travis-ci.com/php-webdriver/php-webdriver)
 [![Sauce Test Status](https://saucelabs.com/buildstatus/php-webdriver)](https://saucelabs.com/u/php-webdriver)
-[![Total Downloads](https://img.shields.io/packagist/dt/facebook/webdriver.svg?style=flat-square)](https://packagist.org/packages/facebook/webdriver)
-[![License](https://img.shields.io/packagist/l/facebook/webdriver.svg?style=flat-square)](https://packagist.org/packages/facebook/webdriver)
+[![Total Downloads](https://img.shields.io/packagist/dt/php-webdriver/webdriver.svg?style=flat-square)](https://packagist.org/packages/php-webdriver/webdriver)
 
 ## Description
 Php-webdriver library is PHP language binding for Selenium WebDriver, which allows you to control web browsers from PHP.
@@ -33,7 +32,7 @@ If you don't already use Composer, you can download the `composer.phar` binary:
 
 Then install the library:
 
-    php composer.phar require facebook/webdriver
+    php composer.phar require php-webdriver/webdriver
 
 ## Getting started
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "facebook/webdriver",
-  "description": "A PHP client for Selenium WebDriver",
-  "keywords": ["webdriver", "selenium", "php"],
+  "name": "php-webdriver/webdriver",
+  "description": "A PHP client for Selenium WebDriver. Previously facebook/php-webdriver.",
+  "keywords": ["webdriver", "selenium", "php", "geckodriver", "chromedriver"],
   "homepage": "https://github.com/php-webdriver/php-webdriver",
   "type": "library",
   "license": "MIT",


### PR DESCRIPTION
Once this is merged, I will mark [facebook/webdriver](https://packagist.org/packages/facebook/webdriver) package abandoned and replaced by this one :tada: 