### PR TITLE
Fix ChromeDriver::start() causes 'mixed' W3c mode

### DIFF
--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -39,6 +39,12 @@ class ChromeDriver extends RemoteWebDriver
             ]
         );
         $response = $this->executor->execute($command);
+        $value = $response->getValue();
+
+        if (!$this->isW3cCompliant = isset($value['capabilities'])) {
+            $this->executor->disableW3cCompliance();
+        }
+
         $this->sessionID = $response->getSessionID();
     }
 


### PR DESCRIPTION
The `new static` within `ChromeDriver::start()` creates a RemoteWebDriver that is not W3C compatible by default (due to the default for RemoteWebDriver's 4th constructor arg). The command executor it uses assumes W3C compatibility by default though. This causes strange bugs, where commands are created assuming non-compliance, but translated by the command executor as if they were W3C compliant.

By using the logic already present in `RemoteWebDriver::create()`, ChromeDriver now detects whether the session it started is in W3C compatible mode and updates the flags both on itself and on its executor.