### PR TITLE
Add PHP nightly build to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,14 @@ services:
   - xvfb
 
 matrix:
+  allow_failures:
+    - php: 'nightly'
+
   include:
+    - name: 'PHP nightly build'
+      php: 'nightly'
+      env: DEPENDENCIES="--ignore-platform-reqs"
+
     # Build with lowest possible dependencies on lowest possible PHP
     - name: 'Lowest dependencies build'
       php: '5.6'


### PR DESCRIPTION
Adds PHP nightly build to Travis CI and allow failures. Currently PHP 8.0.0-dev.