### PR TITLE
Fix alertIsPresent in W3C mode

### DIFF
--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -2,7 +2,7 @@
 
 namespace Facebook\WebDriver;
 
-use Facebook\WebDriver\Exception\NoAlertOpenException;
+use Facebook\WebDriver\Exception\NoSuchAlertException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Exception\NoSuchFrameException;
 use Facebook\WebDriver\Exception\StaleElementReferenceException;
@@ -545,7 +545,7 @@ class WebDriverExpectedCondition
                     $alert->getText();
 
                     return $alert;
-                } catch (NoAlertOpenException $e) {
+                } catch (NoSuchAlertException $e) {
                     return null;
                 }
             }

--- a/tests/functional/WebDriverAlertTest.php
+++ b/tests/functional/WebDriverAlertTest.php
@@ -21,8 +21,8 @@ class WebDriverAlertTest extends WebDriverTestCase
 
     public function testShouldAcceptAlert()
     {
-        // Open alert
-        $this->driver->findElement(WebDriverBy::id('open-alert'))->click();
+        // Open alert (it is delayed for 1 second, to make sure following wait for alertIsPresent works properly)
+        $this->driver->findElement(WebDriverBy::id('open-alert-delayed'))->click();
 
         // Wait until present
         $this->driver->wait()->until(WebDriverExpectedCondition::alertIsPresent());

--- a/tests/functional/web/alert.html
+++ b/tests/functional/web/alert.html
@@ -7,13 +7,18 @@
 <body>
 
 <p>
-    <a href="#" onclick="javascript:alert('This is alert'); return false;" id="open-alert">Open alert</a>
+    <a href="#" onclick="alert('This is alert'); return false;" id="open-alert">Open alert</a>
     <br>
 
-    <a href="#" onclick="javascript:openConfirm(); return false;" id="open-confirm">Open confirm</a>
+    <a href="#" onclick="setTimeout(function(){ alert('This is alert');}, 1000); return false;" id="open-alert-delayed">
+        Open alert after 1 second
+    </a>
     <br>
 
-    <a href="#" onclick="javascript:openPrompt(); return false;" id="open-prompt">Open prompt</a>
+    <a href="#" onclick="openConfirm(); return false;" id="open-confirm">Open confirm</a>
+    <br>
+
+    <a href="#" onclick="openPrompt(); return false;" id="open-prompt">Open prompt</a>
     <br>
 </p>
 


### PR DESCRIPTION
The catched exception was swapped. We can rely on `NoSuchAlertException` (w3c exception), because it catches also `NoAlertOpenException` (oss mode exception), as it is inherited from `NoSuchAlertException`.