### PR TITLE
Exclude fullscreen test from chrome

### DIFF
--- a/tests/functional/WebDriverWindowTest.php
+++ b/tests/functional/WebDriverWindowTest.php
@@ -50,6 +50,8 @@ class WebDriverWindowTest extends WebDriverTestCase
 
     /**
      * @group exclude-edge
+     * @group exclude-chrome
+     * @see https://bugs.chromium.org/p/chromium/issues/detail?id=1049336
      */
     public function testShouldFullscreenWindow()
     {


### PR DESCRIPTION
Chrome / Chromedriver 80 is out, and it did break some things 🤷 - fullscreen test is failing since in headless mode.

https://bugs.chromium.org/p/chromium/issues/detail?id=1049336