### PR TITLE
Implement FirefoxDriver

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -151,8 +151,9 @@ jobs:
           BROWSER_NAME: ${{ matrix.browser }}
           # When running directly against Firefox, we test only using geckodriver (not against legacy Firefox =<45), so we must declare GECKODRIVER=1
           GECKODRIVER: "${{ (matrix.browser == 'firefox' && !matrix.selenium-server) && '1' || '0' }}"
-          # We must provide CHROMEDRIVER_PATH so that ChromeDriverTest is able to start Chromedriver itself
+          # Provide CHROMEDRIVER_PATH and GECKODRIVER_PATH so that tests for local web drivers are able to start the browser
           CHROMEDRIVER_PATH: "${{ (matrix.browser == 'chrome' && !matrix.selenium-server) && '/usr/local/share/chrome_driver/chromedriver' || '' }}"
+          GECKODRIVER_PATH: "${{ (matrix.browser == 'firefox' && !matrix.selenium-server) && '/usr/local/share/gecko_driver/geckodriver' || '' }}"
           DISABLE_W3C_PROTOCOL: "${{ matrix.w3c && '0' || '1' }}"
         run: |
           if [ "$BROWSER_NAME" = "chrome" ]; then EXCLUDE_GROUP+="exclude-chrome,"; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- Add `FirefoxOptions` class to simplify passing Firefox capabilities. Usage is covered [in our wiki](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefoxoptions).
