### PR TITLE
forcing chrome force-color-profile=srgb

### DIFF
--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -437,6 +437,12 @@ class RemoteWebElementTest extends WebDriverTestCase
         $this->assertEquals(5, imagesx($imageFromString));
         $this->assertEquals(5, imagesy($imageFromString));
 
+        // Validate element is actually red
+        $this->assertSame(
+            ['red' => 255, 'green' => 0, 'blue' => 0, 'alpha' => 0],
+            imagecolorsforindex($imageFromString, imagecolorat($imageFromString, 0, 0))
+        );
+
         unlink($screenshotPath);
         rmdir(dirname($screenshotPath));
     }

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -50,7 +50,7 @@ class WebDriverTestCase extends TestCase
                     '--headless',
                     '--window-size=1024,768',
                     '--no-sandbox',
-                    '--force-color-profile=srgb'
+                    '--force-color-profile=srgb',
                 ]);
 
                 if (!static::isW3cProtocolBuild()) {

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -46,7 +46,12 @@ class WebDriverTestCase extends TestCase
             if ($browserName === WebDriverBrowserType::CHROME) {
                 $chromeOptions = new ChromeOptions();
                 // --no-sandbox is a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
-                $chromeOptions->addArguments(['--headless', 'window-size=1024,768', '--no-sandbox']);
+                $chromeOptions->addArguments([
+                    '--headless',
+                    '--window-size=1024,768',
+                    '--no-sandbox',
+                    '--force-color-profile=srgb'
+                ]);
 
                 if (!static::isW3cProtocolBuild()) {
                     $chromeOptions->setExperimentalOption('w3c', false);


### PR DESCRIPTION
Chrome may use different color profile as a result screenshot may have inaccurate colours. (at least on MacOS).
Color should be rgb(255, 0, 0)

![image](https://user-images.githubusercontent.com/1244112/111077866-6fa9f880-84fb-11eb-9a00-3c4e4949171f.png)
