### PR TITLE
Put more information to every deprecation, deprecate PhantomJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Throw `DriverServerDiedException` on local driver process terminating unexpectedly and provide full details of original exception to improve debugging.
 - Do not require `WEBDRIVER_CHROME_DRIVER` environment variable to be set if `chromedriver` binary is already available via system PATH.
+- Mark PhantomJS deprecated, as it is no longer developed and maintained.
 
 ## 1.9.0 - 2020-11-19
 ### Added

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -13,7 +13,7 @@ class ChromeOptions
 {
     /**
      * The key of chrome options desired capabilities (in legacy OSS JsonWire protocol)
-     * @deprecated
+     * @todo Replace value with 'goog:chromeOptions' after JsonWire protocol support is removed
      */
     const CAPABILITY = 'chromeOptions';
     /**

--- a/lib/Exception/ElementNotVisibleException.php
+++ b/lib/Exception/ElementNotVisibleException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class ElementNotVisibleException extends WebDriverException
 {

--- a/lib/Exception/ExpectedException.php
+++ b/lib/Exception/ExpectedException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class ExpectedException extends WebDriverException
 {

--- a/lib/Exception/IMEEngineActivationFailedException.php
+++ b/lib/Exception/IMEEngineActivationFailedException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class IMEEngineActivationFailedException extends WebDriverException
 {

--- a/lib/Exception/IMENotAvailableException.php
+++ b/lib/Exception/IMENotAvailableException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class IMENotAvailableException extends WebDriverException
 {

--- a/lib/Exception/IndexOutOfBoundsException.php
+++ b/lib/Exception/IndexOutOfBoundsException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class IndexOutOfBoundsException extends WebDriverException
 {

--- a/lib/Exception/InvalidCoordinatesException.php
+++ b/lib/Exception/InvalidCoordinatesException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class InvalidCoordinatesException extends WebDriverException
 {

--- a/lib/Exception/NoCollectionException.php
+++ b/lib/Exception/NoCollectionException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NoCollectionException extends WebDriverException
 {

--- a/lib/Exception/NoScriptResultException.php
+++ b/lib/Exception/NoScriptResultException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NoScriptResultException extends WebDriverException
 {

--- a/lib/Exception/NoStringException.php
+++ b/lib/Exception/NoStringException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NoStringException extends WebDriverException
 {

--- a/lib/Exception/NoStringLengthException.php
+++ b/lib/Exception/NoStringLengthException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NoStringLengthException extends WebDriverException
 {

--- a/lib/Exception/NoStringWrapperException.php
+++ b/lib/Exception/NoStringWrapperException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NoStringWrapperException extends WebDriverException
 {

--- a/lib/Exception/NoSuchCollectionException.php
+++ b/lib/Exception/NoSuchCollectionException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NoSuchCollectionException extends WebDriverException
 {

--- a/lib/Exception/NoSuchDriverException.php
+++ b/lib/Exception/NoSuchDriverException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NoSuchDriverException extends WebDriverException
 {

--- a/lib/Exception/NullPointerException.php
+++ b/lib/Exception/NullPointerException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class NullPointerException extends WebDriverException
 {

--- a/lib/Exception/XPathLookupException.php
+++ b/lib/Exception/XPathLookupException.php
@@ -3,7 +3,7 @@
 namespace Facebook\WebDriver\Exception;
 
 /**
- * @deprecated Removed in W3C WebDriver
+ * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686
  */
 class XPathLookupException extends WebDriverException
 {

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -163,7 +163,7 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
-     * @todo Remove side-effects - not change ie. ChromeOptions::CAPABILITY from instance of ChromeOptions to an array
+     * @todo Remove side-effects - not change eg. ChromeOptions::CAPABILITY from instance of ChromeOptions to an array
      * @return array
      */
     public function toArray()

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -392,6 +392,8 @@ class DesiredCapabilities implements WebDriverCapabilities
     }
 
     /**
+     * @deprecated PhantomJS is no longer developed and its support will be removed in next major version.
+     * Use headless Chrome or Firefox instead.
      * @return static
      */
     public static function phantomjs()

--- a/lib/Remote/WebDriverBrowserType.php
+++ b/lib/Remote/WebDriverBrowserType.php
@@ -28,6 +28,10 @@ class WebDriverBrowserType
     const IE = 'internet explorer';
     const IPHONE = 'iphone';
     const IPAD = 'iPad';
+    /**
+     * @deprecated PhantomJS is no longer developed and its support will be removed in next major version.
+     * Use headless Chrome or Firefox instead.
+     */
     const PHANTOMJS = 'phantomjs';
 
     private function __construct()

--- a/lib/WebDriverPlatform.php
+++ b/lib/WebDriverPlatform.php
@@ -10,7 +10,7 @@ namespace Facebook\WebDriver;
 class WebDriverPlatform
 {
     const ANDROID = 'ANDROID';
-    /** @deprecated */
+    /** @deprecated ANY has no meaning in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/731 */
     const ANY = 'ANY';
     const LINUX = 'LINUX';
     const MAC = 'MAC';

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -176,7 +176,7 @@ class DesiredCapabilitiesTest extends TestCase
                     'acceptInsecureCerts' => true,
                 ],
             ],
-            'removed capabilitites' => [
+            'removed capabilities' => [
                 new DesiredCapabilities([
                     WebDriverCapabilityType::WEB_STORAGE_ENABLED => true,
                     WebDriverCapabilityType::TAKES_SCREENSHOT => false,


### PR DESCRIPTION
Its quite helpful for library users to have comment with upgrade path or with a link to more information on every deprecation.

Also, we can mark PhantomJS deprecated (it is no longer developed, headless Chrome or Firefox should be used instead), and its support from the code will be completely removed in next major version.