### PR TITLE
Reimplement element equals method for W3C mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Reimplement element `equals()` method to be working in W3C mode.
 
 ## 1.8.1 - 2020-02-17
 ### Fixed

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -2,7 +2,6 @@
 
 namespace Facebook\WebDriver\Remote;
 
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
@@ -463,7 +462,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
     public function equals(WebDriverElement $other)
     {
         if ($this->isW3cCompliant) {
-            throw new UnsupportedOperationException('"elementEquals" is not supported by the W3C specification');
+            return $this->getID() === $other->getID();
         }
 
         return $this->executor->execute(DriverCommand::ELEMENT_EQUALS, [

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -262,12 +262,9 @@ class RemoteWebElementTest extends WebDriverTestCase
 
     /**
      * @covers ::equals
-     * @group exclude-saucelabs
      */
     public function testShouldCompareEqualsElement()
     {
-        self::skipForW3cProtocol('"equals" is not supported by the W3C specification');
-
         $this->driver->get($this->getTestPageUrl('index.html'));
 
         $firstElement = $this->driver->findElement(WebDriverBy::cssSelector('ul.list'));


### PR DESCRIPTION
Element `/equals` endpoint is not part of the W3C protocol, however it could be easily reimplemented client-side by comparing element ids, making `equals()` working again.

Ref. https://github.com/laravel/dusk/issues/736