### PR TITLE
Revert "Workaround for broken PHPStan parallel processing"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,7 @@
   "scripts": {
     "analyze": [
       "vendor/bin/parallel-lint -j 10 ./lib ./tests example.php",
-      "vendor/bin/phpstan.phar analyze -c phpstan.neon --ansi",
-      "vendor/bin/phpstan.phar analyze -c phpstan-webdriverkeys.neon --ansi"
+      "vendor/bin/phpstan.phar analyze ./lib ./tests --level 2 -c phpstan.neon --ansi"
     ],
     "codestyle:check": [
       "vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run -vvv --ansi",

--- a/phpstan-webdriverkeys.neon
+++ b/phpstan-webdriverkeys.neon
@@ -1,6 +1,0 @@
-# WebDriverKeys.php breaks PHPStan parallel processing, so we must analyze the file separately.
-# See https://github.com/phpstan/phpstan/issues/3956 and https://github.com/clue/reactphp-ndjson/issues/21
-parameters:
-    level: 2
-    paths:
-        - lib/WebDriverKeys.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,3 @@ parameters:
           path: 'lib/Remote/RemoteWebDriver.php'
 
     inferPrivatePropertyTypeFromConstructor: true
-
-    excludes_analyse:
-        - lib/WebDriverKeys.php


### PR DESCRIPTION
This reverts commit 5898a74ce2bb87b2b755d322069200c7460fe907.

PHPStan is fixed already, I just released 0.12.56.

Ref.: https://github.com/php-webdriver/php-webdriver/pull/830