### PR TITLE
Disable the Devtools JSONView

### DIFF
--- a/lib/Firefox/FirefoxPreferences.php
+++ b/lib/Firefox/FirefoxPreferences.php
@@ -16,6 +16,8 @@ class FirefoxPreferences
     const READER_PARSE_ON_LOAD_ENABLED = 'reader.parse-on-load.enabled';
     /** @var string Browser homepage */
     const BROWSER_STARTUP_HOMEPAGE = 'browser.startup.homepage';
+    /** @var string Should the Devtools JSON view be enabled? */
+    const DEVTOOLS_JSONVIEW = 'devtools.jsonview.enabled';
 
     private function __construct()
     {

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -288,9 +288,12 @@ class DesiredCapabilities implements WebDriverCapabilities
             WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
         ]);
 
-        // disable the "Reader View" help tooltip, which can hide elements in the window.document
         $profile = new FirefoxProfile();
+        // disable the "Reader View" help tooltip, which can hide elements in the window.document
         $profile->setPreference(FirefoxPreferences::READER_PARSE_ON_LOAD_ENABLED, false);
+        // disable JSON viewer and let JSON be rendered as raw data
+        $profile->setPreference(FirefoxPreferences::DEVTOOLS_JSONVIEW, false);
+
         $caps->setCapability(FirefoxDriver::PROFILE, $profile);
 
         return $caps;


### PR DESCRIPTION
By default, Firefox's JSONView is enabled, which causes issue when trying to parse a JSON response.

For instance, a JSON like this:

```json
{
    "id": 1,
    "className": "App\\User"
}
```

Would be rendered with lot of HTML in the source like the screenshot below:

![image](https://user-images.githubusercontent.com/19669331/74666120-f19be680-516e-11ea-932d-7b7b6662b16a.png)

To fix the issue, we currently have to disable the preference manually:

```php
$caps = DesiredCapabilities::firefox();

$profile = new FirefoxProfile;
$profile->setPreference('devtools.jsonview.enabled', false);
$profile->setPreference(FirefoxPreferences::READER_PARSE_ON_LOAD_ENABLED, false);

$caps->setCapability(FirefoxDriver::PROFILE, $profile);
```
