### PR TITLE
Add links to Discussions, improve contributor guidance and DX

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,17 +5,23 @@ We love to have your help to make php-webdriver better!
 Feel free to open an [issue](https://github.com/php-webdriver/php-webdriver/issues) if you run into any problem, or
 send a pull request (see bellow) with your contribution.
 
+## Before you contribute
+
+Do not hesitate to ask for a guidance before you implement notable change, or a new feature - use the associated [issue](https://github.com/php-webdriver/php-webdriver/issues) or use [Discussions](https://github.com/php-webdriver/php-webdriver/discussions).
+Because any new code means increased effort in library maintenance (which is being done by volunteers in their free time),
+please understand not every pull request is automatically accepted. This is why we recommend using the mentioned channels to discuss bigger changes in the source code first.
+
+When you are going to contribute, also please keep in mind that this webdriver client aims to be similar to clients in languages Java/Ruby/Python/C#.
+Here is the [official documentation](https://www.selenium.dev/documentation/en/) and overview of [the official Java API](http://seleniumhq.github.io/selenium/docs/api/java/)
+
 ## Workflow when contributing a patch
 
 1. Fork the project on GitHub
 2. Implement your code changes into separate branch
-3. Make sure all PHPUnit tests passes and code-style matches PSR-2 (see below). We also have Travis CI build which will automatically run tests on your pull request.
+3. Make sure all PHPUnit tests passes and code-style matches PSR-2 (see below). We also have CI builds which will automatically run tests on your pull request. Make sure to fix any reported issues reported by these automated tests.
 4. When implementing a notable change, fix or a new feature, add record to the Unreleased section of [CHANGELOG.md](../CHANGELOG.md)
 5. Submit your [pull request](https://github.com/php-webdriver/php-webdriver/pulls) against `main` branch
  
-When you are going to contribute, please keep in mind that this webdriver client aims to be similar to clients in languages Java/Ruby/Python/C#.
-Here is the [official documentation](https://www.selenium.dev/documentation/en/) and overview of [the official Java API](http://seleniumhq.github.io/selenium/docs/api/java/)
-
 ### Run unit tests
 
 There are two test-suites: one with unit tests only, second with functional tests, which require running selenium server.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,22 +21,40 @@ Here is the [official documentation](https://www.selenium.dev/documentation/en/)
 3. Make sure all PHPUnit tests passes and code-style matches PSR-2 (see below). We also have CI builds which will automatically run tests on your pull request. Make sure to fix any reported issues reported by these automated tests.
 4. When implementing a notable change, fix or a new feature, add record to the Unreleased section of [CHANGELOG.md](../CHANGELOG.md)
 5. Submit your [pull request](https://github.com/php-webdriver/php-webdriver/pulls) against `main` branch
- 
-### Run unit tests
 
-There are two test-suites: one with **unit tests** only (called `unit`), second with **functional tests** (called `functional`),
+### Run automated code checks
+
+To make sure your code comply with [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style, tests passes and to execute other automated checks, run locally:
+
+```sh
+composer preinstall # Run this only on the first run - this will install some additional dependencies
+
+composer all
+```
+
+To run functional tests locally there is some additional setup needed - see below. Without this setup, functional tests will be skipped.
+
+
+For easier development there are also few other prepared commands:
+- `composer fix` - to auto-fix the codestyle and composer.json
+- `composer analyze` - to run only code analysis (without tests)
+- `composer test` - to run all tests
+
+### Unit tests
+
+There are two test-suites: one with **unit tests** only (`unit`), and second with **functional tests** (`functional`),
 which requires running Selenium server and local PHP server.
 
 To execute **all tests** in both suites run:
 
 ```sh
-./vendor/bin/phpunit
+composer test
 ```
 
 If you want to execute **just the unit tests**, run:
 
 ```sh
-./vendor/bin/phpunit --testsuite unit
+composer test -- --testsuite unit
 ```
 
 **Functional tests** are run against a real browser. It means they take a bit longer and also require an additional setup:
@@ -44,40 +62,28 @@ you must first [download](https://www.selenium.dev/downloads/) and start the Sel
 then start the local PHP server which will serve the test pages and then run the `functional` test suite:
 
 ```sh
+export BROWSER_NAME="htmlunit" # see below for other browsers
 java -jar selenium-server-standalone-X.X.X.jar -log selenium.log &
 php -S localhost:8000 -t tests/functional/web/ &
-./vendor/bin/phpunit --testsuite functional
+# Use following to run both unit and functional tests
+composer all
+# Or this to run only functional tests:
+composer test -- --testsuite functional
 ```
 
-The functional tests will be started in HtmlUnit headless browser by default. If you want to run them in other browser
-like Chrome, set the `BROWSER_NAME` environment variable:
+If you want to run tests in different browser then "htmlunit" (Chrome or Firefox), you need to setup the browser driver (Chromedriver/Geckodriver), as it is [explained in wiki](https://github.com/php-webdriver/php-webdriver/wiki/Chrome)
+and then the `BROWSER_NAME` environment variable:
 
 ```sh
 ...
 export BROWSER_NAME="chrome"
-./vendor/bin/phpunit --testsuite functional
+composer all
 ```
-
-Don't forget you also need to setup browser driver (Chromedriver/Geckodriver), as its [explained in wiki](https://github.com/php-webdriver/php-webdriver/wiki/Chrome).
 
 To test with Firefox/Geckodriver, you must also set `GECKODRIVER` environment variable:
 
 ```sh
 export GECKODRIVER=1
-export BROWSER_NAME=firefox
-./vendor/bin/phpunit --testsuite functional
-```
-
-### Check coding style
-
-Your code-style should comply with [PSR-2](http://www.php-fig.org/psr/psr-2/). To make sure your code matches this requirement run:
-
-```sh
-composer codestyle:check
-```
-
-To auto-fix the codestyle simply run:
-
-```sh
-composer codestyle:fix
+export BROWSER_NAME="firefox"
+composer all
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,43 +24,60 @@ Here is the [official documentation](https://www.selenium.dev/documentation/en/)
  
 ### Run unit tests
 
-There are two test-suites: one with unit tests only, second with functional tests, which require running selenium server.
+There are two test-suites: one with **unit tests** only (called `unit`), second with **functional tests** (called `functional`),
+which requires running Selenium server and local PHP server.
 
-To execute all tests simply run:
+To execute **all tests** in both suites run:
 
-    ./vendor/bin/phpunit
+```sh
+./vendor/bin/phpunit
+```
 
-If you want to execute just the unit tests, run:
+If you want to execute **just the unit tests**, run:
 
-    ./vendor/bin/phpunit --testsuite unit
+```sh
+./vendor/bin/phpunit --testsuite unit
+```
 
-For the functional tests you must first [download](http://selenium-release.storage.googleapis.com/index.html) and start
-the selenium standalone server, start the local PHP server which will serve the test pages and then run the `functional`
-test suite:
+**Functional tests** are run against a real browser. It means they take a bit longer and also require an additional setup:
+you must first [download](https://www.selenium.dev/downloads/) and start the Selenium standalone server,
+then start the local PHP server which will serve the test pages and then run the `functional` test suite:
 
-    java -jar selenium-server-standalone-3.9.1.jar -log selenium.log &
-    php -S localhost:8000 -t tests/functional/web/ &
-    ./vendor/bin/phpunit --testsuite functional
+```sh
+java -jar selenium-server-standalone-X.X.X.jar -log selenium.log &
+php -S localhost:8000 -t tests/functional/web/ &
+./vendor/bin/phpunit --testsuite functional
+```
 
-The functional tests will be started in HtmlUnit headless browser by default. If you want to run them in eg. Firefox,
-simply set the `BROWSER_NAME` environment variable:
+The functional tests will be started in HtmlUnit headless browser by default. If you want to run them in other browser
+like Chrome, set the `BROWSER_NAME` environment variable:
 
-    ...
-    export BROWSER_NAME="firefox"
-    ./vendor/bin/phpunit --testsuite functional
+```sh
+...
+export BROWSER_NAME="chrome"
+./vendor/bin/phpunit --testsuite functional
+```
 
-To test with Geckodriver, [download](https://github.com/mozilla/geckodriver/releases) and start the server, then run:
+Don't forget you also need to setup browser driver (Chromedriver/Geckodriver), as its [explained in wiki](https://github.com/php-webdriver/php-webdriver/wiki/Chrome).
 
-    export GECKODRIVER=1
-    export BROWSER_NAME=firefox
-    ./vendor/bin/phpunit --testsuite functional
+To test with Firefox/Geckodriver, you must also set `GECKODRIVER` environment variable:
+
+```sh
+export GECKODRIVER=1
+export BROWSER_NAME=firefox
+./vendor/bin/phpunit --testsuite functional
+```
 
 ### Check coding style
 
 Your code-style should comply with [PSR-2](http://www.php-fig.org/psr/psr-2/). To make sure your code matches this requirement run:
 
-    composer codestyle:check
+```sh
+composer codestyle:check
+```
 
 To auto-fix the codestyle simply run:
 
-    composer codestyle:fix
+```sh
+composer codestyle:fix
+```

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -20,20 +20,13 @@ jobs:
           extensions: mbstring, intl, zip
 
       - name: Install dependencies
-        run: |
-          composer update --no-interaction
-          composer require --dev phpstan/phpstan # Not part of require-dev, because it won't install on PHP 5.6
-          composer require --dev ergebnis/composer-normalize
+        run: composer preinstall
 
-      - name: Check composer.json
-        run: |
-          composer validate --strict
-          composer normalize --dry-run
+      - name: Lint
+        run: composer lint
 
-      - name: Run checks
-        run: |
-          composer analyze
-          composer codestyle:check
+      - name: Run analysis
+        run: composer analyze
 
   markdown-link-check:
     name: "Markdown link check"

--- a/README.md
+++ b/README.md
@@ -206,10 +206,16 @@ There are some projects already providing this:
 
 We have a great community willing to help you!
 
-- **Via StackOverflow** - You can [ask a question](https://stackoverflow.com/questions/ask?tags=php+selenium-webdriver+php-webdriver) or find many already answered question on StackOverflow
-- **Via our Facebook Group** - If you have questions or are an active contributor consider joining our [facebook group](https://www.facebook.com/groups/phpwebdriver/) and contribute to communal discussion and support
-- **Via GitHub** - Another option if you have a question (or bug report) is to [submit it here](https://github.com/php-webdriver/php-webdriver/issues/new) as a new issue
+❓ Do you have a **question, idea or some general feedback**? Visit our [Discussions](https://github.com/php-webdriver/php-webdriver/discussions) page.
+(Alternatively, you can [look for many answered questions also on StackOverflow](https://stackoverflow.com/questions/tagged/php+selenium-webdriver)).
 
-## Contributing
+🐛 Something isn't working, and you want to **report a bug**? [Submit it here](https://github.com/php-webdriver/php-webdriver/issues/new) as a new issue.
+
+📙 Looking for a **how-to** or **reference documentation**? See [our wiki](https://github.com/php-webdriver/php-webdriver/wiki).
+
+## Contributing ❤️
 
 We love to have your help to make php-webdriver better. See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for more information about contributing and developing php-webdriver.
+
+Php-webdriver is community project - if you want to join the effort with maintaining and developing this library, the best is to look on [issues marked with "help wanted"](https://github.com/php-webdriver/php-webdriver/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+label. Let us know in the issue comments if you want to contribute and if you want any guidance, and we will be delighted to help you to prepare your pull request.

--- a/composer.json
+++ b/composer.json
@@ -64,17 +64,33 @@
   },
   "minimum-stability": "beta",
   "scripts": {
-    "analyze": [
-      "vendor/bin/parallel-lint -j 10 ./lib ./tests example.php",
-      "vendor/bin/phpstan analyze -c phpstan.neon --ansi"
+    "all": [
+      "@lint",
+      "@analyze",
+      "@test"
     ],
-    "codestyle:check": [
+    "analyze": [
+      "vendor/bin/phpstan analyze -c phpstan.neon --ansi",
       "vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run -vvv --ansi",
       "vendor/bin/phpcs --standard=PSR2 ./lib/ ./tests/"
     ],
-    "codestyle:fix": [
+    "fix": [
+      "@composer normalize",
       "vendor/bin/php-cs-fixer fix --diff --diff-format=udiff -vvv || exit 0",
       "vendor/bin/phpcbf --standard=PSR2 ./lib/ ./tests/"
+    ],
+    "lint": [
+      "vendor/bin/parallel-lint -j 10 ./lib ./tests example.php",
+      "@composer validate",
+      "@composer normalize --dry-run"
+    ],
+    "preinstall": [
+      "@composer update --no-progress --no-interaction",
+      "@composer require --dev phpstan/phpstan",
+      "@composer require --dev ergebnis/composer-normalize"
+    ],
+    "test": [
+      "vendor/bin/phpunit --colors=always"
     ]
   }
 }

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -36,10 +36,11 @@ class WebDriverTestCase extends TestCase
         if (static::isSauceLabsBuild()) {
             $this->setUpSauceLabs();
         } else {
-            if (getenv('BROWSER_NAME')) {
-                $browserName = getenv('BROWSER_NAME');
-            } else {
-                $browserName = WebDriverBrowserType::HTMLUNIT;
+            $browserName = (string) getenv('BROWSER_NAME');
+            if ($browserName === '') {
+                $this->markTestSkipped(
+                    'To execute functional tests browser name must be provided in BROWSER_NAME environment variable'
+                );
             }
 
             if ($browserName === WebDriverBrowserType::CHROME) {


### PR DESCRIPTION
Newly introduced GitHub [Discussions](https://github.com/php-webdriver/php-webdriver/discussions) look like a nice place to provide community support (questions, feedback, ideas etc.), so lets point users there, instead of current (unused) Facebook group and GitHub issues.

Contributor guidance in CONTRIBUTING.md was also extended.

And I've also rearranged composer scripts for better DX (developer experience).