### PR TITLE
Fix move action in W3C mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Fixed
 - Accept array as possible input to `sendKeys()` method. (Unintentional BC break in 1.8.0.)
+- Use relative offset when moving mouse pointer in W3C WebDriver mode.
 
 ## 1.8.0 - 2020-02-10
 ### Added

--- a/lib/Interactions/WebDriverActions.php
+++ b/lib/Interactions/WebDriverActions.php
@@ -245,7 +245,7 @@ class WebDriverActions
 
     /**
      * Send keys by keyboard.
-     * If $element is provided, focus on that element first.
+     * If $element is provided, focus on that element first (using single mouse click).
      *
      * @see WebDriverKeys for special keys like CONTROL, ALT, etc.
      * @param WebDriverElement $element

--- a/lib/Remote/RemoteMouse.php
+++ b/lib/Remote/RemoteMouse.php
@@ -10,6 +10,13 @@ use Facebook\WebDriver\WebDriverMouse;
  */
 class RemoteMouse implements WebDriverMouse
 {
+    /** @internal */
+    const BUTTON_LEFT = 0;
+    /** @internal */
+    const BUTTON_MIDDLE = 1;
+    /** @internal */
+    const BUTTON_RIGHT = 2;
+
     /**
      * @var RemoteExecuteMethod
      */
@@ -54,7 +61,7 @@ class RemoteMouse implements WebDriverMouse
 
         $this->moveIfNeeded($where);
         $this->executor->execute(DriverCommand::CLICK, [
-            'button' => 0,
+            'button' => self::BUTTON_LEFT,
         ]);
 
         return $this;
@@ -78,13 +85,11 @@ class RemoteMouse implements WebDriverMouse
                         'actions' => array_merge($moveAction, [
                             [
                                 'type' => 'pointerDown',
-                                'duration' => 0,
-                                'button' => 2,
+                                'button' => self::BUTTON_RIGHT,
                             ],
                             [
                                 'type' => 'pointerUp',
-                                'duration' => 0,
-                                'button' => 2,
+                                'button' => self::BUTTON_RIGHT,
                             ],
                         ]),
                     ],
@@ -96,7 +101,7 @@ class RemoteMouse implements WebDriverMouse
 
         $this->moveIfNeeded($where);
         $this->executor->execute(DriverCommand::CLICK, [
-            'button' => 2,
+            'button' => self::BUTTON_RIGHT,
         ]);
 
         return $this;
@@ -150,8 +155,7 @@ class RemoteMouse implements WebDriverMouse
                             $this->createMoveAction($where),
                             [
                                 'type' => 'pointerDown',
-                                'duration' => 0,
-                                'button' => 0,
+                                'button' => self::BUTTON_LEFT,
                             ],
                         ],
                     ],
@@ -229,8 +233,7 @@ class RemoteMouse implements WebDriverMouse
                         'actions' => array_merge($moveAction, [
                             [
                                 'type' => 'pointerUp',
-                                'duration' => 0,
-                                'button' => 0,
+                                'button' => self::BUTTON_LEFT,
                             ],
                         ]),
                     ],
@@ -290,13 +293,11 @@ class RemoteMouse implements WebDriverMouse
         return [
             [
                 'type' => 'pointerDown',
-                'duration' => 0,
-                'button' => 0,
+                'button' => self::BUTTON_LEFT,
             ],
             [
                 'type' => 'pointerUp',
-                'duration' => 0,
-                'button' => 0,
+                'button' => self::BUTTON_LEFT,
             ],
         ];
     }

