### PR TITLE
Implement FirefoxOption class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Add `FirefoxOptions` class to simplify passing Firefox capabilities. Usage is covered [in our wiki](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefoxoptions).
 
 ## 1.10.0 - 2021-02-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Desired capabilities define properties of the browser you are about to start.
 They can be customized:
 
 ```php
+use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 
 $desiredCapabilities = DesiredCapabilities::firefox();
@@ -141,15 +142,18 @@ $desiredCapabilities = DesiredCapabilities::firefox();
 // Disable accepting SSL certificates
 $desiredCapabilities->setCapability('acceptSslCerts', false);
 
-// Run headless firefox
-$desiredCapabilities->setCapability('moz:firefoxOptions', ['args' => ['-headless']]);
+// Add arguments via FirefoxOptions to start headless firefox
+$firefoxOptions = new FirefoxOptions();
+$firefoxOptions->addArguments(['-headless']);
+$desiredCapabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);
 
 $driver = RemoteWebDriver::create($serverUrl, $desiredCapabilities);
 ```
 
 Capabilities can also be used to [📙 configure a proxy server](https://github.com/php-webdriver/php-webdriver/wiki/HowTo-Work-with-proxy) which the browser should use.
+
 To configure browser-specific capabilities, you may use [📙 ChromeOptions](https://github.com/php-webdriver/php-webdriver/wiki/Chrome#chromeoptions)
-or [📙 FirefoxOptions](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefox-options).
+or [📙 FirefoxOptions](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefoxoptions).
 
 * See [legacy JsonWire protocol](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities) documentation or [W3C WebDriver specification](https://w3c.github.io/webdriver/#capabilities) for more details.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ chromedriver --port=4444
 
 #### b) Geckodriver
 
+📙 Below you will find a simple example. Make sure to read our wiki for [more information on Firefox/Geckodriver](https://github.com/php-webdriver/php-webdriver/wiki/Firefox).
+
 Install the latest Firefox and [Geckodriver](https://github.com/mozilla/geckodriver/releases).
 Make sure to have a compatible version of Geckodriver and Firefox!
 
@@ -146,7 +148,8 @@ $driver = RemoteWebDriver::create($serverUrl, $desiredCapabilities);
 ```
 
 Capabilities can also be used to [📙 configure a proxy server](https://github.com/php-webdriver/php-webdriver/wiki/HowTo-Work-with-proxy) which the browser should use.
-To configure Chrome capabilities, you may use [📙 ChromeOptions](https://github.com/php-webdriver/php-webdriver/wiki/Chrome#chromeoptions).
+To configure browser-specific capabilities, you may use [📙 ChromeOptions](https://github.com/php-webdriver/php-webdriver/wiki/Chrome#chromeoptions)
+or [📙 FirefoxOptions](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefox-options).
 
 * See [legacy JsonWire protocol](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities) documentation or [W3C WebDriver specification](https://w3c.github.io/webdriver/#capabilities) for more details.
 

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -13,12 +13,12 @@ use JsonSerializable;
 class ChromeOptions implements JsonSerializable
 {
     /**
-     * The key of chrome options desired capabilities (in legacy OSS JsonWire protocol)
+     * The key of chromeOptions in desired capabilities (in legacy OSS JsonWire protocol)
      * @todo Replace value with 'goog:chromeOptions' after JsonWire protocol support is removed
      */
     const CAPABILITY = 'chromeOptions';
     /**
-     * The key of chrome options desired capabilities (in W3C compatible protocol)
+     * The key of chromeOptions in desired capabilities (in W3C compatible protocol)
      */
     const CAPABILITY_W3C = 'goog:chromeOptions';
     /**

--- a/lib/Firefox/FirefoxDriver.php
+++ b/lib/Firefox/FirefoxDriver.php
@@ -3,6 +3,7 @@
 namespace Facebook\WebDriver\Firefox;
 
 /**
+ * @todo Implement service to start local geckodriver
  * @codeCoverageIgnore
  */
 class FirefoxDriver

--- a/lib/Firefox/FirefoxOptions.php
+++ b/lib/Firefox/FirefoxOptions.php
@@ -3,17 +3,106 @@
 namespace Facebook\WebDriver\Firefox;
 
 /**
+ * Class to manage Firefox-specific capabilities
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions
- * @codeCoverageIgnore
  */
-class FirefoxOptions
+class FirefoxOptions implements \JsonSerializable
 {
-    /**
-     * The key of FirefoxOptions in desired capabilities
-     */
+    /** @var string The key of FirefoxOptions in desired capabilities */
     const CAPABILITY = 'moz:firefoxOptions';
+    /** @var string */
+    const OPTION_ARGS = 'args';
+    /** @var string */
+    const OPTION_PREFS = 'prefs';
 
-    private function __construct()
+    /** @var array */
+    private $options = [];
+    /** @var array */
+    private $arguments = [];
+    /** @var array */
+    private $preferences = [];
+
+    public function __construct()
     {
+        // Set default preferences:
+        // disable the "Reader View" help tooltip, which can hide elements in the window.document
+        $this->setPreference(FirefoxPreferences::READER_PARSE_ON_LOAD_ENABLED, false);
+        // disable JSON viewer and let JSON be rendered as raw data
+        $this->setPreference(FirefoxPreferences::DEVTOOLS_JSONVIEW, false);
+    }
+
+    /**
+     * Directly set firefoxOptions.
+     * Use `addArguments` to add command line arguments and `setPreference` to set Firefox about:config entry.
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return self
+     */
+    public function setOption($name, $value)
+    {
+        if ($name === self::OPTION_PREFS) {
+            throw new \InvalidArgumentException('Use setPreference() method to set Firefox preferences');
+        }
+        if ($name === self::OPTION_ARGS) {
+            throw new \InvalidArgumentException('Use addArguments() method to add Firefox arguments');
+        }
+
+        $this->options[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Command line arguments to pass to the Firefox binary.
+     * These must include the leading dash (-) where required, e.g. ['-headless'].
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions#args
+     * @param string[] $arguments
+     * @return self
+     */
+    public function addArguments(array $arguments)
+    {
+        $this->arguments = array_merge($this->arguments, $arguments);
+
+        return $this;
+    }
+
+    /**
+     * Set Firefox preference (about:config entry).
+     *
+     * @see http://kb.mozillazine.org/About:config_entries
+     * @see https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions#prefs
+     * @param string $name
+     * @param string|bool|int $value
+     * @return self
+     */
+    public function setPreference($name, $value)
+    {
+        $this->preferences[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = $this->options;
+        if (!empty($this->arguments)) {
+            $array[self::OPTION_ARGS] = $this->arguments;
+        }
+        if (!empty($this->preferences)) {
+            $array[self::OPTION_PREFS] = $this->preferences;
+        }
+
+        return $array;
+    }
+
+    public function jsonSerialize()
+    {
+        return new \ArrayObject($this->toArray());
     }
 }

--- a/lib/Firefox/FirefoxOptions.php
+++ b/lib/Firefox/FirefoxOptions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions
+ * @codeCoverageIgnore
+ */
+class FirefoxOptions
+{
+    /**
+     * The key of FirefoxOptions in desired capabilities
+     */
+    const CAPABILITY = 'moz:firefoxOptions';
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -5,6 +5,7 @@ namespace Facebook\WebDriver;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Exception\NoSuchWindowException;
 use Facebook\WebDriver\Exception\WebDriverException;
+use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\WebDriverBrowserType;
@@ -62,10 +63,10 @@ class WebDriverTestCase extends TestCase
                 if (getenv('GECKODRIVER') === '1') {
                     $this->serverUrl = 'http://localhost:4444';
                 }
-                $this->desiredCapabilities->setCapability(
-                    'moz:firefoxOptions',
-                    ['args' => ['-headless']]
-                );
+
+                $firefoxOptions = new FirefoxOptions();
+                $firefoxOptions->addArguments(['-headless']);
+                $this->desiredCapabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);
             }
 
             $this->desiredCapabilities->setBrowserName($browserName);

--- a/tests/unit/Firefox/FirefoxOptionsTest.php
+++ b/tests/unit/Firefox/FirefoxOptionsTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+use PHPUnit\Framework\TestCase;
+
+class FirefoxOptionsTest extends TestCase
+{
+    /** @var [] */
+    const EXPECTED_DEFAULT_PREFS = [
+        FirefoxPreferences::READER_PARSE_ON_LOAD_ENABLED => false,
+        FirefoxPreferences::DEVTOOLS_JSONVIEW => false,
+    ];
+
+    public function testShouldBeConstructedWithDefaultOptions()
+    {
+        $options = new FirefoxOptions();
+
+        $this->assertSame(
+            [
+                'prefs' => self::EXPECTED_DEFAULT_PREFS,
+            ],
+            $options->toArray()
+        );
+    }
+
+    public function testShouldAddCustomOptions()
+    {
+        $options = new FirefoxOptions();
+
+        $options->setOption('binary', '/usr/local/firefox/bin/firefox');
+
+        $this->assertSame(
+            [
+                'binary' => '/usr/local/firefox/bin/firefox',
+                'prefs' => self::EXPECTED_DEFAULT_PREFS,
+            ],
+            $options->toArray()
+        );
+    }
+
+    public function testShouldOverwriteDefaultOptionsWhenSpecified()
+    {
+        $options = new FirefoxOptions();
+
+        $options->setPreference(FirefoxPreferences::READER_PARSE_ON_LOAD_ENABLED, true);
+
+        $this->assertSame(
+            [
+                'prefs' => [
+                    FirefoxPreferences::READER_PARSE_ON_LOAD_ENABLED => true,
+                    FirefoxPreferences::DEVTOOLS_JSONVIEW => false,
+                ],
+            ],
+            $options->toArray()
+        );
+    }
+
+    public function testShouldSetCustomPreference()
+    {
+        $options = new FirefoxOptions();
+
+        $options->setPreference('browser.startup.homepage', 'https://github.com/php-webdriver/php-webdriver/');
+
+        $this->assertSame(
+            [
+                'prefs' => [
+                    FirefoxPreferences::READER_PARSE_ON_LOAD_ENABLED => false,
+                    FirefoxPreferences::DEVTOOLS_JSONVIEW => false,
+                    'browser.startup.homepage' => 'https://github.com/php-webdriver/php-webdriver/',
+                ],
+            ],
+            $options->toArray()
+        );
+    }
+
+    public function testShouldAddArguments()
+    {
+        $options = new FirefoxOptions();
+
+        $options->addArguments(['-headless', '-profile', '/path/to/profile']);
+
+        $this->assertSame(
+            [
+                'args' => ['-headless', '-profile', '/path/to/profile'],
+                'prefs' => self::EXPECTED_DEFAULT_PREFS,
+            ],
+            $options->toArray()
+        );
+    }
+
+    public function testShouldJsonSerializeToArrayObject()
+    {
+        $options = new FirefoxOptions();
+        $options->setOption('binary', '/usr/local/firefox/bin/firefox');
+
+        $jsonSerialized = $options->jsonSerialize();
+
+        $this->assertInstanceOf(\ArrayObject::class, $jsonSerialized);
+        $this->assertSame('/usr/local/firefox/bin/firefox', $jsonSerialized['binary']);
+    }
+
+    public function testShouldNotAllowToSetArgumentsOptionDirectly()
+    {
+        $options = new FirefoxOptions();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Use addArguments() method to add Firefox arguments');
+        $options->setOption('args', []);
+    }
+
+    public function testShouldNotAllowToSetPreferencesOptionDirectly()
+    {
+        $options = new FirefoxOptions();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Use setPreference() method to set Firefox preferences');
+        $options->setOption('prefs', []);
+    }
+}


### PR DESCRIPTION
This adds `FirefoxOptions`, which - similarly to [ChromeOptions](https://github.com/php-webdriver/php-webdriver/wiki/Chrome#chromeoptions) - provides language-level data object to construct value of `moz:firefoxOptions`. Until now, this was possible only using multidiemensional arrays.

One nice feature is the possibility to directly pass `about:config` preferences to this object.

This also changes the way how default preferences (which we add to Firefox) are passed to the Capabilities. It is no longer via configured FirefoxProfile, but rather directly using `prefs` key in firefoxOptions, which is the recommended way. (Because of this, there is a BC layer in DesiredCapabilities, otherwise default options will be overwritten for those who already use `moz:firefoxOptions`).

📙 As part of this, I created [Firefox](https://github.com/php-webdriver/php-webdriver/wiki/Firefox) wiki page, which covers all of this and more. Suggestions welcome!

### Example usage
```php
// Configure FirefoxOptions
$firefoxOptions = (new FirefoxOptions())
    ->addArguments(['-headless']); // add Firefox CLI arguments
    ->setPreference('dom.ipc.processCount', 4); // set about:config preference
    ->setOption('binary', '/home/user/Downloads/firefox-esr'); // use this to set directly other firefoxOptions, see https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions

// Add it to DesiredCapabilities
$capabilities = DesiredCapabilities::firefox();
$capabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);

// Start the browser
$driver = RemoteWebDriver::create($serverUrl, $capabilities);
```

### Previously it was only possible using array
```php
$capabilities = DesiredCapabilities::firefox();
// Configure moz:firefoxOptions using array
$capabilities->setCapability(
    'moz:firefoxOptions',
    [
        'args' => ['-headless'],
        'prefs' => ['dom.ipc.processCount' => 4],
        'binary' => '/home/user/Downloads/firefox-esr',
    ]
);

// Start the browser
$driver = RemoteWebDriver::create($serverUrl, $capabilities);
```