### PR TITLE
Run SauceLabs tests via GitHub Actions

### DIFF
--- a/.github/workflows/sauce-labs.yaml
+++ b/.github/workflows/sauce-labs.yaml
@@ -1,0 +1,66 @@
+name: Sauce Labs
+
+on:
+  push:
+  schedule:
+    - cron:  '0 3 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      SAUCELABS: 1
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: "Firefox 47, OSS protocol", BROWSER_NAME: "firefox", VERSION: "47.0", PLATFORM: "Windows 10", DISABLE_W3C_PROTOCOL: "1", tunnel-id: "gh-1" }
+          - { name: "Chrome 74, OSS protocol", BROWSER_NAME: "chrome", VERSION: "74.0", PLATFORM: "Windows 10", DISABLE_W3C_PROTOCOL: "1", tunnel-id: "gh-2" } # 74 is the last version which don't use W3C WebDriver by default
+          - { name: "Chrome latest, W3C protocol", BROWSER_NAME: "chrome", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-3" }
+          - { name: "Edge latest, W3C protocol", BROWSER_NAME: "MicrosoftEdge", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-4" }
+
+    name: ${{ matrix.name }} (${{ matrix.tunnel-id }})
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl, zip
+
+      - name: Install dependencies
+        run: composer update --no-interaction
+
+      - name: Start local PHP server
+        run: |
+          php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
+
+      - name: Start Sauce Connect
+        uses: saucelabs/sauce-connect-action@master
+        with:
+          username: ${{ secrets.SAUCE_USERNAME }}
+          accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+          tunnelIdentifier: ${{ matrix.tunnel-id }}
+
+      - name: Run tests
+        env:
+          BROWSER_NAME: ${{ matrix.BROWSER_NAME }}
+          VERSION: ${{ matrix.VERSION }}
+          PLATFORM: ${{ matrix.PLATFORM }}
+          DISABLE_W3C_PROTOCOL: ${{ matrix.DISABLE_W3C_PROTOCOL }}
+          SAUCE_TUNNEL_IDENTIFIER: ${{ matrix.tunnel-id }}
+        run: |
+          if [ -n "$SAUCELABS" ]; then EXCLUDE_GROUP+="exclude-saucelabs,"; fi
+          if [ "$BROWSER_NAME" = "MicrosoftEdge" ]; then EXCLUDE_GROUP+="exclude-edge,"; fi
+          if [ "$BROWSER_NAME" = "firefox" ]; then EXCLUDE_GROUP+="exclude-firefox,"; fi
+          if [ "$BROWSER_NAME" = "chrome" ]; then EXCLUDE_GROUP+="exclude-chrome,"; fi
+          if [ -n "$EXCLUDE_GROUP" ]; then EXTRA_PARAMS+=" --exclude-group $EXCLUDE_GROUP"; fi
+          ./vendor/bin/phpunit --coverage-clover ./logs/coverage-clover.xml $EXTRA_PARAMS
+
+      - name: Print logs
+        if: ${{ always() }}
+        run: |
+          if [ -f ./logs/php-server.log ]; then cat ./logs/php-server.log; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,51 +70,6 @@ matrix:
       addons:
         chrome: stable
 
-    # Saucelabs builds
-    - name: 'Sauce Labs, Firefox 47, OSS protocol'
-      php: '7.3'
-      env: SAUCELABS=1 BROWSER_NAME="firefox" VERSION="47.0" PLATFORM="Windows 10" DISABLE_W3C_PROTOCOL="1"
-      before_script:
-        - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
-        - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
-      addons:
-        sauce_connect: true
-        jwt:
-          secure: 5s8iQfH1dHgEm0DeP9VZ/MCzCeiE/HnMWqPFzRmg6VD2qJ53oYdseo8j+QCbE25MIwoSnIbKzlnbCN6fVzZc/0S7Mo45xJiq8xVLPSdMjDoOeqYE4of+t5Srq4iSzGLPCLiMTtB4xDEl6blUVGhYxN5rA/tVN+cVtLNQvo3ovRon3Mw3MqR4pgCE6PofcLXtyJc3KuOBlUJLWdPGRdlZrpKWE5ogyj4a1h4bVwidckZqkOF+gm58Gf0zVfFazDQFIw2Xuq7SZmiNgdOD5yUEePkrMhy2tbOlPNAIgHCpzHldv5Y+GYyxIYHZ0mGlGxHrfjrcAoSA6r2iXB9q2ijLVwqOARpcvGcBzZBil9aMAHRIXHAOV9Ihv4velrzmiLKADtD60Bfj2zzntGYZA3EGucitMMkkP7vfAa769i5QWK1Lniq3+VUuGNVjRzl4GuQPpc0wMWeJvQGc5Uf9Kk/sOCkPp0SPWcZ6nNAUebRy3V5OoADA9IntyXxfTlZdOHSbJTsG+eOGve0uLGRAOS+oeCstO7Gk4e/Ylozju+ixkINEY7HHDGt6AyHGtjPdy08Y0XrIqs0JMxsHKrtTVNxDjIFKbMees+vtxU3DEr/tNo1sTo34ieGKZP2Cp5mG/IrcjD1saebUaCngQO3QfeuKcU8pBTR7l7PtFNHm3HrmdkY=
-
-    - name: 'Sauce Labs, Chrome 74, OSS protocol'
-      php: '7.3'
-      env: SAUCELABS=1 BROWSER_NAME="chrome" VERSION="74.0" PLATFORM="Windows 10" DISABLE_W3C_PROTOCOL="1" # 74 is the last version which don't use W3C WebDriver by default
-      before_script:
-        - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
-        - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
-      addons:
-        sauce_connect: true
-        jwt:
-          secure: 5s8iQfH1dHgEm0DeP9VZ/MCzCeiE/HnMWqPFzRmg6VD2qJ53oYdseo8j+QCbE25MIwoSnIbKzlnbCN6fVzZc/0S7Mo45xJiq8xVLPSdMjDoOeqYE4of+t5Srq4iSzGLPCLiMTtB4xDEl6blUVGhYxN5rA/tVN+cVtLNQvo3ovRon3Mw3MqR4pgCE6PofcLXtyJc3KuOBlUJLWdPGRdlZrpKWE5ogyj4a1h4bVwidckZqkOF+gm58Gf0zVfFazDQFIw2Xuq7SZmiNgdOD5yUEePkrMhy2tbOlPNAIgHCpzHldv5Y+GYyxIYHZ0mGlGxHrfjrcAoSA6r2iXB9q2ijLVwqOARpcvGcBzZBil9aMAHRIXHAOV9Ihv4velrzmiLKADtD60Bfj2zzntGYZA3EGucitMMkkP7vfAa769i5QWK1Lniq3+VUuGNVjRzl4GuQPpc0wMWeJvQGc5Uf9Kk/sOCkPp0SPWcZ6nNAUebRy3V5OoADA9IntyXxfTlZdOHSbJTsG+eOGve0uLGRAOS+oeCstO7Gk4e/Ylozju+ixkINEY7HHDGt6AyHGtjPdy08Y0XrIqs0JMxsHKrtTVNxDjIFKbMees+vtxU3DEr/tNo1sTo34ieGKZP2Cp5mG/IrcjD1saebUaCngQO3QfeuKcU8pBTR7l7PtFNHm3HrmdkY=
-
-    - name: 'Sauce Labs, Chrome latest, W3C protocol'
-      php: '7.3'
-      env: SAUCELABS=1 BROWSER_NAME="chrome" VERSION="latest" PLATFORM="Windows 10"
-      before_script:
-        - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
-        - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
-      addons:
-        sauce_connect: true
-        jwt:
-          secure: 5s8iQfH1dHgEm0DeP9VZ/MCzCeiE/HnMWqPFzRmg6VD2qJ53oYdseo8j+QCbE25MIwoSnIbKzlnbCN6fVzZc/0S7Mo45xJiq8xVLPSdMjDoOeqYE4of+t5Srq4iSzGLPCLiMTtB4xDEl6blUVGhYxN5rA/tVN+cVtLNQvo3ovRon3Mw3MqR4pgCE6PofcLXtyJc3KuOBlUJLWdPGRdlZrpKWE5ogyj4a1h4bVwidckZqkOF+gm58Gf0zVfFazDQFIw2Xuq7SZmiNgdOD5yUEePkrMhy2tbOlPNAIgHCpzHldv5Y+GYyxIYHZ0mGlGxHrfjrcAoSA6r2iXB9q2ijLVwqOARpcvGcBzZBil9aMAHRIXHAOV9Ihv4velrzmiLKADtD60Bfj2zzntGYZA3EGucitMMkkP7vfAa769i5QWK1Lniq3+VUuGNVjRzl4GuQPpc0wMWeJvQGc5Uf9Kk/sOCkPp0SPWcZ6nNAUebRy3V5OoADA9IntyXxfTlZdOHSbJTsG+eOGve0uLGRAOS+oeCstO7Gk4e/Ylozju+ixkINEY7HHDGt6AyHGtjPdy08Y0XrIqs0JMxsHKrtTVNxDjIFKbMees+vtxU3DEr/tNo1sTo34ieGKZP2Cp5mG/IrcjD1saebUaCngQO3QfeuKcU8pBTR7l7PtFNHm3HrmdkY=
-
-    - name: 'Sauce Labs, Edge latest, W3C protocol'
-      php: '7.3'
-      env: SAUCELABS=1 BROWSER_NAME="MicrosoftEdge" VERSION="latest" PLATFORM="Windows 10"
-      before_script:
-        - php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
-        - until $(echo | nc localhost 8000); do sleep 1; echo waiting for PHP server on port 8000...; done; echo "PHP server started"
-      addons:
-        sauce_connect: true
-        jwt:
-          secure: 5s8iQfH1dHgEm0DeP9VZ/MCzCeiE/HnMWqPFzRmg6VD2qJ53oYdseo8j+QCbE25MIwoSnIbKzlnbCN6fVzZc/0S7Mo45xJiq8xVLPSdMjDoOeqYE4of+t5Srq4iSzGLPCLiMTtB4xDEl6blUVGhYxN5rA/tVN+cVtLNQvo3ovRon3Mw3MqR4pgCE6PofcLXtyJc3KuOBlUJLWdPGRdlZrpKWE5ogyj4a1h4bVwidckZqkOF+gm58Gf0zVfFazDQFIw2Xuq7SZmiNgdOD5yUEePkrMhy2tbOlPNAIgHCpzHldv5Y+GYyxIYHZ0mGlGxHrfjrcAoSA6r2iXB9q2ijLVwqOARpcvGcBzZBil9aMAHRIXHAOV9Ihv4velrzmiLKADtD60Bfj2zzntGYZA3EGucitMMkkP7vfAa769i5QWK1Lniq3+VUuGNVjRzl4GuQPpc0wMWeJvQGc5Uf9Kk/sOCkPp0SPWcZ6nNAUebRy3V5OoADA9IntyXxfTlZdOHSbJTsG+eOGve0uLGRAOS+oeCstO7Gk4e/Ylozju+ixkINEY7HHDGt6AyHGtjPdy08Y0XrIqs0JMxsHKrtTVNxDjIFKbMees+vtxU3DEr/tNo1sTo34ieGKZP2Cp5mG/IrcjD1saebUaCngQO3QfeuKcU8pBTR7l7PtFNHm3HrmdkY=
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -156,6 +111,7 @@ before_script:
 
 script:
   - if [ -n "$SAUCELABS" ]; then EXCLUDE_GROUP+="exclude-saucelabs,"; fi
+  - if [ -n "$SAUCELABS" ]; then export SAUCE_TUNNEL_IDENTIFIER="$TRAVIS_JOB_NUMBER"; fi
   - if [ "$BROWSER_NAME" = "MicrosoftEdge" ]; then EXCLUDE_GROUP+="exclude-edge,"; fi
   - if [ "$BROWSER_NAME" = "firefox" ]; then EXCLUDE_GROUP+="exclude-firefox,"; fi
   - if [ "$BROWSER_NAME" = "chrome" ]; then EXCLUDE_GROUP+="exclude-chrome,"; fi

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.0",
+    "ondram/ci-detector": "^2.1 || ^3.5",
     "php-coveralls/php-coveralls": "^2.0",
     "php-mock/php-mock-phpunit": "^1.1",
     "php-parallel-lint/php-parallel-lint": "^1.2",


### PR DESCRIPTION
SauceLabs tests are broken on Travis: https://travis-ci.community/t/opening-test-url-times-out-over-sauce-connect/9824/4 and are causing Travis build to fail since 27th August.

This moves them to GH Actions. Unfortunately, they will no longer by available for pull requests (because there is no sage way how to share secrets with pull request runs).