### PR TITLE
Make path to chromedriver executable not required

### DIFF
--- a/lib/Chrome/ChromeDriverService.php
+++ b/lib/Chrome/ChromeDriverService.php
@@ -11,18 +11,27 @@ class ChromeDriverService extends DriverService
      * @deprecated Use ChromeDriverService::CHROME_DRIVER_EXECUTABLE
      */
     const CHROME_DRIVER_EXE_PROPERTY = 'webdriver.chrome.driver';
-    // The environment variable storing the path to the chrome driver executable
+    /** @var string The environment variable storing the path to the chrome driver executable */
     const CHROME_DRIVER_EXECUTABLE = 'WEBDRIVER_CHROME_DRIVER';
+    /**
+     * @var string Default executable used when no other is provided
+     * @internal
+     */
+    const DEFAULT_EXECUTABLE = 'chromedriver';
 
     /**
      * @return static
      */
     public static function createDefaultService()
     {
-        $exe = getenv(self::CHROME_DRIVER_EXECUTABLE) ?: getenv(self::CHROME_DRIVER_EXE_PROPERTY);
+        $pathToExecutable = getenv(self::CHROME_DRIVER_EXECUTABLE) ?: getenv(self::CHROME_DRIVER_EXE_PROPERTY);
+        if ($pathToExecutable === false) {
+            $pathToExecutable = static::DEFAULT_EXECUTABLE;
+        }
+
         $port = 9515; // TODO: Get another port if the default port is used.
         $args = ['--port=' . $port];
 
-        return new static($exe, $port, $args);
+        return new static($pathToExecutable, $port, $args);
     }
 }

--- a/tests/functional/Chrome/ChromeDriverServiceTest.php
+++ b/tests/functional/Chrome/ChromeDriverServiceTest.php
@@ -11,10 +11,20 @@ use PHPUnit\Framework\TestCase;
  */
 class ChromeDriverServiceTest extends TestCase
 {
+    /** @var ChromeDriverService */
+    private $driverService;
+
     protected function setUp(): void
     {
         if (!getenv('BROWSER_NAME') === 'chrome' || getenv('SAUCELABS') || !getenv('CHROMEDRIVER_PATH')) {
             $this->markTestSkipped('ChromeDriverServiceTest is run only when running against local chrome');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->driverService !== null && $this->driverService->isRunning()) {
+            $this->driverService->stop();
         }
     }
 
@@ -23,41 +33,32 @@ class ChromeDriverServiceTest extends TestCase
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=' . getenv('CHROMEDRIVER_PATH'));
 
-        $driverService = ChromeDriverService::createDefaultService();
+        $this->driverService = ChromeDriverService::createDefaultService();
 
-        $this->assertSame('http://localhost:9515', $driverService->getURL());
+        $this->assertSame('http://localhost:9515', $this->driverService->getURL());
 
-        $this->assertInstanceOf(ChromeDriverService::class, $driverService->start());
-        $this->assertTrue($driverService->isRunning());
+        $this->assertInstanceOf(ChromeDriverService::class, $this->driverService->start());
+        $this->assertTrue($this->driverService->isRunning());
 
-        $this->assertInstanceOf(ChromeDriverService::class, $driverService->start());
+        $this->assertInstanceOf(ChromeDriverService::class, $this->driverService->start());
 
-        $this->assertInstanceOf(ChromeDriverService::class, $driverService->stop());
-        $this->assertFalse($driverService->isRunning());
+        $this->assertInstanceOf(ChromeDriverService::class, $this->driverService->stop());
+        $this->assertFalse($this->driverService->isRunning());
 
-        $this->assertInstanceOf(ChromeDriverService::class, $driverService->stop());
+        $this->assertInstanceOf(ChromeDriverService::class, $this->driverService->stop());
     }
 
     public function testShouldStartAndStopServiceCreatedUsingDefaultConstructor()
     {
-        $driverService = new ChromeDriverService(getenv('CHROMEDRIVER_PATH'), 9515, ['--port=9515']);
+        $this->driverService = new ChromeDriverService(getenv('CHROMEDRIVER_PATH'), 9515, ['--port=9515']);
 
-        $this->assertSame('http://localhost:9515', $driverService->getURL());
+        $this->assertSame('http://localhost:9515', $this->driverService->getURL());
 
-        $driverService->start();
-        $this->assertTrue($driverService->isRunning());
+        $this->driverService->start();
+        $this->assertTrue($this->driverService->isRunning());
 
-        $driverService->stop();
-        $this->assertFalse($driverService->isRunning());
-    }
-
-    public function testShouldThrowExceptionIfExecutableCannotBeFound()
-    {
-        putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=/not/existing');
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('\'/not/existing\' is not a file.');
-        ChromeDriverService::createDefaultService();
+        $this->driverService->stop();
+        $this->assertFalse($this->driverService->isRunning());
     }
 
     public function testShouldThrowExceptionIfExecutableIsNotExecutable()
@@ -67,5 +68,21 @@ class ChromeDriverServiceTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('is not executable');
         ChromeDriverService::createDefaultService();
+    }
+
+    public function testShouldUseDefaultExecutableIfNoneProvided()
+    {
+        // Put path where ChromeDriver was downloaded to system PATH
+        putenv('PATH=' . getenv('PATH') . ':' . dirname(getenv('CHROMEDRIVER_PATH')));
+
+        // Unset CHROME_DRIVER_EXECUTABLE so that ChromeDriverService will attempt to run the binary from system PATH
+        putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=');
+
+        $this->driverService = ChromeDriverService::createDefaultService();
+
+        $this->assertSame('http://localhost:9515', $this->driverService->getURL());
+
+        $this->assertInstanceOf(ChromeDriverService::class, $this->driverService->start());
+        $this->assertTrue($this->driverService->isRunning());
     }
 }


### PR DESCRIPTION
Currently we require `WEBDRIVER_CHROME_DRIVER` (or deprecated `webdriver.chrome.driver`) environment variable to be set before attempting to start ChromeDriver. Even if you install `chromedriver` to your system PATH and can only start `chromedriver`, you'd still need to set the environment variable.

This PR changes this behavior, so that if you don't define you own path to executable, `ChromeDriver::start()` will by default try to execute `chromedriver` command.

Meaning you don't need to setup anything when chromedriver in already in system PATH.