### PR TITLE
Mark package replacing facebook/webdriver (fixes #780)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "symfony/polyfill-mbstring": "^1.12",
     "symfony/process": "^2.8 || ^3.1 || ^4.0 || ^5.0"
   },
+  "replace": {
+    "facebook/webdriver": "*"
+  },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.0",
     "php-coveralls/php-coveralls": "^2.0",


### PR DESCRIPTION
If ones subdependency requires facebook/webdriver, composer will try to require both php-webdriver/webdriver and facebook/webdriver, which will cause namespace conflicts, as shown in #780.

See https://getcomposer.org/doc/04-schema.md#replace