### PR TITLE
WebDriverSingleKeyAction will throw an exception if not a modifier

### DIFF
--- a/lib/Interactions/Internal/WebDriverKeyDownAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyDownAction.php
@@ -2,9 +2,7 @@
 
 namespace Facebook\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
-
-class WebDriverKeyDownAction extends WebDriverSingleKeyAction implements WebDriverAction
+class WebDriverKeyDownAction extends WebDriverSingleKeyAction
 {
     public function perform()
     {

--- a/lib/Interactions/Internal/WebDriverKeyUpAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyUpAction.php
@@ -2,9 +2,7 @@
 
 namespace Facebook\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
-
-class WebDriverKeyUpAction extends WebDriverSingleKeyAction implements WebDriverAction
+class WebDriverKeyUpAction extends WebDriverSingleKeyAction
 {
     public function perform()
     {

--- a/lib/Interactions/Internal/WebDriverSingleKeyAction.php
+++ b/lib/Interactions/Internal/WebDriverSingleKeyAction.php
@@ -5,13 +5,33 @@ namespace Facebook\WebDriver\Interactions\Internal;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverAction;
 use Facebook\WebDriver\WebDriverKeyboard;
+use Facebook\WebDriver\WebDriverKeys;
 use Facebook\WebDriver\WebDriverMouse;
 
 abstract class WebDriverSingleKeyAction extends WebDriverKeysRelatedAction implements WebDriverAction
 {
-    /** @var string */
-    protected $key = '';
+    const MODIFIER_KEYS = [
+        WebDriverKeys::SHIFT,
+        WebDriverKeys::LEFT_SHIFT,
+        WebDriverKeys::RIGHT_SHIFT,
+        WebDriverKeys::CONTROL,
+        WebDriverKeys::LEFT_CONTROL,
+        WebDriverKeys::RIGHT_CONTROL,
+        WebDriverKeys::ALT,
+        WebDriverKeys::LEFT_ALT,
+        WebDriverKeys::RIGHT_ALT,
+        WebDriverKeys::META,
+        WebDriverKeys::RIGHT_META,
+        WebDriverKeys::COMMAND,
+    ];
 
+    /** @var string */
+    protected $key;
+
+    /**
+     * @param string $key
+     * @todo Remove default $key value in next major version (BC)
+     */
     public function __construct(
         WebDriverKeyboard $keyboard,
         WebDriverMouse $mouse,
@@ -19,6 +39,15 @@ abstract class WebDriverSingleKeyAction extends WebDriverKeysRelatedAction imple
         $key = ''
     ) {
         parent::__construct($keyboard, $mouse, $location_provider);
+
+        if (!in_array($key, self::MODIFIER_KEYS, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'keyDown / keyUp actions can only be used for modifier keys, but "%s" was given',
+                    $key
+                )
+            );
+        }
         $this->key = $key;
     }
 }

--- a/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
@@ -4,6 +4,7 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverKeyboard;
+use Facebook\WebDriver\WebDriverKeys;
 use Facebook\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
@@ -20,21 +21,21 @@ class WebDriverKeyDownActionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->webDriverKeyboard = $this->getMockBuilder(WebDriverKeyboard::class)->getMock();
-        $this->webDriverMouse = $this->getMockBuilder(WebDriverMouse::class)->getMock();
-        $this->locationProvider = $this->getMockBuilder(WebDriverLocatable::class)->getMock();
+        $this->webDriverKeyboard = $this->createMock(WebDriverKeyboard::class);
+        $this->webDriverMouse = $this->createMock(WebDriverMouse::class);
+        $this->locationProvider = $this->createMock(WebDriverLocatable::class);
 
         $this->webDriverKeyDownAction = new WebDriverKeyDownAction(
             $this->webDriverKeyboard,
             $this->webDriverMouse,
-            $this->locationProvider
+            $this->locationProvider,
+            WebDriverKeys::LEFT_SHIFT
         );
     }
 
     public function testPerformFocusesOnElementAndSendPressKeyCommand()
     {
-        $coords = $this->getMockBuilder(WebDriverCoordinates::class)
-            ->disableOriginalConstructor()->getMock();
+        $coords = $this->createMock(WebDriverCoordinates::class);
         $this->webDriverMouse->expects($this->once())->method('click')->with($coords);
         $this->locationProvider->expects($this->once())->method('getCoordinates')->willReturn($coords);
         $this->webDriverKeyboard->expects($this->once())->method('pressKey');

--- a/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
@@ -4,6 +4,7 @@ namespace Facebook\WebDriver\Interactions\Internal;
 
 use Facebook\WebDriver\Internal\WebDriverLocatable;
 use Facebook\WebDriver\WebDriverKeyboard;
+use Facebook\WebDriver\WebDriverKeys;
 use Facebook\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
@@ -28,17 +29,16 @@ class WebDriverKeyUpActionTest extends TestCase
             $this->webDriverKeyboard,
             $this->webDriverMouse,
             $this->locationProvider,
-            'a'
+            WebDriverKeys::LEFT_SHIFT
         );
     }
 
     public function testPerformFocusesOnElementAndSendPressKeyCommand()
     {
-        $coords = $this->getMockBuilder(WebDriverCoordinates::class)
-            ->disableOriginalConstructor()->getMock();
+        $coords = $this->createMock(WebDriverCoordinates::class);
         $this->webDriverMouse->expects($this->once())->method('click')->with($coords);
         $this->locationProvider->expects($this->once())->method('getCoordinates')->willReturn($coords);
-        $this->webDriverKeyboard->expects($this->once())->method('releaseKey')->with('a');
+        $this->webDriverKeyboard->expects($this->once())->method('releaseKey')->with(WebDriverKeys::LEFT_SHIFT);
         $this->webDriverKeyUpAction->perform();
     }
 }

--- a/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+use Facebook\WebDriver\Internal\WebDriverLocatable;
+use Facebook\WebDriver\WebDriverKeyboard;
+use Facebook\WebDriver\WebDriverMouse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverSingleKeyAction
+ */
+class WebDriverSingleKeyActionTest extends TestCase
+{
+    public function testShouldThrowExceptionWhenNotUsedForModifier()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'keyDown / keyUp actions can only be used for modifier keys, but "foo" was given'
+        );
+
+        new WebDriverKeyUpAction(
+            $this->createMock(WebDriverKeyboard::class),
+            $this->createMock(WebDriverMouse::class),
+            $this->createMock(WebDriverLocatable::class),
+            'foo'
+        );
+
+        $this->assertTrue(true); // To generate coverage, see https://github.com/sebastianbergmann/phpunit/issues/3016
+    }
+}


### PR DESCRIPTION
while it's not defined in specs directly, it makes sense to throw an exception from WebDriverSingleKeyAction if key is not a modifier

Ref.:
https://github.com/SeleniumHQ/selenium/blob/e561ca8672b199ca6931b46b32290ee7ca77cf3e/java/client/src/org/openqa/selenium/interactions/internal/SingleKeyAction.java#L49
https://github.com/SeleniumHQ/selenium/blob/00de1c6b652278181721f3f4e2373b6d0088795d/javascript/node/selenium-webdriver/lib/actions.js#L59

What do you think?

To Do:
- [x] Test