### PR TITLE
Add new window command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Support of SameSite cookie property.
+- Command `RemoteWebDriver::newWindow()` for W3C mode to open new top-level browsing context (aka window).
 
 ## 1.8.3 - 2020-10-06
 ### Fixed

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -140,6 +140,7 @@ class DriverCommand
     const ACTIONS = 'actions';
     const GET_ELEMENT_PROPERTY = 'getElementProperty';
     const GET_NAMED_COOKIE = 'getNamedCookie';
+    const NEW_WINDOW = 'newWindow';
     const TAKE_ELEMENT_SCREENSHOT = 'takeElementScreenshot';
     const MINIMIZE_WINDOW = 'minimizeWindow';
 

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -157,6 +157,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::IMPLICITLY_WAIT => ['method' => 'POST', 'url' => '/session/:sessionId/timeouts'],
         DriverCommand::MAXIMIZE_WINDOW => ['method' => 'POST', 'url' => '/session/:sessionId/window/maximize'],
         DriverCommand::MINIMIZE_WINDOW => ['method' => 'POST', 'url' => '/session/:sessionId/window/minimize'],
+        DriverCommand::NEW_WINDOW => ['method' => 'POST', 'url' => '/session/:sessionId/window/new'],
         DriverCommand::SET_ALERT_VALUE => ['method' => 'POST', 'url' => '/session/:sessionId/alert/text'],
         DriverCommand::SET_SCRIPT_TIMEOUT => ['method' => 'POST', 'url' => '/session/:sessionId/timeouts'],
         DriverCommand::SET_TIMEOUT => ['method' => 'POST', 'url' => '/session/:sessionId/timeouts'],

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -2,6 +2,7 @@
 
 namespace Facebook\WebDriver\Remote;
 
+use Facebook\WebDriver\Exception\UnsupportedOperationException;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\WebDriver;
@@ -195,6 +196,25 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     public function close()
     {
         $this->execute(DriverCommand::CLOSE, []);
+
+        return $this;
+    }
+
+    /**
+     * Create a new top-level browsing context.
+     *
+     * @return RemoteWebDriver The current instance.
+     */
+    public function newWindow()
+    {
+        if (!$this->isW3cCompliant) {
+            throw new UnsupportedOperationException('New window is only supported in W3C mode');
+        }
+
+        $response = $this->execute(DriverCommand::NEW_WINDOW, []);
+        $handle = $response['handle'];
+
+        $this->switchTo()->window($handle);
 
         return $this;
     }

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -319,6 +319,9 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     /**
      * Get all window handles available to the current session.
      *
+     * Note: Do not use `end($driver->getWindowHandles())` to find the last open window, for proper solution see:
+     * https://github.com/php-webdriver/php-webdriver/wiki/Alert,-tabs,-frames,-iframes#switch-to-the-new-window
+     *
      * @return array An array of string containing all available window handles.
      */
     public function getWindowHandles()

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -48,6 +48,40 @@ class RemoteWebDriverTest extends WebDriverTestCase
     }
 
     /**
+     * @group exclude-saucelabs
+     * @covers ::window
+     */
+    public function testShouldCreateNewWindow()
+    {
+        self::skipForJsonWireProtocol('Create new window is not supported in JsonWire protocol');
+
+        // Ensure that the initial context matches.
+        $initialHandle = $this->driver->getWindowHandle();
+        $this->driver->get($this->getTestPageUrl('index.html'));
+        $this->assertEquals($this->getTestPageUrl('index.html'), $this->driver->getCurrentUrl());
+        $source = $this->driver->getPageSource();
+        $this->compatAssertStringContainsString('<h1 id="welcome">', $source);
+        $this->compatAssertStringContainsString('Welcome to the php-webdriver testing page.', $source);
+        $windowHandles = $this->driver->getWindowHandles();
+        $this->assertCount(1, $windowHandles);
+
+        // Create a new window
+        $this->driver->newWindow();
+
+        $windowHandles = $this->driver->getWindowHandles();
+        $this->assertCount(2, $windowHandles);
+
+        $newWindowHandle = $this->driver->getWindowHandle();
+        $this->driver->get($this->getTestPageUrl('upload.html'));
+        $this->assertEquals($this->getTestPageUrl('upload.html'), $this->driver->getCurrentUrl());
+        $this->assertNotEquals($initialHandle, $newWindowHandle);
+
+        // Switch back to original context.
+        $this->driver->switchTo()->window($initialHandle);
+        $this->assertEquals($this->getTestPageUrl('index.html'), $this->driver->getCurrentUrl());
+    }
+
+    /**
      * @covers ::getSessionID
      * @covers ::isW3cCompliant
      */


### PR DESCRIPTION
The “New window” command (https://www.w3.org/TR/webdriver/#new-window) is not currently supported.

I’m not happy with this PR in its current form, mainly because I can’t work out the best return type, and I won’t write tests until then.

The remote endpoint returns an object containing:
- `handle`; and 
- `type` (tab, window)

In similar cases we return new objects like `WebDriverDimension` which contain the relevant data and but I’m not sure that there’s any point in returning a new `WebDriverWindow` element of any kind, because the Window performs the same as Frames - i.e. it sets the current top-level context.

I feel the best solution here is to return just the data - either just the new handle as a string, or both the handle and the type. I’m not sure if it’s worth creating a new WebDriverHandle for this.

Happy to take guidance.
