### PR TITLE
Workaround for broken PHPStan builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,8 @@
   "scripts": {
     "analyze": [
       "vendor/bin/parallel-lint -j 10 ./lib ./tests example.php",
-      "vendor/bin/phpstan.phar analyze ./lib ./tests --level 2 -c phpstan.neon --ansi"
+      "vendor/bin/phpstan.phar analyze -c phpstan.neon --ansi",
+      "vendor/bin/phpstan.phar analyze -c phpstan-webdriverkeys.neon --ansi"
     ],
     "codestyle:check": [
       "vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run -vvv --ansi",

--- a/phpstan-webdriverkeys.neon
+++ b/phpstan-webdriverkeys.neon
@@ -1,0 +1,6 @@
+# WebDriverKeys.php breaks PHPStan parallel processing, so we must analyze the file separately.
+# See https://github.com/phpstan/phpstan/issues/3956 and https://github.com/clue/reactphp-ndjson/issues/21
+parameters:
+    level: 2
+    paths:
+        - lib/WebDriverKeys.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,3 +16,6 @@ parameters:
           path: 'lib/Remote/RemoteWebDriver.php'
 
     inferPrivatePropertyTypeFromConstructor: true
+
+    excludes_analyse:
+        - lib/WebDriverKeys.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,9 @@
 parameters:
+    level: 2
+    paths:
+        - lib/
+        - tests/
+
     ignoreErrors:
         # To be fixed:
         - '#Call to an undefined method Facebook\\WebDriver\\WebDriver::getTouch\(\)#'


### PR DESCRIPTION
[WebDriverKeys.php](https://github.com/php-webdriver/php-webdriver/blob/main/lib/WebDriverKeys.php#L12-L81) breaks PHPStan parallel processing, so we exclude the file first and then we analyze it separately.

Ref. https://github.com/php-webdriver/php-webdriver/pull/828#issuecomment-728001440, https://github.com/phpstan/phpstan/issues/3956 and https://github.com/clue/reactphp-ndjson/issues/21 .