### PR TITLE
Make the capability conversion JsonSerializable

### DIFF
--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -3,13 +3,14 @@
 namespace Facebook\WebDriver\Chrome;
 
 use Facebook\WebDriver\Remote\DesiredCapabilities;
+use JsonSerializable;
 
 /**
  * The class manages the capabilities in ChromeDriver.
  *
  * @see https://sites.google.com/a/chromium.org/chromedriver/capabilities
  */
-class ChromeOptions
+class ChromeOptions implements JsonSerializable
 {
     /**
      * The key of chrome options desired capabilities (in legacy OSS JsonWire protocol)
@@ -36,6 +37,16 @@ class ChromeOptions
      * @var array
      */
     private $experimentalOptions = [];
+
+    /**
+     * Return a version of the class which can JSON serialized.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
 
     /**
      * Sets the path of the Chrome executable. The path should be either absolute

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -143,9 +143,9 @@ class DesiredCapabilitiesTest extends TestCase
         DesiredCapabilities $inputJsonWireCapabilities,
         array $expectedW3cCapabilities
     ) {
-        $this->assertEquals(
-            $expectedW3cCapabilities,
-            $inputJsonWireCapabilities->toW3cCompatibleArray()
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expectedW3cCapabilities),
+            json_encode($inputJsonWireCapabilities->toW3cCompatibleArray())
         );
     }
 
@@ -224,6 +224,18 @@ class DesiredCapabilitiesTest extends TestCase
             'chromeOptions should be converted' => [
                 new DesiredCapabilities([
                     ChromeOptions::CAPABILITY => $chromeOptions,
+                ]),
+                [
+                    'goog:chromeOptions' => new \ArrayObject(
+                        [
+                            'args' => ['--headless'],
+                        ]
+                    ),
+                ],
+            ],
+            'chromeOptions as W3C capability should be converted' => [
+                new DesiredCapabilities([
+                    ChromeOptions::CAPABILITY_W3C => $chromeOptions,
                 ]),
                 [
                     'goog:chromeOptions' => new \ArrayObject(


### PR DESCRIPTION
By making the ChromeOptions and FirefoxProfile implement
JsonSerializable, both the ChromeOptions::CAPABILITY and
ChromeOptions::CAPABILITY_W3C will be serializable when converting to
JSON for the Desired Capabilities.

This also solves an issue whereby it is not possible to specify
CAPABILITY_W3C as the capability key.

Fixes #849