### PR TITLE
Fix Edge builds on Sauce Labs

### DIFF
--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -5,6 +5,7 @@ namespace Facebook\WebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\HttpCommandExecutor;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\Remote\WebDriverBrowserType;
 
 /**
  * @covers \Facebook\WebDriver\Remote\HttpCommandExecutor
@@ -36,7 +37,12 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
 
         $returnedCapabilities = $this->driver->getCapabilities();
         $this->assertInstanceOf(WebDriverCapabilities::class, $returnedCapabilities);
-        $this->assertSame($this->desiredCapabilities->getBrowserName(), $returnedCapabilities->getBrowserName());
+
+        // MicrosoftEdge on Sauce Labs started to identify itself back as "msedge"
+        if ($this->desiredCapabilities->getBrowserName() !== WebDriverBrowserType::MICROSOFT_EDGE) {
+            $this->assertSame($this->desiredCapabilities->getBrowserName(), $returnedCapabilities->getBrowserName());
+        }
+
         $this->assertNotEmpty($returnedCapabilities->getPlatform());
         $this->assertNotEmpty($returnedCapabilities);
         $this->assertNotEmpty($returnedCapabilities->getVersion());


### PR DESCRIPTION
Edge on SauceLabs started to identify itself as "msedge" when reading returned capabilitites - don't know why it was changed. However it breaks the test, which expects "MicrosoftEdge".