### PR TITLE
Work around NULL key issue in sendKeys

### DIFF
--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -152,11 +152,19 @@ class RemoteWebElementTest extends WebDriverTestCase
         $input->sendKeys(' baz');
         $this->assertSame('foo bar baz', $input->getAttribute('value'));
 
+        $input->clear();
+        $input->sendKeys([WebDriverKeys::SHIFT, 'H', WebDriverKeys::NULL, 'ello']);
+        $this->assertSame('Hello', $input->getAttribute('value'));
+
         $textarea->clear();
         $textarea->sendKeys('foo bar');
         $this->assertSame('foo bar', $textarea->getAttribute('value'));
         $textarea->sendKeys(' baz');
         $this->assertSame('foo bar baz', $textarea->getAttribute('value'));
+
+        $textarea->clear();
+        $textarea->sendKeys([WebDriverKeys::SHIFT, 'H', WebDriverKeys::NULL, 'ello']);
+        $this->assertSame('Hello', $textarea->getAttribute('value'));
 
         // Send keys as array
         $textarea->clear();


### PR DESCRIPTION
We can work around this bug in Webdriver by a

A long-standing geckodriver bug
(https://bugzilla.mozilla.org/show_bug.cgi?id=1494661) means that it is
not possible to send a key combination such as SHIFT + 'h' + NULL + 'ello'.
In this case the NULL key does not clear the SHIFT modifier as per the
specification, and it additionally prints a character for the NULL key.

It is possible to work around this bug by splitting on the encoded key
and sending the input in multiple commands instead.
Geckodriver already sends an implicity NULL at the end of the sendKeys
command which does work, does release the modifier and does not print
any character.

### What are you trying to achieve? (Expected behavior)
Send a chord, followed by a NULL to clear the modifiers, and then a subsequent value

### What do you get instead? (Actual behavior)
On Chrome: Works as expected.
On Firefox (W3C): The NULL value is typed, a character is displayed for it, and the modifiers are not released

### How could the issue be reproduced? (Steps to reproduce)

```php
diff --git a/tests/functional/RemoteWebElementTest.php b/tests/functional/RemoteWebElementTest.php
index cacf163..4a71c93 100644
--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -152,6 +152,10 @@ class RemoteWebElementTest extends WebDriverTestCase
         $input->sendKeys(' baz');
         $this->assertSame('foo bar baz', $input->getAttribute('value'));

+        $input->clear();
+        $input->sendKeys([WebDriverKeys::SHIFT, 'H', WebDriverKeys::NULL, 'ello']);
+        $this->assertSame('Hello', $input->getAttribute('value'));
+
         $textarea->clear();
         $textarea->sendKeys('foo bar');
         $this->assertSame('foo bar', $textarea->getAttribute('value'));
```

### Details
This is a known bug in Geckodriver. See https://bugzilla.mozilla.org/show_bug.cgi?id=1494661.
It has been open for over two years with no ETA on fixing it.

The W3C Webdriver specification states at https://w3c.github.io/webdriver/#dfn-element-send-keys

> The key input state used for input may be cleared mid-way through “typing” by sending the null key, which is U+E000 (NULL).

The same issue does _not_ affect:
* any version of Chrome that I have tested;
* Firefox 47.0.1 with Marionette disabled and using the JSONWire protocol

* Php-webdriver version: main branch
* PHP version: Any
* Selenium server version: 3.141.59
* Operating system: MacOS
* Browser used + version: Firefox Nightly; Firefox 47.0.1, Chrome 83


