### PR TITLE
Pass W3C capabilitites when starting chromedriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for sending Chrome DevTools Protocol commands (see details in [wiki](https://github.com/php-webdriver/php-webdriver/wiki/Chrome#chrome-devtools-protocol-cdp)).
 
+### Fixed
+- Actually start ChromeDriver in W3C mode if it is supported by the browser driver. Until now, when it was initialized using `ChromeDriver::start()`, it has always been unintentionally started in OSS mode.
+
 ### Changed
 - Throw `DriverServerDiedException` on local driver process terminating unexpectedly and provide full details of original exception to improve debugging.
 - Do not require `WEBDRIVER_CHROME_DRIVER` environment variable to be set if `chromedriver` binary is already available via system PATH.

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -38,6 +38,9 @@ class ChromeDriver extends RemoteWebDriver
             null,
             DriverCommand::NEW_SESSION,
             [
+                'capabilities' => [
+                    'firstMatch' => [(object) $desired_capabilities->toW3cCompatibleArray()],
+                ],
                 'desiredCapabilities' => (object) $desired_capabilities->toArray(),
             ]
         );


### PR DESCRIPTION
While looking into #849 and #852, I discovered we are not passing capabilities in W3C format when staring browser via `ChromeDriver::start()`, as we do [in RemoteWebDriver::create()](https://github.com/php-webdriver/php-webdriver/blob/main/lib/Remote/RemoteWebDriver.php#L108-L113). With this PR, capabilities as submitted in both formats.

Because chromedriver accepts capabilities in new session command in both formats, **there will be no effective change** in behavior right now. But should Chromedriver team decide to remove JsonWire protocol support, creating new browser session will not work without this change. By this change, we are adding **forward compatibility**.