### PR TITLE
tmp zip file fix

### DIFF
--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -150,7 +150,7 @@ class FirefoxProfile
 
         $zip = new ZipArchive();
         $temp_zip = tempnam(sys_get_temp_dir(), 'WebDriverFirefoxProfileZip');
-        $zip->open($temp_zip.".zip", ZipArchive::CREATE);
+        $zip->open($temp_zip . ".zip", ZipArchive::CREATE);
 
         $dir = new RecursiveDirectoryIterator($temp_dir);
         $files = new RecursiveIteratorIterator($dir);

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -150,7 +150,7 @@ class FirefoxProfile
 
         $zip = new ZipArchive();
         $temp_zip = tempnam(sys_get_temp_dir(), 'WebDriverFirefoxProfileZip');
-        $zip->open($temp_zip . ".zip", ZipArchive::CREATE);
+        $zip->open($temp_zip . '.zip', ZipArchive::CREATE);
 
         $dir = new RecursiveDirectoryIterator($temp_dir);
         $files = new RecursiveIteratorIterator($dir);

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -150,7 +150,7 @@ class FirefoxProfile
 
         $zip = new ZipArchive();
         $temp_zip = tempnam(sys_get_temp_dir(), 'WebDriverFirefoxProfileZip');
-        $zip->open($temp_zip, ZipArchive::CREATE);
+        $zip->open($temp_zip.".zip", ZipArchive::CREATE);
 
         $dir = new RecursiveDirectoryIterator($temp_dir);
         $files = new RecursiveIteratorIterator($dir);


### PR DESCRIPTION
fixed php 5.6.40 unable to create zip file without .zip file type name.