### PR TITLE
Validate SameSite cookie value

### DIFF
--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -13,6 +13,13 @@ use InvalidArgumentException;
  */
 class Cookie implements \ArrayAccess
 {
+    /** @var string */
+    const SAMESITE_LAX = 'Lax';
+    /** @var string */
+    const SAMESITE_STRICT = 'Strict';
+    /** @var string */
+    const SAMESITE_NONE = 'None';
+
     /** @var array */
     protected $cookie = [];
 
@@ -182,6 +189,12 @@ class Cookie implements \ArrayAccess
      */
     public function setSameSite($sameSite)
     {
+        if (!in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE, null], true)) {
+            throw new InvalidArgumentException(
+                'The "sameSite" parameter value is not valid, must be one of "Lax", "Strict" or "None"'
+            );
+        }
+
         $this->offsetSet('sameSite', $sameSite);
     }
 


### PR DESCRIPTION
SameSite cookie value is validated to be only "Lax", "Strict" or "None". Extends #820 .

Also added constants for this value:

```php
$cookie = new Cookie('cookieName', 'cookie value');
$cookie->setSameSite(Cookie::SAMESITE_LAX);
```