### PR TITLE
Fix browser capabilities to be set to driver instance when using ChromeDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,17 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- Add `FirefoxOptions` class to simplify passing Firefox capabilities. Usage is covered [in our wiki](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefoxoptions).`
-- Add `FirefoxDriver` to easy local start of Firefox instance without a need to start the `geckodriver` process manually.
+
+### Added
+- `FirefoxOptions` class to simplify passing Firefox capabilities. Usage is covered [in our wiki](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefoxoptions).`
+- `FirefoxDriver` to easy local start of Firefox instance without a need to start the `geckodriver` process manually.
+- Method `ChromeDriver::startUsingDriverService()` to be used for creating ChromeDriver instance with custom service.
+
+### Fixed
+- Driver capabilities received from the browser when creating now session were not set to the instance of ChromeDriver (when ChromeDriver::start() was used).
+
+### Changed
+- Deprecate `ChromeDriver::startSession`. However the method was supposed to be used only internally.
 
 ## 1.10.0 - 2021-02-25
 ### Added

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -14,25 +14,64 @@ class ChromeDriver extends LocalWebDriver
     private $devTools;
 
     /**
+     * Creates a new ChromeDriver using default configuration.
+     * This includes starting a new chromedriver process each time this method is called. However this may be
+     * unnecessary overhead - instead, you can start the process once using ChromeDriverService and pass
+     * this instance to startUsingDriverService() method.
+     *
+     * @todo Remove $service parameter. Use `ChromeDriver::startUsingDriverService` to pass custom $service instance.
      * @return static
      */
     public static function start(DesiredCapabilities $desired_capabilities = null, ChromeDriverService $service = null)
     {
-        if ($desired_capabilities === null) {
-            $desired_capabilities = DesiredCapabilities::chrome();
-        }
-        if ($service === null) {
+        if ($service === null) { // TODO: Remove the condition (always create default service)
             $service = ChromeDriverService::createDefaultService();
         }
-        $executor = new DriverCommandExecutor($service);
-        $driver = new static($executor, null, $desired_capabilities);
-        $driver->startSession($desired_capabilities);
 
-        return $driver;
+        return static::startUsingDriverService($service, $desired_capabilities);
     }
 
     /**
-     * @todo Make the class protected
+     * Creates a new ChromeDriver using given ChromeDriverService.
+     * This is usable when you for example don't want to start new chromedriver process for each individual test
+     * and want to reuse the already started chromedriver, which will lower the overhead associated with spinning up
+     * a new process.
+
+     * @return static
+     */
+    public static function startUsingDriverService(
+        ChromeDriverService $service,
+        DesiredCapabilities $capabilities = null
+    ) {
+        if ($capabilities === null) {
+            $capabilities = DesiredCapabilities::chrome();
+        }
+
+        $executor = new DriverCommandExecutor($service);
+        $newSessionCommand = new WebDriverCommand(
+            null,
+            DriverCommand::NEW_SESSION,
+            [
+                'capabilities' => [
+                    'firstMatch' => [(object) $capabilities->toW3cCompatibleArray()],
+                ],
+                'desiredCapabilities' => (object) $capabilities->toArray(),
+            ]
+        );
+
+        $response = $executor->execute($newSessionCommand);
+
+        /*
+         * TODO: in next major version we may not need to use this method, because without OSS compatibility the
+         * driver creation is straightforward.
+         */
+        return static::createFromResponse($response, $executor);
+    }
+
+    /**
+     * @todo Remove in next major version. The class is internally no longer used and is kept only to keep BC.
+     * @deprecated Use start or startUsingDriverService method instead.
+     * @codeCoverageIgnore
      * @internal
      */
     public function startSession(DesiredCapabilities $desired_capabilities)

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -133,21 +133,8 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         );
 
         $response = $executor->execute($command);
-        $value = $response->getValue();
 
