### PR TITLE
Add support for same-site cookies

### DIFF
--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -58,6 +58,9 @@ class Cookie implements \ArrayAccess
         if (isset($cookieArray['httpOnly'])) {
             $cookie->setHttpOnly($cookieArray['httpOnly']);
         }
+        if (isset($cookieArray['sameSite'])) {
+            $cookie->setSameSite($cookieArray['sameSite']);
+        }
 
         return $cookie;
     }
@@ -170,6 +173,24 @@ class Cookie implements \ArrayAccess
     public function isHttpOnly()
     {
         return $this->offsetGet('httpOnly');
+    }
+
+    /**
+     * The cookie's same-site value.
+     *
+     * @param string $sameSite
+     */
+    public function setSameSite($sameSite)
+    {
+        $this->offsetSet('sameSite', $sameSite);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSameSite()
+    {
+        return $this->offsetGet('sameSite');
     }
 
     /**

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -67,6 +67,7 @@ class CookieTest extends TestCase
 
         $cookie->setHttpOnly(null);
         $cookie->setPath(null);
+        $cookie->setSameSite(null);
         $cookieArray = $cookie->toArray();
 
         foreach ($cookieArray as $key => $value) {

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -17,6 +17,7 @@ class CookieTest extends TestCase
         $cookie->setExpiry(1485388387);
         $cookie->setSecure(true);
         $cookie->setHttpOnly(true);
+        $cookie->setSameSite('Lax');
 
         $this->assertSame('cookieName', $cookie->getName());
         $this->assertSame('someValue', $cookie->getValue());
@@ -25,6 +26,7 @@ class CookieTest extends TestCase
         $this->assertSame(1485388387, $cookie->getExpiry());
         $this->assertTrue($cookie->isSecure());
         $this->assertTrue($cookie->isHttpOnly());
+        $this->assertSame('Lax', $cookie->getSameSite());
 
         return $cookie;
     }
@@ -44,6 +46,7 @@ class CookieTest extends TestCase
                 'expiry' => 1485388387,
                 'secure' => true,
                 'httpOnly' => true,
+                'sameSite' => 'Lax',
             ],
             $cookie->toArray()
         );
@@ -84,6 +87,7 @@ class CookieTest extends TestCase
         $this->assertSame(1485388387, $cookie['expiry']);
         $this->assertTrue($cookie['secure']);
         $this->assertTrue($cookie['httpOnly']);
+        $this->assertSame('Lax', $cookie['sameSite']);
 
         $cookie->offsetSet('domain', 'bar.com');
         $this->assertSame('bar.com', $cookie['domain']);
@@ -122,6 +126,10 @@ class CookieTest extends TestCase
         $this->assertArrayNotHasKey('httpOnly', $cookie);
         $this->assertNull($cookie['httpOnly']);
         $this->assertNull($cookie->isHttpOnly());
+
+        $this->assertArrayNotHasKey('sameSite', $cookie);
+        $this->assertNull($cookie['sameSite']);
+        $this->assertNull($cookie->getSameSite());
     }
 
     public function testShouldBeCreatableFromAnArrayWithAllValues()
@@ -134,6 +142,7 @@ class CookieTest extends TestCase
             'expiry' => 1485388333,
             'secure' => false,
             'httpOnly' => false,
+            'sameSite' => 'Lax',
         ];
 
         $cookie = Cookie::createFromArray($sourceArray);
@@ -145,6 +154,7 @@ class CookieTest extends TestCase
         $this->assertSame(1485388333, $cookie['expiry']);
         $this->assertFalse($cookie['secure']);
         $this->assertFalse($cookie['httpOnly']);
+        $this->assertSame('Lax', $cookie['sameSite']);
     }
 
     /**


### PR DESCRIPTION
Fixes #705 

I tested this in a VM on Ubuntu 16.04 with the `chromium-browser` and the `chromedriver` packages:

```
Chromium 85.0.4183.83
ChromeDriver 85.0.4183.83
```

It correctly sets the values `Lax` and `Strict` (and `null` if `sameSite` is not set on the cookie). I also think I didn't come up with a good description for `setSameSite`, maybe someone comes up with a better one :)