### PR TITLE
Fix creating driver from session ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Reimplement element `equals()` method to be working in W3C mode.
 
+### Fixed
+- Properly read fifth parameter whether W3C compliant instance should be created when using `createBySessionID()`.
+
 ## 1.8.1 - 2020-02-17
 ### Fixed
 - Accept array as possible input to `sendKeys()` method. (Unintentional BC break in 1.8.0.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Changed
 - Reimplement element `equals()` method to be working in W3C mode.
+- New instance of `RemoteWebDriver` created via `createBySessionID()` by default expects W3C mode. This could be disabled using fifth parameter of `createBySessionID()`.
 
 ### Fixed
 - Properly read fifth parameter whether W3C compliant instance should be created when using `createBySessionID()`.

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -161,6 +161,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      * @param string $session_id The existing session id
      * @param int|null $connection_timeout_in_ms Set timeout for the connect phase to remote Selenium WebDriver server
      * @param int|null $request_timeout_in_ms Set the maximum time of a request to remote Selenium WebDriver server
+     * @param bool $isW3cCompliant false to use the legacy JsonWire protocol, true for the W3C WebDriver spec
      * @return static
      */
     public static function createBySessionID(
@@ -170,7 +171,8 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         $request_timeout_in_ms = null
     ) {
         // BC layer to not break the method signature
-        $w3c_compliant = func_num_args() > 3 ? func_get_arg(3) : false;
+        $isW3cCompliant = func_num_args() > 4 ? func_get_arg(4) : false;
+
         $executor = new HttpCommandExecutor($selenium_server_url, null, null);
         if ($connection_timeout_in_ms !== null) {
             $executor->setConnectionTimeout($connection_timeout_in_ms);
@@ -179,7 +181,11 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $executor->setRequestTimeout($request_timeout_in_ms);
         }
 
-        return new static($executor, $session_id, null, $w3c_compliant);
+        if (!$isW3cCompliant) {
+            $executor->disableW3cCompliance();
+        }
+
+        return new static($executor, $session_id, null, $isW3cCompliant);
     }
 
     /**

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -161,7 +161,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      * @param string $session_id The existing session id
      * @param int|null $connection_timeout_in_ms Set timeout for the connect phase to remote Selenium WebDriver server
      * @param int|null $request_timeout_in_ms Set the maximum time of a request to remote Selenium WebDriver server
-     * @param bool $isW3cCompliant false to use the legacy JsonWire protocol, true for the W3C WebDriver spec
+     * @param bool $isW3cCompliant True to use W3C WebDriver (default), false to use the legacy JsonWire protocol
      * @return static
      */
     public static function createBySessionID(
@@ -171,7 +171,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         $request_timeout_in_ms = null
     ) {
         // BC layer to not break the method signature
-        $isW3cCompliant = func_num_args() > 4 ? func_get_arg(4) : false;
+        $isW3cCompliant = func_num_args() > 4 ? func_get_arg(4) : true;
 
         $executor = new HttpCommandExecutor($selenium_server_url, null, null);
         if ($connection_timeout_in_ms !== null) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,4 +10,8 @@ parameters:
         - '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::equals\(\)#'
         - '#Unsafe usage of new static\(\)#'
 
+        # Parameter is intentionally not part of signature to not break BC
+        - message: '#PHPDoc tag \@param references unknown parameter: \$isW3cCompliant#'
+          path: 'lib/Remote/RemoteWebDriver.php'
+
     inferPrivatePropertyTypeFromConstructor: true

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -92,11 +92,15 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
 
         // Store session ID
         $sessionId = $originalDriver->getSessionID();
+        $isW3cCompliant = $originalDriver->isW3cCompliant();
 
         // Create new RemoteWebDriver instance based on the session ID
-        $this->driver = RemoteWebDriver::createBySessionID($sessionId, $this->serverUrl);
+        $this->driver = RemoteWebDriver::createBySessionID($sessionId, $this->serverUrl, null, null, $isW3cCompliant);
 
         // Check we reused the previous instance (window) and it has the same URL
         $this->assertContains('/index.html', $this->driver->getCurrentURL());
+
+        // Do some interaction with the new driver
+        $this->assertNotEmpty($this->driver->findElement(WebDriverBy::id('id_test'))->getText());
     }
 }


### PR DESCRIPTION
Fixes #771.

When using `createBySessionID()`, I didn't find simple and reliable way how to programatically determine whether the existing browser instance is in W3C/JsonWire mode, so it must be told via fifth parameter.

Two changes happend here:
- The method incorrectly read fourth parameter instead of fifth, making it impossible to override the default (JsonWire) mode
- The mode is now by default W3C when using  `createBySessionID()` - its because W3C mode is also enabled by default in `create()` method, so I think we can assume most people will now use the W3C mode. And if they do not (or they don't know or use both modes on different browsers, like we do in functional tests), they can save value of `isW3cCompliant()` and provide it via fifth parameter - [see tests](https://github.com/php-webdriver/php-webdriver/compare/master...OndraM:fix/create-from-session?expand=1#diff-ec1da9cd066dfececa8924c3e954cf36R95-R98) for reference.