--- a/lib/Remote/RemoteMouse.php
+++ b/lib/Remote/RemoteMouse.php
@@ -273,13 +273,15 @@ class RemoteMouse implements WebDriverMouse
     ) {
         $move_action = [
             'type' => 'pointerMove',
-            'duration' => 0,
+            'duration' => 100, // to simulate human delay
             'x' => $x_offset === null ? 0 : $x_offset,
             'y' => $y_offset === null ? 0 : $y_offset,
         ];
 
         if ($where !== null) {
             $move_action['origin'] = [JsonWireCompat::WEB_DRIVER_ELEMENT_IDENTIFIER => $where->getAuxiliary()];
+        } else {
+            $move_action['origin'] = 'pointer';
         }
 
         return $move_action;

--- a/tests/functional/RemoteKeyboardTest.php
+++ b/tests/functional/RemoteKeyboardTest.php
@@ -9,6 +9,8 @@ use Facebook\WebDriver\Remote\WebDriverBrowserType;
  */
 class RemoteKeyboardTest extends WebDriverTestCase
 {
+    use RetrieveEventsTrait;
+
     /**
      * @group exclude-firefox
      * Firefox does not properly support keyboard actions:
@@ -55,7 +57,7 @@ class RemoteKeyboardTest extends WebDriverTestCase
                     'keyup "Shift"',
                     'keyup "f"',
                 ],
-                $this->retrieveLoggedEvents()
+                $this->retrieveLoggedKeyboardEvents()
             );
         } else {
             $this->assertEquals(
@@ -79,18 +81,8 @@ class RemoteKeyboardTest extends WebDriverTestCase
                     'keydown "f"',
                     'keyup "f"',
                 ],
-                $this->retrieveLoggedEvents()
+                $this->retrieveLoggedKeyboardEvents()
             );
         }
-    }
-
-    /**
-     * @return array
-     */
-    private function retrieveLoggedEvents()
-    {
-        $logElement = $this->driver->findElement(WebDriverBy::id('keyboardEventsLog'));
-
-        return explode("\n", $logElement->getText());
     }
 }

--- a/tests/functional/RetrieveEventsTrait.php
+++ b/tests/functional/RetrieveEventsTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+
+trait RetrieveEventsTrait
+{
+    /** @var RemoteWebDriver $driver */
+    public $driver;
+
+    /**
+     * @return array
+     */
+    private function retrieveLoggedKeyboardEvents()
+    {
+        $logElement = $this->driver->findElement(WebDriverBy::id('keyboardEventsLog'));
+
+        return explode("\n", $logElement->getText());
+    }
+
+    /**
+     * @return array
+     */
+    private function retrieveLoggedMouseEvents()
+    {
+        $logElement = $this->driver->findElement(WebDriverBy::id('mouseEventsLog'));
+
+        return explode("\n", $logElement->getText());
+    }
+}

--- a/tests/functional/web/events.html
+++ b/tests/functional/web/events.html
@@ -28,8 +28,10 @@
     <li id="item-3" draggable="true">Third item</li>
 </ul>
 
+<h2>Mouse events:</h2>
 <pre id="mouseEventsLog" style="border: 1px solid black; height: 20em; overflow: auto;"></pre>
 
+<h2>Keyboard events:</h2>
 <pre id="keyboardEventsLog" style="border: 1px solid black; height: 20em; overflow: auto;"></pre>
 
 <script>

--- a/tests/functional/web/index.html
+++ b/tests/functional/web/index.html
@@ -35,6 +35,8 @@
     <a href="alert.html" id="a-alerts">Javascript alerts</a>
     |
     <a href="events.html" id="a-drag">Events</a>
+    |
+    <a href="sortable.html" id="a-sortable">Sortable</a>
 
     <p id="id_test">Test by ID</p>
     <p class="test_class">Test by Class</p>

--- a/tests/functional/web/sortable.html
+++ b/tests/functional/web/sortable.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Sortable via jQuery</title>
+
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <style>
+        .row {
+            display: flex;
+            width: 200px;
+        }
+
+        .column {
+            flex: 50%;
+            margin-right: 10px;
+        }
+
+        .list-group {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+            width: 100%;
+        }
+
+        .list-group li {
+            margin: 0 0 2px 0;
+            padding: 0.5em;
+            height: 20px;
+        }
+
+        .tinted {
+            background-color: #ffbbbb;
+        }
+
+    </style>
+
+    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <script>
+        $(function () {
+            $("#sortable1, #sortable2").sortable({
+                placeholder: "ui-state-highlight",
+                connectWith: ".list-group"
+            });
+        });
+    </script>
+</head>
+<body>
+
+<h1>Sortable using jQuery</h1>
+
+
+<div class="row">
+    <div class="column">
+        <ul id="sortable1" class="list-group">
+            <li class="ui-state-default" id="item-1-1">1-1</li>
+            <li class="ui-state-default" id="item-1-2">1-2</li>
+            <li class="ui-state-default" id="item-1-3">1-3</li>
+            <li class="ui-state-default" id="item-1-4">1-4</li>
+            <li class="ui-state-default" id="item-1-5">1-5</li>
+        </ul>
+    </div>
+    <div class="column">
+        <ul id="sortable2" class="list-group">
+            <li class="ui-state-default tinted" id="item-2-1">2-1</li>
+            <li class="ui-state-default tinted" id="item-2-2">2-2</li>
+            <li class="ui-state-default tinted" id="item-2-3">2-3</li>
+            <li class="ui-state-default tinted" id="item-2-4">2-4</li>
+            <li class="ui-state-default tinted" id="item-2-5">2-5</li>
+        </ul>
+    </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
To preserve JsonWire protocol behavior when moving a mouse pointer we need to use relative offset via `origin` action property set to `pointer`. Fixes #757 .

https://w3c.github.io/webdriver/#dfn-dispatch-a-pointermove-action

I also added some functional tests for actions.