### PR TITLE
Work around a bug in Geckodriver (653)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,7 @@ script:
   - if [ "$BROWSER_NAME" = "MicrosoftEdge" ]; then EXCLUDE_GROUP+="exclude-edge,"; fi
   - if [ "$BROWSER_NAME" = "firefox" ]; then EXCLUDE_GROUP+="exclude-firefox,"; fi
   - if [ "$BROWSER_NAME" = "chrome" ]; then EXCLUDE_GROUP+="exclude-chrome,"; fi
+  - if [ "$BROWSER_NAME" = "htmlunit" ]; then EXCLUDE_GROUP+="exclude-htmlunit,"; fi
   - if [ -n "$EXCLUDE_GROUP" ]; then EXTRA_PARAMS+=" --exclude-group $EXCLUDE_GROUP"; fi
   - ./vendor/bin/phpunit --coverage-clover ./logs/coverage-clover.xml $EXTRA_PARAMS
 

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -126,7 +126,7 @@ class WebDriverTestCase extends TestCase
     /**
      * Mark a test as skipped if the current browser is not in the list of browsers.
      *
-     * @param array $browsers List of browsers for this test
+     * @param string[] $browsers List of browsers for this test
      * @param string|null $message
      */
     public static function skipForUnmatchedBrowsers($browsers = [], $message = null)

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -36,7 +36,7 @@ class WebDriverTestCase extends TestCase
         if (static::isSauceLabsBuild()) {
             $this->setUpSauceLabs();
         } else {
-            $browserName = (string) getenv('BROWSER_NAME');
+            $browserName = getenv('BROWSER_NAME');
             if ($browserName === '') {
                 $this->markTestSkipped(
                     'To execute functional tests browser name must be provided in BROWSER_NAME environment variable'
@@ -119,6 +119,25 @@ class WebDriverTestCase extends TestCase
     {
         if (getenv('GECKODRIVER') !== '1'
             && (getenv('BROWSER_NAME') !== 'chrome' || getenv('DISABLE_W3C_PROTOCOL') === '1')) {
+            static::markTestSkipped($message);
+        }
+    }
+
+    /**
+     * Mark a test as skipped if the current browser is not in the list of browsers.
+     *
+     * @param array $browsers List of browsers for this test
+     * @param string|null $message
+     */
+    public static function skipForUnmatchedBrowsers($browsers = [], $message = null)
+    {
+        $browserName = (string) getenv('BROWSER_NAME');
+        if (array_search($browserName, $browsers) === false) {
+            if (!$message) {
+                $browserlist = implode(', ', $browsers);
+                $message = 'Browser ' . $browserName . ' not supported for this test (' . $browserlist . ')';
+            }
+
             static::markTestSkipped($message);
         }
     }

--- a/tests/functional/web/gecko653.html
+++ b/tests/functional/web/gecko653.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test page for geckodriver#653 workaround</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <style>
+        .hidden {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <a href="index.html" id="a-index-plain">Link text</a>
+
+    <a href="index.html" id="a-index-plain-hidden" class="hidden">Link text</a>
+
+    <a href="index.html" id="a-index-block-child">
+        <div>Link in a block element</div>
+    </a>
+
+    <a href="index.html" id="a-index-hidden-block-child" class="hidden">
+        <div>Link in a block element</div>
+    </a>
+
+    <a href="index.html" id="a-index-block-child-hidden">
+        <div class="hidden">Hidden link</div>
+        <div>Link in a block element</div>
+    </a>
+
+    <a href="index.html" id="a-index-second-child-hidden">
+        Link text
+        <div class="hidden">A description in a block-level element</div>
+    </a>
+</body>
+</html>


### PR DESCRIPTION
Hi @OndraM ,

This is a bit of a weird one, and I have fixed it in the Mink driver, but I feel that others may also benefit from it too.
I can't think of a better way to address this reliably.

This issue works around a long-standing bug in Geckodriver whereby if
the first child of an anchor is a block-level element, that element
covers the click-point of the anchor. This causes an
ElementNotInteractable exception to be thrown as Marionette believes
that it cannot be scrolled into view.

The workaround to this issue is to attempt to click on an immediate
child node instead. Usually the first child will be sufficient, but if
that first child is a hidden element, then a sibling should instead be
used.

This issue has existed for several years and there is no timeframe for
fixing it upstream.

The upstream issue is https://github.com/mozilla/geckodriver/issues/653 and the gecko issue is https://bugzilla.mozilla.org/show_bug.cgi?id=1374283. I have considered fixing this upstream but it's a crazy complicated problem to solve, I don't currently have time to dedicate to it, and @whimboo is keen to fix this in the spec before fixing it in geckodriver/marionette.