### PR TITLE
Fix Firefox support on Mac OS Catalina

### DIFF
--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -148,8 +148,10 @@ class FirefoxProfile
         }
         file_put_contents($temp_dir . '/user.js', $content);
 
+        // Intentionally do not use `tempnam()`, as it creates empty file which zip extension may not handle.
+        $temp_zip = sys_get_temp_dir() . '/' . uniqid('WebDriverFirefoxProfileZip', false);
+
         $zip = new ZipArchive();
-        $temp_zip = tempnam(sys_get_temp_dir(), 'WebDriverFirefoxProfileZip');
         $zip->open($temp_zip, ZipArchive::CREATE);
 
         $dir = new RecursiveDirectoryIterator($temp_dir);


### PR DESCRIPTION
Firefox support is currently not working on Mac OS Catalina because of https://bugs.php.net/bug.php?id=79296. This PR introduces a workaround to make it working.