### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 2. Implement your code changes into separate branch
 3. Make sure all PHPUnit tests passes and code-style matches PSR-2 (see below). We also have Travis CI build which will automatically run tests on your pull request.
 4. When implementing notable change, fix or a new feature, add record to Unreleased section of [CHANGELOG.md](CHANGELOG.md)
-5. Submit your [pull request](https://github.com/php-webdriver/php-webdriver/pulls) against `master` branch
+5. Submit your [pull request](https://github.com/php-webdriver/php-webdriver/pulls) against `main` branch
  
 When you are going to contribute, please keep in mind that this webdriver client aims to be as close as possible to other languages Java/Ruby/Python/C#.
 FYI, here is the overview of [the official Java API](http://seleniumhq.github.io/selenium/docs/api/java/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # php-webdriver – Selenium WebDriver bindings for PHP
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/php-webdriver/webdriver.svg?style=flat-square)](https://packagist.org/packages/php-webdriver/webdriver)
-[![Travis Build](https://img.shields.io/travis/php-webdriver/php-webdriver/master.svg?style=flat-square)](https://travis-ci.com/php-webdriver/php-webdriver)
+[![Travis Build](https://img.shields.io/travis/php-webdriver/php-webdriver/main.svg?style=flat-square)](https://travis-ci.com/php-webdriver/php-webdriver)
 [![Sauce Test Status](https://saucelabs.com/buildstatus/php-webdriver)](https://saucelabs.com/u/php-webdriver)
 [![Total Downloads](https://img.shields.io/packagist/dd/php-webdriver/webdriver.svg?style=flat-square)](https://packagist.org/packages/php-webdriver/webdriver)
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.8.x-dev"
+      "dev-main": "1.8.x-dev"
     }
   },
   "autoload": {


### PR DESCRIPTION
We plan to change default branch from "master" to "main". Some reasons behind these changes were covered by @localheinz here: https://localheinz.com/blog/2020/06/12/black-lives-matter/ 

We aim to have welcoming environment in this project, and if this change from possibly offensive language could help, then lets do it! Furthermore, the term `main` is semantically more explicit for what its used.

Also this should have minimal downsides: to notable one is for people relying on `dev-master` in composer.json, which will end with broken build. Using `dev-master` is not a good practice (constrain should be on version range, not on branch), but the only thing needed to fix this issue is in composer.json:

```diff
  "require": {
-    "php-webdriver/webdriver": "dev-master"
+    "php-webdriver/webdriver": "dev-main"
  },
```

As `main` branch is already pushed into repo, this could be used right now.

Once this PR is merged, I will change GitHub settings to have "main" as default branch, retarget active PRs and delete master branch few days afterwards (to have short transition period).

- [ ] Merge #800 
- [ ] Set default branch on github
- [ ] Retarget pull requests
- [ ] Remove master branch