-        if (!$isW3cCompliant = isset($value['capabilities'])) {
-            $executor->disableW3cCompliance();
-        }
-
-        if ($isW3cCompliant) {
-            $returnedCapabilities = DesiredCapabilities::createFromW3cCapabilities($value['capabilities']);
-        } else {
-            $returnedCapabilities = new DesiredCapabilities($value);
-        }
-
-        $driver = new static($executor, $response->getSessionID(), $returnedCapabilities, $isW3cCompliant);
-
-        return $driver;
+        return static::createFromResponse($response, $executor);
     }
 
     /**
@@ -644,6 +631,30 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     public function isW3cCompliant()
     {
         return $this->isW3cCompliant;
+    }
+
+    /**
+     * Create instance based on response to NEW_SESSION command.
+     * Also detect W3C/OSS dialect and setup the driver/executor accordingly.
+     *
+     * @internal
+     * @return static
+     */
+    protected static function createFromResponse(WebDriverResponse $response, HttpCommandExecutor $commandExecutor)
+    {
+        $responseValue = $response->getValue();
+
+        if (!$isW3cCompliant = isset($responseValue['capabilities'])) {
+            $commandExecutor->disableW3cCompliance();
+        }
+
+        if ($isW3cCompliant) {
+            $returnedCapabilities = DesiredCapabilities::createFromW3cCapabilities($responseValue['capabilities']);
+        } else {
+            $returnedCapabilities = new DesiredCapabilities($responseValue);
+        }
+
+        return new static($commandExecutor, $response->getSessionID(), $returnedCapabilities, $isW3cCompliant);
     }
 
     /**

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -36,9 +36,12 @@ class ChromeDriverTest extends TestCase
     public function testShouldStartChromeDriver()
     {
         $this->startChromeDriver();
-
         $this->assertInstanceOf(ChromeDriver::class, $this->driver);
         $this->assertInstanceOf(DriverCommandExecutor::class, $this->driver->getCommandExecutor());
+
+        // Make sure actual browser capabilities were set
+        $this->assertNotEmpty($this->driver->getCapabilities()->getVersion());
+        $this->assertNotEmpty($this->driver->getCapabilities()->getCapability('goog:chromeOptions'));
 
         $this->driver->get('http://localhost:8000/');
 

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -33,9 +33,13 @@ class ChromeDriverTest extends TestCase
         }
     }
 
-    public function testShouldStartChromeDriver()
+    /**
+     * @dataProvider provideDialect
+     * @param bool $isW3cDialect
+     */
+    public function testShouldStartChromeDriver($isW3cDialect)
     {
-        $this->startChromeDriver();
+        $this->startChromeDriver($isW3cDialect);
         $this->assertInstanceOf(ChromeDriver::class, $this->driver);
         $this->assertInstanceOf(DriverCommandExecutor::class, $this->driver->getCommandExecutor());
 
@@ -46,6 +50,17 @@ class ChromeDriverTest extends TestCase
         $this->driver->get('http://localhost:8000/');
 
         $this->assertSame('http://localhost:8000/', $this->driver->getCurrentURL());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideDialect()
+    {
+        return [
+            'w3c' => [true],
+            'oss' => [false],
+        ];
     }
 
     public function testShouldInstantiateDevTools()
@@ -66,7 +81,7 @@ class ChromeDriverTest extends TestCase
         $this->assertSame(['result' => ['type' => 'string', 'value' => 'http://localhost:8000/']], $cdpResult);
     }
 
-    private function startChromeDriver()
+    private function startChromeDriver($w3cDialect = true)
     {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=' . getenv('CHROMEDRIVER_PATH'));
@@ -74,6 +89,7 @@ class ChromeDriverTest extends TestCase
         // Add --no-sandbox as a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
         $chromeOptions = new ChromeOptions();
         $chromeOptions->addArguments(['--no-sandbox', '--headless']);
+        $chromeOptions->setExperimentalOption('w3c', $w3cDialect);
         $desiredCapabilities = DesiredCapabilities::chrome();
         $desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
 


### PR DESCRIPTION
As part of #892 I noticed capabilities received from the browser are not set to instance of `ChromeDriver`, when the driver is created using `ChromeDriver::start()` and we receive response to the new session command.

Instead, the driver was created with capabilities used to create the browser, which is wrong and also different behavior than is when using `RemoteWebDriver::create()`.

I also added `startUsingDriverService()` static constructor method, to make it consistent with FirefoxDriver.