### PR TITLE
Add `all` and `any` expected conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Add `all` and `any` expected conditions
 
 ## 1.8.2 - 2020-03-04
 ### Changed

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -6,6 +6,7 @@ use Facebook\WebDriver\Exception\NoAlertOpenException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\NoSuchFrameException;
 use Facebook\WebDriver\Exception\StaleElementReferenceException;
+use InvalidArgumentException;
 
 /**
  * Canned ExpectedConditions which are generally useful within webdriver tests.
@@ -580,6 +581,59 @@ class WebDriverExpectedCondition
                 $result = call_user_func($condition->getApply(), $driver);
 
                 return !$result;
+            }
+        );
+    }
+
+    /**
+     * An expectation with the logical AND condition of the given conditions.
+     *
+     * @param WebDriverExpectedCondition[] $conditions
+     * @return WebDriverExpectedCondition
+     */
+    public static function all($conditions)
+    {
+        return new static(
+            function (WebDriver $driver) use ($conditions) {
+                $result = true;
+
+                foreach ($conditions as $condition) {
+                    if (!$condition instanceof self) {
+                        throw new InvalidArgumentException('$condition must be instance of WebDriverExpectedCondition class');
+                    }
+                    $result = $result && call_user_func($condition->getApply(), $driver);
+
+                    if( !$result) {
+                        return false;
+                    }
+                }
+
+                return $result;
+            }
+        );
+    }
+
+    /**
+     * An expectation with the logical OR condition of the given conditions.
+     *
+     * @param WebDriverExpectedCondition[] $conditions
+     * @return WebDriverExpectedCondition
+     */
+    public static function any($conditions)
+    {
+        return new static(
+            function (WebDriver $driver) use ($conditions) {
+                foreach ($conditions as $condition) {
+                    if (!$condition instanceof self) {
+                        throw new InvalidArgumentException('$condition must be instance of WebDriverExpectedCondition class');
+                    }
+
+                    if ($result = call_user_func($condition->getApply(), $driver)) {
+                        return $result;
+                    }
+                }
+
+                return false;
             }
         );
     }

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -588,8 +588,8 @@ class WebDriverExpectedCondition
     /**
      * An expectation with the logical AND condition of the given conditions.
      *
-     * @param WebDriverExpectedCondition[] $conditions
-     * @return WebDriverExpectedCondition
+     * @param WebDriverExpectedCondition[] $conditions Array of the conditions to be satisfied.
+     * @return static Are all conditions satisfied or not.
      */
     public static function all($conditions)
     {
@@ -616,8 +616,8 @@ class WebDriverExpectedCondition
     /**
      * An expectation with the logical OR condition of the given conditions.
      *
-     * @param WebDriverExpectedCondition[] $conditions
-     * @return WebDriverExpectedCondition
+     * @param WebDriverExpectedCondition[] $conditions Array of the conditions one of them to be satisfied.
+     * @return static Condition returns the return value of the getApply() of the first satisfied condition.
      */
     public static function any($conditions)
     {


### PR DESCRIPTION
Along with an `not` condition would be great to have `and` and `or` conditions. I called them `all` and `any` respectively