### PR TITLE
Custom commands support (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Experimental W3C WebDriver protocol support. The protocol will be used automatically when remote end (like Geckodriver, newer Chromedriver etc.) supports it.
 - `getStatus()` method of `RemoteWebDriver` to get information about remote-end readiness to create new sessions.
 - `takeElementScreenshot()` method of `RemoteWebElement` to do the obvious - take screenshot of the particular element.
+- Support for sending custom commands via `executeCustomCommand()`. See [wiki](https://github.com/php-webdriver/php-webdriver/wiki/Custom-commands) for more information.
 
 ### Changed
 - The repository was migrated to [`php-webdriver/php-webdriver`](https://github.com/php-webdriver/php-webdriver/).

--- a/lib/Remote/CustomWebDriverCommand.php
+++ b/lib/Remote/CustomWebDriverCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+use Facebook\WebDriver\Exception\WebDriverException;
+
+class CustomWebDriverCommand extends WebDriverCommand
+{
+    const METHOD_GET = 'GET';
+    const METHOD_POST = 'POST';
+
+    /** @var string */
+    private $customUrl;
+    /** @var string */
+    private $customMethod;
+
+    /**
+     * @param string $session_id
+     * @param string $url
+     * @param string $method
+     * @param array $parameters
+     */
+    public function __construct($session_id, $url, $method, array $parameters)
+    {
+        $this->setCustomRequestParameters($url, $method);
+
+        parent::__construct($session_id, DriverCommand::CUSTOM_COMMAND, $parameters);
+    }
+
+    /**
+     * @throws WebDriverException
+     * @return string
+     */
+    public function getCustomUrl()
+    {
+        if ($this->customUrl === null) {
+            throw new WebDriverException('URL of custom command is not set');
+        }
+
+        return $this->customUrl;
+    }
+
+    /**
+     * @throws WebDriverException
+     * @return string
+     */
+    public function getCustomMethod()
+    {
+        if ($this->customMethod === null) {
+            throw new WebDriverException('Method of custom command is not set');
+        }
+
+        return $this->customMethod;
+    }
+
+    /**
+     * @param string $custom_url
+     * @param string $custom_method
+     * @throws WebDriverException
+     */
+    protected function setCustomRequestParameters($custom_url, $custom_method)
+    {
+        $allowedMethods = [static::METHOD_GET, static::METHOD_POST];
+        if (!in_array($custom_method, $allowedMethods, true)) {
+            throw new WebDriverException(
+                sprintf(
+                    'Invalid custom method "%s", must be one of [%s]',
+                    $custom_method,
+                    implode(', ', $allowedMethods)
+                )
+            );
+        }
+        $this->customMethod = $custom_method;
+
+        if (mb_strpos($custom_url, '/') !== 0) {
+            throw new WebDriverException(
+                sprintf('URL of custom command has to start with / but is "%s"', $custom_url)
+            );
+        }
+        $this->customUrl = $custom_url;
+    }
+}

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -133,6 +133,8 @@ class DriverCommand
     // Mobile API
     const GET_NETWORK_CONNECTION = 'getNetworkConnection';
     const SET_NETWORK_CONNECTION = 'setNetworkConnection';
+    // Custom command
+    const CUSTOM_COMMAND = 'customCommand';
 
     // W3C specific
     const ACTIONS = 'actions';

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -130,7 +130,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::TOUCH_MOVE => ['method' => 'POST', 'url' => '/session/:sessionId/touch/move'],
         DriverCommand::TOUCH_SCROLL => ['method' => 'POST', 'url' => '/session/:sessionId/touch/scroll'],
         DriverCommand::TOUCH_UP => ['method' => 'POST', 'url' => '/session/:sessionId/touch/up'],
-        DriverCommand::CUSTOM_COMMAND => false,
+        DriverCommand::CUSTOM_COMMAND => [],
     ];
     /**
      * @var array Will be merged with $commands
@@ -409,7 +409,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
             $raw = self::$commands[$command->getName()];
         }
 
-        if ($raw === false) {
+        if ($command instanceof CustomWebDriverCommand) {
             $url = $command->getCustomUrl();
             $method = $command->getCustomMethod();
         } else {

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -130,6 +130,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::TOUCH_MOVE => ['method' => 'POST', 'url' => '/session/:sessionId/touch/move'],
         DriverCommand::TOUCH_SCROLL => ['method' => 'POST', 'url' => '/session/:sessionId/touch/scroll'],
         DriverCommand::TOUCH_UP => ['method' => 'POST', 'url' => '/session/:sessionId/touch/up'],
+        DriverCommand::CUSTOM_COMMAND => false,
     ];
     /**
      * @var array Will be merged with $commands
@@ -262,21 +263,10 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
      */
     public function execute(WebDriverCommand $command)
     {
-        $commandName = $command->getName();
-        if (!isset(self::$commands[$commandName])) {
-            if ($this->isW3cCompliant && !isset(self::$w3cCompliantCommands[$commandName])) {
-                throw new InvalidArgumentException($command->getName() . ' is not a valid command.');
-            }
-        }
+        $http_options = $this->getCommandHttpOptions($command);
+        $http_method = $http_options['method'];
+        $url = $http_options['url'];
 
-        if ($this->isW3cCompliant) {
-            $raw = self::$w3cCompliantCommands[$command->getName()];
-        } else {
-            $raw = self::$commands[$command->getName()];
-        }
-
-        $http_method = $raw['method'];
-        $url = $raw['url'];
         $url = str_replace(':sessionId', $command->getSessionID(), $url);
         $params = $command->getParameters();
         foreach ($params as $name => $value) {
@@ -399,5 +389,37 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
     public function getAddressOfRemoteServer()
     {
         return $this->url;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getCommandHttpOptions(WebDriverCommand $command)
+    {
+        $commandName = $command->getName();
+        if (!isset(self::$commands[$commandName])) {
+            if ($this->isW3cCompliant && !isset(self::$w3cCompliantCommands[$commandName])) {
+                throw new InvalidArgumentException($command->getName() . ' is not a valid command.');
+            }
+        }
+
+        if ($this->isW3cCompliant) {
+            $raw = self::$w3cCompliantCommands[$command->getName()];
+        } else {
+            $raw = self::$commands[$command->getName()];
+        }
+
+        if ($raw === false) {
+            $url = $command->getCustomUrl();
+            $method = $command->getCustomMethod();
+        } else {
+            $url = $raw['url'];
+            $method = $raw['method'];
+        }
+
+        return [
+            'url' => $url,
+            'method' => $method,
+        ];
     }
 }

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -590,20 +590,19 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     }
 
     /**
-     * @param string $url
+     * @param string $endpointUrl
      * @param string $method
      * @param array $params
      * @return mixed|null
      */
-    public function executeCustomCommand($url, $method = 'GET', $params = [])
+    public function executeCustomCommand($endpointUrl, $method = 'GET', $params = [])
     {
-        $command = new WebDriverCommand(
+        $command = new CustomWebDriverCommand(
             $this->sessionID,
-            DriverCommand::CUSTOM_COMMAND,
+            $endpointUrl,
+            $method,
             $params
         );
-
-        $command->setCustomRequestParameters($url, $method);
 
         if ($this->executor) {
             $response = $this->executor->execute($command);

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -590,6 +590,31 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     }
 
     /**
+     * @param string $url
+     * @param string $method
+     * @param array $params
+     * @return mixed|null
+     */
+    public function executeCustomCommand($url, $method = 'GET', $params = [])
+    {
+        $command = new WebDriverCommand(
+            $this->sessionID,
+            DriverCommand::CUSTOM_COMMAND,
+            $params
+        );
+
+        $command->setCustomRequestParameters($url, $method);
+
+        if ($this->executor) {
+            $response = $this->executor->execute($command);
+
+            return $response->getValue();
+        }
+
+        return null;
+    }
+
+    /**
      * @internal
      * @return bool
      */

--- a/lib/Remote/WebDriverCommand.php
+++ b/lib/Remote/WebDriverCommand.php
@@ -2,14 +2,22 @@
 
 namespace Facebook\WebDriver\Remote;
 
+use Facebook\WebDriver\Exception\WebDriverException;
+
 class WebDriverCommand
 {
+    const METHOD_GET = 'GET';
+    const METHOD_POST = 'POST';
     /** @var string */
     private $sessionID;
     /** @var string */
     private $name;
     /** @var array */
     private $parameters;
+    /** @var string */
+    private $customUrl;
+    /** @var string */
+    private $customMethod;
 
     /**
      * @param string $session_id
@@ -46,5 +54,49 @@ class WebDriverCommand
     public function getParameters()
     {
         return $this->parameters;
+    }
+
+    /**
+     * @param string $custom_url
+     * @param string $custom_method
+     * @throws WebDriverException
+     */
+    public function setCustomRequestParameters($custom_url, $custom_method)
+    {
+        if (!in_array($custom_method, [static::METHOD_GET, static::METHOD_POST])) {
+            throw new WebDriverException('Invalid custom method');
+        }
+        $this->customMethod = $custom_method;
+
+        if (mb_substr($custom_url, 0, 1) !== '/') {
+            throw new WebDriverException('Custom url should start with /');
+        }
+        $this->customUrl = $custom_url;
+    }
+
+    /**
+     * @throws WebDriverException
+     * @return string
+     */
+    public function getCustomUrl()
+    {
+        if ($this->customUrl === null) {
+            throw new WebDriverException('Custom url is not set');
+        }
+
+        return $this->customUrl;
+    }
+
+    /**
+     * @throws WebDriverException
+     * @return string
+     */
+    public function getCustomMethod()
+    {
+        if ($this->customUrl === null) {
+            throw new WebDriverException('Custom url is not set');
+        }
+
+        return $this->customMethod;
     }
 }

--- a/lib/Remote/WebDriverCommand.php
+++ b/lib/Remote/WebDriverCommand.php
@@ -2,22 +2,14 @@
 
 namespace Facebook\WebDriver\Remote;
 
-use Facebook\WebDriver\Exception\WebDriverException;
-
 class WebDriverCommand
 {
-    const METHOD_GET = 'GET';
-    const METHOD_POST = 'POST';
     /** @var string */
-    private $sessionID;
+    protected $sessionID;
     /** @var string */
-    private $name;
+    protected $name;
     /** @var array */
-    private $parameters;
-    /** @var string */
-    private $customUrl;
-    /** @var string */
-    private $customMethod;
+    protected $parameters;
 
     /**
      * @param string $session_id
@@ -54,49 +46,5 @@ class WebDriverCommand
     public function getParameters()
     {
         return $this->parameters;
-    }
-
-    /**
-     * @param string $custom_url
-     * @param string $custom_method
-     * @throws WebDriverException
-     */
-    public function setCustomRequestParameters($custom_url, $custom_method)
-    {
-        if (!in_array($custom_method, [static::METHOD_GET, static::METHOD_POST])) {
-            throw new WebDriverException('Invalid custom method');
-        }
-        $this->customMethod = $custom_method;
-
-        if (mb_substr($custom_url, 0, 1) !== '/') {
-            throw new WebDriverException('Custom url should start with /');
-        }
-        $this->customUrl = $custom_url;
-    }
-
-    /**
-     * @throws WebDriverException
-     * @return string
-     */
-    public function getCustomUrl()
-    {
-        if ($this->customUrl === null) {
-            throw new WebDriverException('Custom url is not set');
-        }
-
-        return $this->customUrl;
-    }
-
-    /**
-     * @throws WebDriverException
-     * @return string
-     */
-    public function getCustomMethod()
-    {
-        if ($this->customUrl === null) {
-            throw new WebDriverException('Custom url is not set');
-        }
-
-        return $this->customMethod;
     }
 }

--- a/tests/unit/Remote/CustomWebDriverCommandTest.php
+++ b/tests/unit/Remote/CustomWebDriverCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+use Facebook\WebDriver\Exception\WebDriverException;
+use PHPUnit\Framework\TestCase;
+
+class CustomWebDriverCommandTest extends TestCase
+{
+    public function testShouldSetOptionsUsingConstructor()
+    {
+        $command = new CustomWebDriverCommand(
+            'session-id-123',
+            '/some-url',
+            'POST',
+            ['foo' => 'bar']
+        );
+
+        $this->assertSame('/some-url', $command->getCustomUrl());
+        $this->assertSame('POST', $command->getCustomMethod());
+    }
+
+    public function testCustomCommandInvalidUrlExceptionInit()
+    {
+        $this->expectException(WebDriverException::class);
+        $this->expectExceptionMessage('URL of custom command has to start with / but is "url-without-leading-slash"');
+
+        new CustomWebDriverCommand('session-id-123', 'url-without-leading-slash', 'POST', []);
+    }
+
+    public function testCustomCommandInvalidMethodExceptionInit()
+    {
+        $this->expectException(WebDriverException::class);
+        $this->expectExceptionMessage('Invalid custom method "invalid-method", must be one of [GET, POST]');
+
+        new CustomWebDriverCommand('session-id-123', '/some-url', 'invalid-method', []);
+    }
+}

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -24,15 +24,24 @@ class HttpCommandExecutorTest extends TestCase
      * @param bool $shouldResetExpectHeader
      * @param string $expectedUrl
      * @param string $expectedPostData
+     * @param null|array $customCommandParameters
      */
     public function testShouldSendRequestToAssembledUrl(
         $command,
         array $params,
         $shouldResetExpectHeader,
         $expectedUrl,
-        $expectedPostData
+        $expectedPostData,
+        $customCommandParameters = null
     ) {
         $command = new WebDriverCommand('foo-123', $command, $params);
+
+        if ($customCommandParameters !== null) {
+            $command->setCustomRequestParameters(
+                $customCommandParameters['url'],
+                $customCommandParameters['method']
+            );
+        }
 
         $curlSetoptMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
         $curlSetoptMock->expects($this->at(0))
@@ -105,6 +114,28 @@ class HttpCommandExecutorTest extends TestCase
                 false,
                 'http://localhost:4444/sessions',
                 null,
+            ],
+            'Custom GET command' => [
+                DriverCommand::CUSTOM_COMMAND,
+                [':someParameter' => 'someValue'],
+                false,
+                'http://localhost:4444/session/foo-123/custom-command/someValue',
+                null,
+                [
+                    'url' => '/session/:sessionId/custom-command/:someParameter',
+                    'method' => 'GET',
+                ],
+            ],
+            'Custom POST command' => [
+                DriverCommand::CUSTOM_COMMAND,
+                ['someParameter' => 'someValue'],
+                true,
+                'http://localhost:4444/session/foo-123/custom-post-command/',
+                '{"someParameter":"someValue"}',
+                [
+                    'url' => '/session/:sessionId/custom-post-command/',
+                    'method' => 'POST',
+                ],
             ],
         ];
     }

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -19,30 +19,17 @@ class HttpCommandExecutorTest extends TestCase
 
     /**
      * @dataProvider provideCommand
-     * @param int $command
-     * @param array $params
+     * @param WebDriverCommand $command
      * @param bool $shouldResetExpectHeader
      * @param string $expectedUrl
-     * @param string $expectedPostData
-     * @param null|array $customCommandParameters
+     * @param string|null $expectedPostData
      */
     public function testShouldSendRequestToAssembledUrl(
-        $command,
-        array $params,
+        WebDriverCommand $command,
         $shouldResetExpectHeader,
         $expectedUrl,
-        $expectedPostData,
-        $customCommandParameters = null
+        $expectedPostData
     ) {
-        $command = new WebDriverCommand('foo-123', $command, $params);
-
-        if ($customCommandParameters !== null) {
-            $command->setCustomRequestParameters(
-                $customCommandParameters['url'],
-                $customCommandParameters['method']
-            );
-        }
-
         $curlSetoptMock = $this->getFunctionMock(__NAMESPACE__, 'curl_setopt');
         $curlSetoptMock->expects($this->at(0))
             ->with($this->anything(), CURLOPT_URL, $expectedUrl);
@@ -81,61 +68,60 @@ class HttpCommandExecutorTest extends TestCase
     {
         return [
             'POST command having :id placeholder in url' => [
-                DriverCommand::SEND_KEYS_TO_ELEMENT,
-                ['value' => 'submitted-value', ':id' => '1337'],
+                new WebDriverCommand(
+                    'fooSession',
+                    DriverCommand::SEND_KEYS_TO_ELEMENT,
+                    ['value' => 'submitted-value', ':id' => '1337']
+                ),
                 true,
-                'http://localhost:4444/session/foo-123/element/1337/value',
+                'http://localhost:4444/session/fooSession/element/1337/value',
                 '{"value":"submitted-value"}',
             ],
             'POST command without :id placeholder in url' => [
-                DriverCommand::TOUCH_UP,
-                ['x' => 3, 'y' => 6],
+                new WebDriverCommand('fooSession', DriverCommand::TOUCH_UP, ['x' => 3, 'y' => 6]),
                 true,
-                'http://localhost:4444/session/foo-123/touch/up',
+                'http://localhost:4444/session/fooSession/touch/up',
                 '{"x":3,"y":6}',
             ],
             'Extra useless placeholder parameter should be removed' => [
-                DriverCommand::TOUCH_UP,
-                ['x' => 3, 'y' => 6, ':useless' => 'foo'],
+                new WebDriverCommand('fooSession', DriverCommand::TOUCH_UP, ['x' => 3, 'y' => 6, ':useless' => 'foo']),
                 true,
-                'http://localhost:4444/session/foo-123/touch/up',
+                'http://localhost:4444/session/fooSession/touch/up',
                 '{"x":3,"y":6}',
             ],
             'DELETE command' => [
-                DriverCommand::DELETE_COOKIE,
-                [':name' => 'cookie-name'],
+                new WebDriverCommand('fooSession', DriverCommand::DELETE_COOKIE, [':name' => 'cookie-name']),
                 false,
-                'http://localhost:4444/session/foo-123/cookie/cookie-name',
+                'http://localhost:4444/session/fooSession/cookie/cookie-name',
                 null,
             ],
             'GET command without session in URL' => [
-                DriverCommand::GET_ALL_SESSIONS,
-                [],
+                new WebDriverCommand('fooSession', DriverCommand::GET_ALL_SESSIONS, []),
                 false,
                 'http://localhost:4444/sessions',
                 null,
             ],
             'Custom GET command' => [
-                DriverCommand::CUSTOM_COMMAND,
-                [':someParameter' => 'someValue'],
+                new CustomWebDriverCommand(
+                    'fooSession',
+                    '/session/:sessionId/custom-command/:someParameter',
+                    'GET',
+                    [':someParameter' => 'someValue']
+                ),
                 false,
-                'http://localhost:4444/session/foo-123/custom-command/someValue',
+                'http://localhost:4444/session/fooSession/custom-command/someValue',
                 null,
-                [
-                    'url' => '/session/:sessionId/custom-command/:someParameter',
-                    'method' => 'GET',
-                ],
             ],
             'Custom POST command' => [
-                DriverCommand::CUSTOM_COMMAND,
-                ['someParameter' => 'someValue'],
+                new CustomWebDriverCommand(
+                    'fooSession',
+                    '/session/:sessionId/custom-post-command/',
+                    'POST',
+                    ['someParameter' => 'someValue']
+                ),
                 true,
-                'http://localhost:4444/session/foo-123/custom-post-command/',
+                'http://localhost:4444/session/fooSession/custom-post-command/',
                 '{"someParameter":"someValue"}',
-                [
-                    'url' => '/session/:sessionId/custom-post-command/',
-                    'method' => 'POST',
-                ],
             ],
         ];
     }

--- a/tests/unit/Remote/WebDriverCommandTest.php
+++ b/tests/unit/Remote/WebDriverCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Facebook\WebDriver\Remote;
 
+use Facebook\WebDriver\Exception\WebDriverException;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverCommandTest extends TestCase
@@ -13,5 +14,28 @@ class WebDriverCommandTest extends TestCase
         $this->assertSame('session-id-123', $command->getSessionID());
         $this->assertSame('bar-baz-name', $command->getName());
         $this->assertSame(['foo' => 'bar'], $command->getParameters());
+    }
+
+    public function testCustomCommandInit()
+    {
+        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
+        $command->setCustomRequestParameters('/some-url', 'POST');
+
+        $this->assertSame('/some-url', $command->getCustomUrl());
+        $this->assertSame('POST', $command->getCustomMethod());
+    }
+
+    public function testCustomCommandInvalidUrlExceptionInit()
+    {
+        $this->expectException(WebDriverException::class);
+        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
+        $command->setCustomRequestParameters('url-without-leading-slash', 'POST');
+    }
+
+    public function testCustomCommandInvalidMethodExceptionInit()
+    {
+        $this->expectException(WebDriverException::class);
+        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
+        $command->setCustomRequestParameters('/some-url', 'invalid-method');
     }
 }

--- a/tests/unit/Remote/WebDriverCommandTest.php
+++ b/tests/unit/Remote/WebDriverCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Facebook\WebDriver\Remote;
 
-use Facebook\WebDriver\Exception\WebDriverException;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverCommandTest extends TestCase
@@ -14,28 +13,5 @@ class WebDriverCommandTest extends TestCase
         $this->assertSame('session-id-123', $command->getSessionID());
         $this->assertSame('bar-baz-name', $command->getName());
         $this->assertSame(['foo' => 'bar'], $command->getParameters());
-    }
-
-    public function testCustomCommandInit()
-    {
-        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
-        $command->setCustomRequestParameters('/some-url', 'POST');
-
-        $this->assertSame('/some-url', $command->getCustomUrl());
-        $this->assertSame('POST', $command->getCustomMethod());
-    }
-
-    public function testCustomCommandInvalidUrlExceptionInit()
-    {
-        $this->expectException(WebDriverException::class);
-        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
-        $command->setCustomRequestParameters('url-without-leading-slash', 'POST');
-    }
-
-    public function testCustomCommandInvalidMethodExceptionInit()
-    {
-        $this->expectException(WebDriverException::class);
-        $command = new WebDriverCommand('session-id-123', 'customCommand', ['foo' => 'bar']);
-        $command->setCustomRequestParameters('/some-url', 'invalid-method');
     }
 }


### PR DESCRIPTION
Alternative implementation of Custom Commands, based on #611 .

The changes were only internal refactoring, so the usage is exactly the same as in #611:

```php
$clipboard = $driver->executeCustomCommand(
    '/session/:sessionId/appium/device/get_clipboard/',
    'POST'
);
```