### PR TITLE
Remove Firefox 47 saucelabs build

### DIFF
--- a/.github/workflows/sauce-labs.yaml
+++ b/.github/workflows/sauce-labs.yaml
@@ -16,12 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#         # Firefox 47 is the last Firefox with OSS protocol support
-          - { name: "Firefox 47, OSS protocol", BROWSER_NAME: "firefox", VERSION: "47.0", PLATFORM: "Windows 10", DISABLE_W3C_PROTOCOL: "1", tunnel-id: "gh-1" }
           # Chrome 74 is the last version which doesn't use W3C WebDriver by default and rather use OSS protocol
-          - { name: "Chrome 74, OSS protocol", BROWSER_NAME: "chrome", VERSION: "74.0", PLATFORM: "Windows 10", DISABLE_W3C_PROTOCOL: "1", tunnel-id: "gh-2" }
-          - { name: "Chrome latest, W3C protocol", BROWSER_NAME: "chrome", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-3" }
-          - { name: "Edge latest, W3C protocol", BROWSER_NAME: "MicrosoftEdge", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-4" }
+          - { name: "Chrome 74, OSS protocol", BROWSER_NAME: "chrome", VERSION: "74.0", PLATFORM: "Windows 10", DISABLE_W3C_PROTOCOL: "1", tunnel-id: "gh-1" }
+          - { name: "Chrome latest, W3C protocol", BROWSER_NAME: "chrome", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-2" }
+          - { name: "Edge latest, W3C protocol", BROWSER_NAME: "MicrosoftEdge", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-3" }
 
     name: ${{ matrix.name }} (${{ matrix.tunnel-id }})
     steps:

--- a/.github/workflows/sauce-labs.yaml
+++ b/.github/workflows/sauce-labs.yaml
@@ -15,9 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        w3c: [true]
         include:
           # Chrome 74 is the last version which doesn't use W3C WebDriver by default and rather use OSS protocol
-          - { name: "Chrome 74, OSS protocol", BROWSER_NAME: "chrome", VERSION: "74.0", PLATFORM: "Windows 10", DISABLE_W3C_PROTOCOL: "1", tunnel-id: "gh-1" }
+          - { name: "Chrome 74, OSS protocol", BROWSER_NAME: "chrome", VERSION: "74.0", PLATFORM: "Windows 10", w3c: false, tunnel-id: "gh-1" }
           - { name: "Chrome latest, W3C protocol", BROWSER_NAME: "chrome", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-2" }
           - { name: "Edge latest, W3C protocol", BROWSER_NAME: "MicrosoftEdge", VERSION: "latest", PLATFORM: "Windows 10", tunnel-id: "gh-3" }
 
@@ -30,6 +31,7 @@ jobs:
         with:
           php-version: '7.4'
           extensions: mbstring, intl, zip
+          coverage: none
 
       - name: Install PHP dependencies
         run: composer update --no-interaction
@@ -50,7 +52,7 @@ jobs:
           BROWSER_NAME: ${{ matrix.BROWSER_NAME }}
           VERSION: ${{ matrix.VERSION }}
           PLATFORM: ${{ matrix.PLATFORM }}
-          DISABLE_W3C_PROTOCOL: ${{ matrix.DISABLE_W3C_PROTOCOL }}
+          DISABLE_W3C_PROTOCOL: "${{ matrix.w3c && '0' || '1' }}"
           SAUCE_TUNNEL_IDENTIFIER: ${{ matrix.tunnel-id }}
         run: |
           if [ -n "$SAUCELABS" ]; then EXCLUDE_GROUP+="exclude-saucelabs,"; fi
@@ -58,7 +60,7 @@ jobs:
           if [ "$BROWSER_NAME" = "firefox" ]; then EXCLUDE_GROUP+="exclude-firefox,"; fi
           if [ "$BROWSER_NAME" = "chrome" ]; then EXCLUDE_GROUP+="exclude-chrome,"; fi
           if [ -n "$EXCLUDE_GROUP" ]; then EXTRA_PARAMS+=" --exclude-group $EXCLUDE_GROUP"; fi
-          ./vendor/bin/phpunit --testsuite functional --coverage-clover ./logs/coverage-clover.xml $EXTRA_PARAMS
+          ./vendor/bin/phpunit --testsuite functional $EXTRA_PARAMS
 
       - name: Print logs
         if: ${{ always() }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,6 @@ jobs:
           extensions: mbstring, intl, zip
           coverage: xdebug
           ini-values: ${{ matrix.xdebug-ini-values }}
-          tools: composer:v2
 
       - name: Install PHP dependencies
         run: composer update --no-interaction ${{ matrix.dependencies }}
@@ -83,12 +82,12 @@ jobs:
           ~/.composer/vendor/bin/php-coveralls -v
 
   functional-tests:
-
     runs-on: ubuntu-latest
     env:
       SELENIUM_SERVER_DOWNLOAD_URL: http://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar
 
     strategy:
+      fail-fast: false
       matrix:
         browser: ['chrome', 'firefox']
         selenium-server: [true, false] # Whether to run via Selenium server or directly via browser driver
@@ -108,7 +107,6 @@ jobs:
           php-version: 7.4
           extensions: mbstring, intl, zip
           coverage: xdebug
-          tools: composer:v2
 
       - name: Install PHP dependencies
         run: composer update --no-interaction


### PR DESCRIPTION
Exclusions and conditions in tests for the old FF were already removed in #863 , so now the old-FF tests on saucelabs are failing.