+- Add `FirefoxOptions` class to simplify passing Firefox capabilities. Usage is covered [in our wiki](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefoxoptions).`
+- Add `FirefoxDriver` to easy local start of Firefox instance without a need to start the `geckodriver` process manually.
 
 ## 1.10.0 - 2021-02-25
 ### Added

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -2,14 +2,13 @@
 
 namespace Facebook\WebDriver\Chrome;
 
-use Facebook\WebDriver\Exception\WebDriverException;
+use Facebook\WebDriver\Local\LocalWebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
 use Facebook\WebDriver\Remote\WebDriverCommand;
 
-class ChromeDriver extends RemoteWebDriver
+class ChromeDriver extends LocalWebDriver
 {
     /** @var ChromeDevToolsDriver */
     private $devTools;
@@ -32,6 +31,10 @@ class ChromeDriver extends RemoteWebDriver
         return $driver;
     }
 
+    /**
+     * @todo Make the class protected
+     * @internal
+     */
     public function startSession(DesiredCapabilities $desired_capabilities)
     {
         $command = new WebDriverCommand(
@@ -52,50 +55,6 @@ class ChromeDriver extends RemoteWebDriver
         }
 
         $this->sessionID = $response->getSessionID();
-    }
-
-    /**
-     * Always throws an exception. Use ChromeDriver::start() instead.
-     *
-     * @param string $selenium_server_url
-     * @param DesiredCapabilities|array $desired_capabilities
-     * @param int|null $connection_timeout_in_ms
-     * @param int|null $request_timeout_in_ms
-     * @param string|null $http_proxy
-     * @param int|null $http_proxy_port
-     * @param DesiredCapabilities $required_capabilities
-     * @throws WebDriverException
-     * @return RemoteWebDriver
-     */
-    public static function create(
-        $selenium_server_url = 'http://localhost:4444/wd/hub',
-        $desired_capabilities = null,
-        $connection_timeout_in_ms = null,
-        $request_timeout_in_ms = null,
-        $http_proxy = null,
-        $http_proxy_port = null,
-        DesiredCapabilities $required_capabilities = null
-    ) {
-        throw new WebDriverException('Please use ChromeDriver::start() instead.');
-    }
-
-    /**
-     * Always throws an exception. Use ChromeDriver::start() instead.
-     *
-     * @param string $session_id The existing session id
-     * @param string $selenium_server_url The url of the remote Selenium WebDriver server
-     * @param int|null $connection_timeout_in_ms Set timeout for the connect phase to remote Selenium WebDriver server
-     * @param int|null $request_timeout_in_ms Set the maximum time of a request to remote Selenium WebDriver server
-     * @throws WebDriverException
-     * @return RemoteWebDriver|void
-     */
-    public static function createBySessionID(
-        $session_id,
-        $selenium_server_url = 'http://localhost:4444/wd/hub',
-        $connection_timeout_in_ms = null,
-        $request_timeout_in_ms = null
-    ) {
-        throw new WebDriverException('Please use ChromeDriver::start() instead.');
     }
 
     /**

--- a/lib/Chrome/ChromeDriverService.php
+++ b/lib/Chrome/ChromeDriverService.php
@@ -25,7 +25,7 @@ class ChromeDriverService extends DriverService
     public static function createDefaultService()
     {
         $pathToExecutable = getenv(self::CHROME_DRIVER_EXECUTABLE) ?: getenv(self::CHROME_DRIVER_EXE_PROPERTY);
-        if ($pathToExecutable === false) {
+        if ($pathToExecutable === false || $pathToExecutable === '') {
             $pathToExecutable = static::DEFAULT_EXECUTABLE;
         }
 

--- a/lib/Firefox/FirefoxDriver.php
+++ b/lib/Firefox/FirefoxDriver.php
@@ -2,15 +2,63 @@
 
 namespace Facebook\WebDriver\Firefox;
 
-/**
- * @todo Implement service to start local geckodriver
- * @codeCoverageIgnore
- */
-class FirefoxDriver
+use Facebook\WebDriver\Local\LocalWebDriver;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
+use Facebook\WebDriver\Remote\WebDriverCommand;
+
+class FirefoxDriver extends LocalWebDriver
 {
     const PROFILE = 'firefox_profile';
 
-    private function __construct()
+    /**
+     * Creates a new FirefoxDriver using default configuration.
+     * This includes starting a new geckodriver process  each time this method is called. However this may be
+     * unnecessary overhead - instead, you can start the process once using FirefoxDriverService and pass
+     * this instance to startUsingDriverService() method.
+     *
+     * @return static
+     */
+    public static function start(DesiredCapabilities $capabilities = null)
     {
+        $service = FirefoxDriverService::createDefaultService();
+
+        return static::startUsingDriverService($service, $capabilities);
+    }
+
+    /**
+     * Creates a new FirefoxDriver using given FirefoxDriverService.
+     * This is usable when you for example don't want to start new geckodriver process for each individual test
+     * and want to reuse the already started geckodriver, which will lower the overhead associated with spinning up
+     * a new process.
+     *
+     * @return static
+     */
+    public static function startUsingDriverService(
+        FirefoxDriverService $service,
+        DesiredCapabilities $capabilities = null
+    ) {
+        if ($capabilities === null) {
+            $capabilities = DesiredCapabilities::firefox();
+        }
+
+        $executor = new DriverCommandExecutor($service);
+        $newSessionCommand = new WebDriverCommand(
+            null,
+            DriverCommand::NEW_SESSION,
+            [
+                'capabilities' => [
+                    'firstMatch' => [(object) $capabilities->toW3cCompatibleArray()],
+                ],
+            ]
+        );
+
+        $response = $executor->execute($newSessionCommand);
+
+        $returnedCapabilities = DesiredCapabilities::createFromW3cCapabilities($response->getValue()['capabilities']);
+        $sessionId = $response->getSessionID();
+
+        return new static($executor, $sessionId, $returnedCapabilities, true);
     }
 }

--- a/lib/Firefox/FirefoxDriverService.php
+++ b/lib/Firefox/FirefoxDriverService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+use Facebook\WebDriver\Remote\Service\DriverService;
+
+class FirefoxDriverService extends DriverService
+{
+    /**
+     * @var string Name of the environment variable storing the path to the driver binary
+     */
+    const WEBDRIVER_FIREFOX_DRIVER = 'WEBDRIVER_FIREFOX_DRIVER';
+    /**
+     * @var string Default executable used when no other is provided
+     * @internal
+     */
+    const DEFAULT_EXECUTABLE = 'geckodriver';
+
+    /**
+     * @return static
+     */
+    public static function createDefaultService()
+    {
+        $pathToExecutable = getenv(static::WEBDRIVER_FIREFOX_DRIVER);
+        if ($pathToExecutable === false || $pathToExecutable === '') {
+            $pathToExecutable = static::DEFAULT_EXECUTABLE;
+        }
+
+        $port = 9515; // TODO: Get another free port if the default port is used.
+        $args = ['-p=' . $port];
+
+        return new static($pathToExecutable, $port, $args);
+    }
+}

--- a/lib/Local/LocalWebDriver.php
+++ b/lib/Local/LocalWebDriver.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Facebook\WebDriver\Local;
+
+use Facebook\WebDriver\Exception\WebDriverException;
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+
+/**
+ * @todo Break inheritance from RemoteWebDriver in next major version. (Composition over inheritance!)
+ */
+abstract class LocalWebDriver extends RemoteWebDriver
+{
+    /**
+     * @param string $selenium_server_url
+     * @param null $desired_capabilities
+     * @param null $connection_timeout_in_ms
+     * @param null $request_timeout_in_ms
+     * @param null $http_proxy
+     * @param null $http_proxy_port
+     * @param DesiredCapabilities|null $required_capabilities
+     * @throws WebDriverException
+     * @return RemoteWebDriver
+     * @todo Remove in next major version (should not be inherited)
+     */
+    public static function create(
+        $selenium_server_url = 'http://localhost:4444/wd/hub',
+        $desired_capabilities = null,
+        $connection_timeout_in_ms = null,
+        $request_timeout_in_ms = null,
+        $http_proxy = null,
+        $http_proxy_port = null,
+        DesiredCapabilities $required_capabilities = null
+    ) {
+        throw new WebDriverException('Use start() method to start local WebDriver.');
+    }
+
+    /**
+     * @param string $session_id
+     * @param string $selenium_server_url
+     * @param null $connection_timeout_in_ms
+     * @param null $request_timeout_in_ms
+     * @throws WebDriverException
+     * @return RemoteWebDriver
+     * @todo Remove in next major version (should not be inherited)
+     */
+    public static function createBySessionID(
+        $session_id,
+        $selenium_server_url = 'http://localhost:4444/wd/hub',
+        $connection_timeout_in_ms = null,
+        $request_timeout_in_ms = null
+    ) {
+        throw new WebDriverException('Use start() method to start local WebDriver.');
+    }
+}

--- a/lib/Remote/Service/DriverService.php
+++ b/lib/Remote/Service/DriverService.php
@@ -9,6 +9,7 @@ use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Start local WebDriver service (when remote WebDriver server is not used).
+ * This will start new process of respective browser driver and take care of its lifecycle.
  */
 class DriverService
 {

--- a/tests/functional/Chrome/ChromeDriverServiceTest.php
+++ b/tests/functional/Chrome/ChromeDriverServiceTest.php
@@ -19,7 +19,7 @@ class ChromeDriverServiceTest extends TestCase
     {
         if (getenv('BROWSER_NAME') !== 'chrome' || empty(getenv('CHROMEDRIVER_PATH'))
             || WebDriverTestCase::isSauceLabsBuild()) {
-            $this->markTestSkipped('ChromeDriverServiceTest is run only when running against local chrome');
+            $this->markTestSkipped('The test is run only when running against local chrome');
         }
     }
 

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -21,7 +21,7 @@ class ChromeDriverTest extends TestCase
     {
         if (getenv('BROWSER_NAME') !== 'chrome' || empty(getenv('CHROMEDRIVER_PATH'))
             || WebDriverTestCase::isSauceLabsBuild()) {
-            $this->markTestSkipped('ChromeDriverServiceTest is run only when running against local chrome');
+            $this->markTestSkipped('The test is run only when running against local chrome');
         }
     }
 

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @group exclude-saucelabs
  * @covers \Facebook\WebDriver\Chrome\ChromeDriver
+ * @covers \Facebook\WebDriver\Local\LocalWebDriver
  */
 class ChromeDriverTest extends TestCase
 {

--- a/tests/functional/Firefox/FirefoxDriverServiceTest.php
+++ b/tests/functional/Firefox/FirefoxDriverServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+use Facebook\WebDriver\WebDriverTestCase;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group exclude-saucelabs
+ * @covers \Facebook\WebDriver\Firefox\FirefoxDriverService
+ */
+class FirefoxDriverServiceTest extends TestCase
+{
+    /** @var FirefoxDriverService */
+    private $driverService;
+
+    protected function setUp(): void
+    {
+        if (getenv('BROWSER_NAME') !== 'firefox' || empty(getenv('GECKODRIVER_PATH'))
+            || WebDriverTestCase::isSauceLabsBuild()) {
+            $this->markTestSkipped('The test is run only when running against local chrome');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->driverService !== null && $this->driverService->isRunning()) {
+            $this->driverService->stop();
+        }
+    }
+
+    public function testShouldStartAndStopServiceCreatedUsingShortcutConstructor()
+    {
+        // The createDefaultService() method expect path to the executable to be present in the environment variable
+        putenv(FirefoxDriverService::WEBDRIVER_FIREFOX_DRIVER . '=' . getenv('GECKODRIVER_PATH'));
+
+        $this->driverService = FirefoxDriverService::createDefaultService();
+
+        $this->assertSame('http://localhost:9515', $this->driverService->getURL());
+
+        $this->assertInstanceOf(FirefoxDriverService::class, $this->driverService->start());
+        $this->assertTrue($this->driverService->isRunning());
+
+        $this->assertInstanceOf(FirefoxDriverService::class, $this->driverService->start());
+
+        $this->assertInstanceOf(FirefoxDriverService::class, $this->driverService->stop());
+        $this->assertFalse($this->driverService->isRunning());
+
+        $this->assertInstanceOf(FirefoxDriverService::class, $this->driverService->stop());
+    }
+
+    public function testShouldStartAndStopServiceCreatedUsingDefaultConstructor()
+    {
+        $this->driverService = new FirefoxDriverService(getenv('GECKODRIVER_PATH'), 9515, ['-p=9515']);
+
+        $this->assertSame('http://localhost:9515', $this->driverService->getURL());
+
+        $this->driverService->start();
+        $this->assertTrue($this->driverService->isRunning());
+
+        $this->driverService->stop();
+        $this->assertFalse($this->driverService->isRunning());
+    }
+
+    public function testShouldUseDefaultExecutableIfNoneProvided()
+    {
+        // Put path where geckodriver binary is actually located to system PATH, to make sure we can locate it
+        putenv('PATH=' . getenv('PATH') . ':' . dirname(getenv('GECKODRIVER_PATH')));
+
+        // Unset WEBDRIVER_FIREFOX_BINARY so that FirefoxDriverService will attempt to run the binary from system PATH
+        putenv(FirefoxDriverService::WEBDRIVER_FIREFOX_DRIVER . '=');
+
+        $this->driverService = FirefoxDriverService::createDefaultService();
+
+        $this->assertSame('http://localhost:9515', $this->driverService->getURL());
+
+        $this->assertInstanceOf(FirefoxDriverService::class, $this->driverService->start());
+        $this->assertTrue($this->driverService->isRunning());
+    }
+}

--- a/tests/functional/Firefox/FirefoxDriverTest.php
+++ b/tests/functional/Firefox/FirefoxDriverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
+use Facebook\WebDriver\WebDriverTestCase;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group exclude-saucelabs
+ * @covers \Facebook\WebDriver\Firefox\FirefoxDriver
+ * @covers \Facebook\WebDriver\Local\LocalWebDriver
+ */
+class FirefoxDriverTest extends TestCase
+{
+    /** @var FirefoxDriver */
+    protected $driver;
+
+    protected function setUp(): void
+    {
+        if (getenv('BROWSER_NAME') !== 'firefox' || empty(getenv('GECKODRIVER_PATH'))
+            || WebDriverTestCase::isSauceLabsBuild()) {
+            $this->markTestSkipped('The test is run only when running against local chrome');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->driver instanceof RemoteWebDriver && $this->driver->getCommandExecutor() !== null) {
+            $this->driver->quit();
+        }
+    }
+
+    public function testShouldStartFirefoxDriver()
+    {
+        $this->startFirefoxDriver();
+        $this->assertInstanceOf(FirefoxDriver::class, $this->driver);
+        $this->assertInstanceOf(DriverCommandExecutor::class, $this->driver->getCommandExecutor());
+
+        // Make sure actual browser capabilities were set
+        $this->assertNotEmpty($this->driver->getCapabilities()->getVersion());
+        $this->assertNotEmpty($this->driver->getCapabilities()->getCapability('moz:profile'));
+        $this->assertTrue($this->driver->getCapabilities()->getCapability('moz:headless'));
+
+        // Ensure browser is responding to basic command
+        $this->driver->get('http://localhost:8000/');
+        $this->assertSame('http://localhost:8000/', $this->driver->getCurrentURL());
+    }
+
+    private function startFirefoxDriver()
+    {
+        // The createDefaultService() method expect path to the executable to be present in the environment variable
+        putenv(FirefoxDriverService::WEBDRIVER_FIREFOX_DRIVER . '=' . getenv('GECKODRIVER_PATH'));
+
+        $firefoxOptions = new FirefoxOptions();
+        $firefoxOptions->addArguments(['-headless']);
+        $desiredCapabilities = DesiredCapabilities::firefox();
+        $desiredCapabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);
+
+        $this->driver = FirefoxDriver::start($desiredCapabilities);
+    }
+}


### PR DESCRIPTION
This adds FirefoxDriver. Now you are able to start Firefox locally without need to run `geckodriver` binary separately. The usage is [similar to ChromeDriver class](https://github.com/php-webdriver/php-webdriver/wiki/Chrome#start-directly-using-chromedriver-class).

There is also new `LocalWebDriver`, which is used as a base class for local browser drivers implementations (currently ChromeDriver and now FirefoxDriver).

Fixes #891.

#### Basic example:
```php
$driver = FirefoxDriver::start();
$driver->get('https://google.com/');
```

#### Using new FirefoxOptions from #890:
```php
$firefoxOptions = new FirefoxOptions();
$firefoxOptions->addArguments(['-headless']);

$capabilities = new DesiredCapabilities([FirefoxOptions::CAPABILITY => $firefoxOptions]);

$driver = FirefoxDriver::start($capabilities);
$driver->get('https://google.com/');
```

#### TODO
- [x] Update [wiki](https://github.com/php-webdriver/php-webdriver/wiki/Firefox) to include `FirefoxDriver::start`
