### PR TITLE
Add DriverServerDied exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Throw `DriverServerDiedException` on driver server process terminating unexpectedly in `DriverCommandExecutor`, with triggering error attached to improve debugging of 'The driver server has died' errors. 
 
 ## 1.9.0 - 2020-11-19
 ### Added

--- a/lib/Exception/DriverServerDiedException.php
+++ b/lib/Exception/DriverServerDiedException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+/**
+ * The driver server process is unexpectedly no longer available.
+ */
+class DriverServerDiedException extends WebDriverException
+{
+    public function __construct(\Exception $previous = null)
+    {
+        parent::__construct('The driver server has died.');
+        \Exception::__construct($this->getMessage(), 0, $previous);
+    }
+}

--- a/lib/Exception/DriverServerDiedException.php
+++ b/lib/Exception/DriverServerDiedException.php
@@ -10,6 +10,6 @@ class DriverServerDiedException extends WebDriverException
     public function __construct(\Exception $previous = null)
     {
         parent::__construct('The driver server has died.');
-        \Exception::__construct($this->getMessage(), 0, $previous);
+        \Exception::__construct($this->getMessage(), $this->getCode(), $previous);
     }
 }

--- a/lib/Remote/Service/DriverCommandExecutor.php
+++ b/lib/Remote/Service/DriverCommandExecutor.php
@@ -10,8 +10,7 @@ use Facebook\WebDriver\Remote\WebDriverCommand;
 use Facebook\WebDriver\Remote\WebDriverResponse;
 
 /**
- * A HttpCommandExecutor that talks to a local driver service instead of
- * a remote server.
+ * A HttpCommandExecutor that talks to a local driver service instead of a remote server.
  */
 class DriverCommandExecutor extends HttpCommandExecutor
 {

--- a/lib/Remote/Service/DriverCommandExecutor.php
+++ b/lib/Remote/Service/DriverCommandExecutor.php
@@ -2,6 +2,7 @@
 
 namespace Facebook\WebDriver\Remote\Service;
 
+use Facebook\WebDriver\Exception\DriverServerDiedException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Remote\DriverCommand;
 use Facebook\WebDriver\Remote\HttpCommandExecutor;
@@ -47,7 +48,7 @@ class DriverCommandExecutor extends HttpCommandExecutor
             return $value;
         } catch (\Exception $e) {
             if (!$this->service->isRunning()) {
-                throw new WebDriverException('The driver server has died.');
+                throw new DriverServerDiedException($e);
             }
             throw $e;
         }

--- a/tests/unit/Exception/DriverServerDiedExceptionTest.php
+++ b/tests/unit/Exception/DriverServerDiedExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+use PHPUnit\Framework\TestCase;
+
+class DriverServerDiedExceptionTest extends TestCase
+{
+    public function testShouldCreateWithPreviousException()
+    {
+        $dummyPreviousException = new WebDriverCurlException('CURL error');
+
+        $exception = new DriverServerDiedException($dummyPreviousException);
+
+        $this->assertSame($dummyPreviousException, $exception->getPrevious());
+    }
+}


### PR DESCRIPTION
This PR adds a new `DriverServerDiedException` with the previous error chained to improve debugging of 'Driver server has died.' exceptions. Note that line 15 of `DriverServerDiedException` is nasty but it is needed to avoid a BC break as `DriverCommandExecutor::execute()` currently throws a `WebDriverException`. 

Alternatively a named constructor could be used in `WebDriverException` to allow injection of the previous exception. It didn't feel like it fit in this class as it isn't a driver exception but rather a process control exception. Let me know if you would prefer this.

Fixes #595.