### PR TITLE
Add aliases for new vendor namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
   },
   "autoload": {
     "psr-4": {
-      "Facebook\\WebDriver\\": "lib/"
+      "Facebook\\WebDriver\\": "lib/",
+      "PhpWebDriver\\": "src/"
     },
     "files": [
       "lib/Exception/TimeoutException.php"

--- a/lib/AbstractWebDriverCheckboxOrRadio.php
+++ b/lib/AbstractWebDriverCheckboxOrRadio.php
@@ -238,3 +238,5 @@ abstract class AbstractWebDriverCheckboxOrRadio implements WebDriverSelectInterf
         }
     }
 }
+
+class_alias('Facebook\WebDriver\AbstractWebDriverCheckboxOrRadio', 'PhpWebDriver\AbstractWebDriverCheckboxOrRadio');

--- a/lib/Chrome/ChromeDevToolsDriver.php
+++ b/lib/Chrome/ChromeDevToolsDriver.php
@@ -44,3 +44,5 @@ class ChromeDevToolsDriver
         );
     }
 }
+
+class_alias('Facebook\WebDriver\Chrome\ChromeDevToolsDriver', 'PhpWebDriver\Chrome\ChromeDevToolsDriver');

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -108,3 +108,5 @@ class ChromeDriver extends LocalWebDriver
         return $this->devTools;
     }
 }
+
+class_alias('Facebook\WebDriver\Chrome\ChromeDriver', 'PhpWebDriver\Chrome\ChromeDriver');

--- a/lib/Chrome/ChromeDriverService.php
+++ b/lib/Chrome/ChromeDriverService.php
@@ -35,3 +35,5 @@ class ChromeDriverService extends DriverService
         return new static($pathToExecutable, $port, $args);
     }
 }
+
+class_alias('Facebook\WebDriver\Chrome\ChromeDriverService', 'PhpWebDriver\Chrome\ChromeDriverService');

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -178,3 +178,5 @@ class ChromeOptions implements JsonSerializable
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\Chrome\ChromeOptions', 'PhpWebDriver\Chrome\ChromeOptions');

--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -255,3 +255,5 @@ class Cookie implements \ArrayAccess
         }
     }
 }
+
+class_alias('Facebook\WebDriver\Cookie', 'PhpWebDriver\Cookie');

--- a/lib/Exception/DriverServerDiedException.php
+++ b/lib/Exception/DriverServerDiedException.php
@@ -13,3 +13,5 @@ class DriverServerDiedException extends WebDriverException
         \Exception::__construct($this->getMessage(), $this->getCode(), $previous);
     }
 }
+
+class_alias('Facebook\WebDriver\Exception\DriverServerDiedException', 'PhpWebDriver\Exception\DriverServerDiedException');

--- a/lib/Exception/ElementClickInterceptedException.php
+++ b/lib/Exception/ElementClickInterceptedException.php
@@ -9,3 +9,5 @@ namespace Facebook\WebDriver\Exception;
 class ElementClickInterceptedException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\ElementClickInterceptedException', 'PhpWebDriver\Exception\ElementClickInterceptedException');

--- a/lib/Exception/ElementNotInteractableException.php
+++ b/lib/Exception/ElementNotInteractableException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class ElementNotInteractableException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\ElementNotInteractableException', 'PhpWebDriver\Exception\ElementNotInteractableException');

--- a/lib/Exception/InsecureCertificateException.php
+++ b/lib/Exception/InsecureCertificateException.php
@@ -9,3 +9,5 @@ namespace Facebook\WebDriver\Exception;
 class InsecureCertificateException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\InsecureCertificateException', 'PhpWebDriver\Exception\InsecureCertificateException');

--- a/lib/Exception/InvalidArgumentException.php
+++ b/lib/Exception/InvalidArgumentException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class InvalidArgumentException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\InvalidArgumentException', 'PhpWebDriver\Exception\InvalidArgumentException');

--- a/lib/Exception/InvalidCookieDomainException.php
+++ b/lib/Exception/InvalidCookieDomainException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class InvalidCookieDomainException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\InvalidCookieDomainException', 'PhpWebDriver\Exception\InvalidCookieDomainException');

--- a/lib/Exception/InvalidElementStateException.php
+++ b/lib/Exception/InvalidElementStateException.php
@@ -9,3 +9,5 @@ namespace Facebook\WebDriver\Exception;
 class InvalidElementStateException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\InvalidElementStateException', 'PhpWebDriver\Exception\InvalidElementStateException');

--- a/lib/Exception/InvalidSelectorException.php
+++ b/lib/Exception/InvalidSelectorException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class InvalidSelectorException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\InvalidSelectorException', 'PhpWebDriver\Exception\InvalidSelectorException');

--- a/lib/Exception/InvalidSessionIdException.php
+++ b/lib/Exception/InvalidSessionIdException.php
@@ -9,3 +9,5 @@ namespace Facebook\WebDriver\Exception;
 class InvalidSessionIdException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\InvalidSessionIdException', 'PhpWebDriver\Exception\InvalidSessionIdException');

--- a/lib/Exception/JavascriptErrorException.php
+++ b/lib/Exception/JavascriptErrorException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class JavascriptErrorException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\JavascriptErrorException', 'PhpWebDriver\Exception\JavascriptErrorException');

--- a/lib/Exception/MoveTargetOutOfBoundsException.php
+++ b/lib/Exception/MoveTargetOutOfBoundsException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class MoveTargetOutOfBoundsException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\MoveTargetOutOfBoundsException', 'PhpWebDriver\Exception\MoveTargetOutOfBoundsException');

--- a/lib/Exception/NoSuchAlertException.php
+++ b/lib/Exception/NoSuchAlertException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class NoSuchAlertException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\NoSuchAlertException', 'PhpWebDriver\Exception\NoSuchAlertException');

--- a/lib/Exception/NoSuchCookieException.php
+++ b/lib/Exception/NoSuchCookieException.php
@@ -9,3 +9,5 @@ namespace Facebook\WebDriver\Exception;
 class NoSuchCookieException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\NoSuchCookieException', 'PhpWebDriver\Exception\NoSuchCookieException');

--- a/lib/Exception/NoSuchElementException.php
+++ b/lib/Exception/NoSuchElementException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class NoSuchElementException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\NoSuchElementException', 'PhpWebDriver\Exception\NoSuchElementException');

--- a/lib/Exception/NoSuchFrameException.php
+++ b/lib/Exception/NoSuchFrameException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class NoSuchFrameException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\NoSuchFrameException', 'PhpWebDriver\Exception\NoSuchFrameException');

--- a/lib/Exception/NoSuchWindowException.php
+++ b/lib/Exception/NoSuchWindowException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class NoSuchWindowException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\NoSuchWindowException', 'PhpWebDriver\Exception\NoSuchWindowException');

--- a/lib/Exception/ScriptTimeoutException.php
+++ b/lib/Exception/ScriptTimeoutException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class ScriptTimeoutException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\ScriptTimeoutException', 'PhpWebDriver\Exception\ScriptTimeoutException');

--- a/lib/Exception/SessionNotCreatedException.php
+++ b/lib/Exception/SessionNotCreatedException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class SessionNotCreatedException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\SessionNotCreatedException', 'PhpWebDriver\Exception\SessionNotCreatedException');

--- a/lib/Exception/StaleElementReferenceException.php
+++ b/lib/Exception/StaleElementReferenceException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class StaleElementReferenceException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\StaleElementReferenceException', 'PhpWebDriver\Exception\StaleElementReferenceException');

--- a/lib/Exception/TimeoutException.php
+++ b/lib/Exception/TimeoutException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class TimeoutException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\TimeoutException', 'PhpWebDriver\Exception\TimeoutException');

--- a/lib/Exception/UnableToCaptureScreenException.php
+++ b/lib/Exception/UnableToCaptureScreenException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class UnableToCaptureScreenException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnableToCaptureScreenException', 'PhpWebDriver\Exception\UnableToCaptureScreenException');

--- a/lib/Exception/UnableToSetCookieException.php
+++ b/lib/Exception/UnableToSetCookieException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class UnableToSetCookieException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnableToSetCookieException', 'PhpWebDriver\Exception\UnableToSetCookieException');

--- a/lib/Exception/UnexpectedAlertOpenException.php
+++ b/lib/Exception/UnexpectedAlertOpenException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class UnexpectedAlertOpenException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnexpectedAlertOpenException', 'PhpWebDriver\Exception\UnexpectedAlertOpenException');

--- a/lib/Exception/UnexpectedTagNameException.php
+++ b/lib/Exception/UnexpectedTagNameException.php
@@ -21,3 +21,5 @@ class UnexpectedTagNameException extends WebDriverException
         );
     }
 }
+
+class_alias('Facebook\WebDriver\Exception\UnexpectedTagNameException', 'PhpWebDriver\Exception\UnexpectedTagNameException');

--- a/lib/Exception/UnknownCommandException.php
+++ b/lib/Exception/UnknownCommandException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class UnknownCommandException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnknownCommandException', 'PhpWebDriver\Exception\UnknownCommandException');

--- a/lib/Exception/UnknownErrorException.php
+++ b/lib/Exception/UnknownErrorException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class UnknownErrorException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnknownErrorException', 'PhpWebDriver\Exception\UnknownErrorException');

--- a/lib/Exception/UnknownMethodException.php
+++ b/lib/Exception/UnknownMethodException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class UnknownMethodException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnknownMethodException', 'PhpWebDriver\Exception\UnknownMethodException');

--- a/lib/Exception/UnrecognizedExceptionException.php
+++ b/lib/Exception/UnrecognizedExceptionException.php
@@ -5,3 +5,5 @@ namespace Facebook\WebDriver\Exception;
 class UnrecognizedExceptionException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnrecognizedExceptionException', 'PhpWebDriver\Exception\UnrecognizedExceptionException');

--- a/lib/Exception/UnsupportedOperationException.php
+++ b/lib/Exception/UnsupportedOperationException.php
@@ -8,3 +8,5 @@ namespace Facebook\WebDriver\Exception;
 class UnsupportedOperationException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\UnsupportedOperationException', 'PhpWebDriver\Exception\UnsupportedOperationException');

--- a/lib/Exception/WebDriverCurlException.php
+++ b/lib/Exception/WebDriverCurlException.php
@@ -5,3 +5,5 @@ namespace Facebook\WebDriver\Exception;
 class WebDriverCurlException extends WebDriverException
 {
 }
+
+class_alias('Facebook\WebDriver\Exception\WebDriverCurlException', 'PhpWebDriver\Exception\WebDriverCurlException');

--- a/lib/Exception/WebDriverException.php
+++ b/lib/Exception/WebDriverException.php
@@ -220,3 +220,5 @@ class WebDriverException extends Exception
         }
     }
 }
+
+class_alias('Facebook\WebDriver\Exception\WebDriverException', 'PhpWebDriver\Exception\WebDriverException');

--- a/lib/Firefox/FirefoxDriver.php
+++ b/lib/Firefox/FirefoxDriver.php
@@ -62,3 +62,5 @@ class FirefoxDriver extends LocalWebDriver
         return new static($executor, $sessionId, $returnedCapabilities, true);
     }
 }
+
+class_alias('Facebook\WebDriver\Firefox\FirefoxDriver', 'PhpWebDriver\Firefox\FirefoxDriver');

--- a/lib/Firefox/FirefoxDriverService.php
+++ b/lib/Firefox/FirefoxDriverService.php
@@ -32,3 +32,5 @@ class FirefoxDriverService extends DriverService
         return new static($pathToExecutable, $port, $args);
     }
 }
+
+class_alias('Facebook\WebDriver\Firefox\FirefoxDriverService', 'PhpWebDriver\Firefox\FirefoxDriverService');

--- a/lib/Firefox/FirefoxOptions.php
+++ b/lib/Firefox/FirefoxOptions.php
@@ -106,3 +106,5 @@ class FirefoxOptions implements \JsonSerializable
         return new \ArrayObject($this->toArray());
     }
 }
+
+class_alias('Facebook\WebDriver\Firefox\FirefoxOptions', 'PhpWebDriver\Firefox\FirefoxOptions');

--- a/lib/Firefox/FirefoxPreferences.php
+++ b/lib/Firefox/FirefoxPreferences.php
@@ -23,3 +23,5 @@ class FirefoxPreferences
     {
     }
 }
+
+class_alias('Facebook\WebDriver\Firefox\FirefoxPreferences', 'PhpWebDriver\Firefox\FirefoxPreferences');

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -289,3 +289,5 @@ class FirefoxProfile
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\Firefox\FirefoxProfile', 'PhpWebDriver\Firefox\FirefoxProfile');

--- a/lib/Interactions/Internal/WebDriverButtonReleaseAction.php
+++ b/lib/Interactions/Internal/WebDriverButtonReleaseAction.php
@@ -14,3 +14,5 @@ class WebDriverButtonReleaseAction extends WebDriverMouseAction implements WebDr
         $this->mouse->mouseUp($this->getActionLocation());
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction', 'PhpWebDriver\Interactions\Internal\WebDriverButtonReleaseAction');

--- a/lib/Interactions/Internal/WebDriverClickAction.php
+++ b/lib/Interactions/Internal/WebDriverClickAction.php
@@ -11,3 +11,5 @@ class WebDriverClickAction extends WebDriverMouseAction implements WebDriverActi
         $this->mouse->click($this->getActionLocation());
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverClickAction', 'PhpWebDriver\Interactions\Internal\WebDriverClickAction');

--- a/lib/Interactions/Internal/WebDriverClickAndHoldAction.php
+++ b/lib/Interactions/Internal/WebDriverClickAndHoldAction.php
@@ -14,3 +14,5 @@ class WebDriverClickAndHoldAction extends WebDriverMouseAction implements WebDri
         $this->mouse->mouseDown($this->getActionLocation());
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction', 'PhpWebDriver\Interactions\Internal\WebDriverClickAndHoldAction');

--- a/lib/Interactions/Internal/WebDriverContextClickAction.php
+++ b/lib/Interactions/Internal/WebDriverContextClickAction.php
@@ -14,3 +14,5 @@ class WebDriverContextClickAction extends WebDriverMouseAction implements WebDri
         $this->mouse->contextClick($this->getActionLocation());
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverContextClickAction', 'PhpWebDriver\Interactions\Internal\WebDriverContextClickAction');

--- a/lib/Interactions/Internal/WebDriverCoordinates.php
+++ b/lib/Interactions/Internal/WebDriverCoordinates.php
@@ -76,3 +76,5 @@ class WebDriverCoordinates
         return $this->auxiliary;
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates', 'PhpWebDriver\Interactions\Internal\WebDriverCoordinates');

--- a/lib/Interactions/Internal/WebDriverDoubleClickAction.php
+++ b/lib/Interactions/Internal/WebDriverDoubleClickAction.php
@@ -11,3 +11,5 @@ class WebDriverDoubleClickAction extends WebDriverMouseAction implements WebDriv
         $this->mouse->doubleClick($this->getActionLocation());
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverDoubleClickAction', 'PhpWebDriver\Interactions\Internal\WebDriverDoubleClickAction');

--- a/lib/Interactions/Internal/WebDriverKeyDownAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyDownAction.php
@@ -10,3 +10,5 @@ class WebDriverKeyDownAction extends WebDriverSingleKeyAction
         $this->keyboard->pressKey($this->key);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverKeyDownAction', 'PhpWebDriver\Interactions\Internal\WebDriverKeyDownAction');

--- a/lib/Interactions/Internal/WebDriverKeyUpAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyUpAction.php
@@ -10,3 +10,5 @@ class WebDriverKeyUpAction extends WebDriverSingleKeyAction
         $this->keyboard->releaseKey($this->key);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverKeyUpAction', 'PhpWebDriver\Interactions\Internal\WebDriverKeyUpAction');

--- a/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
+++ b/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
@@ -46,3 +46,5 @@ abstract class WebDriverKeysRelatedAction
         }
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction', 'PhpWebDriver\Interactions\Internal\WebDriverKeysRelatedAction');

--- a/lib/Interactions/Internal/WebDriverMouseAction.php
+++ b/lib/Interactions/Internal/WebDriverMouseAction.php
@@ -46,3 +46,5 @@ class WebDriverMouseAction
         $this->mouse->mouseMove($this->locationProvider);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverMouseAction', 'PhpWebDriver\Interactions\Internal\WebDriverMouseAction');

--- a/lib/Interactions/Internal/WebDriverMouseMoveAction.php
+++ b/lib/Interactions/Internal/WebDriverMouseMoveAction.php
@@ -11,3 +11,5 @@ class WebDriverMouseMoveAction extends WebDriverMouseAction implements WebDriver
         $this->mouse->mouseMove($this->getActionLocation());
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverMouseMoveAction', 'PhpWebDriver\Interactions\Internal\WebDriverMouseMoveAction');

--- a/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
+++ b/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
@@ -43,3 +43,5 @@ class WebDriverMoveToOffsetAction extends WebDriverMouseAction implements WebDri
         );
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction', 'PhpWebDriver\Interactions\Internal\WebDriverMoveToOffsetAction');

--- a/lib/Interactions/Internal/WebDriverSendKeysAction.php
+++ b/lib/Interactions/Internal/WebDriverSendKeysAction.php
@@ -36,3 +36,5 @@ class WebDriverSendKeysAction extends WebDriverKeysRelatedAction implements WebD
         $this->keyboard->sendKeys($this->keys);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverSendKeysAction', 'PhpWebDriver\Interactions\Internal\WebDriverSendKeysAction');

--- a/lib/Interactions/Internal/WebDriverSingleKeyAction.php
+++ b/lib/Interactions/Internal/WebDriverSingleKeyAction.php
@@ -51,3 +51,5 @@ abstract class WebDriverSingleKeyAction extends WebDriverKeysRelatedAction imple
         $this->key = $key;
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Internal\WebDriverSingleKeyAction', 'PhpWebDriver\Interactions\Internal\WebDriverSingleKeyAction');

--- a/lib/Interactions/Touch/WebDriverDoubleTapAction.php
+++ b/lib/Interactions/Touch/WebDriverDoubleTapAction.php
@@ -11,3 +11,5 @@ class WebDriverDoubleTapAction extends WebDriverTouchAction implements WebDriver
         $this->touchScreen->doubleTap($this->locationProvider);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverDoubleTapAction', 'PhpWebDriver\Interactions\Touch\WebDriverDoubleTapAction');

--- a/lib/Interactions/Touch/WebDriverDownAction.php
+++ b/lib/Interactions/Touch/WebDriverDownAction.php
@@ -32,3 +32,5 @@ class WebDriverDownAction extends WebDriverTouchAction implements WebDriverActio
         $this->touchScreen->down($this->x, $this->y);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverDownAction', 'PhpWebDriver\Interactions\Touch\WebDriverDownAction');

--- a/lib/Interactions/Touch/WebDriverFlickAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickAction.php
@@ -32,3 +32,5 @@ class WebDriverFlickAction extends WebDriverTouchAction implements WebDriverActi
         $this->touchScreen->flick($this->x, $this->y);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverFlickAction', 'PhpWebDriver\Interactions\Touch\WebDriverFlickAction');

--- a/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
@@ -50,3 +50,5 @@ class WebDriverFlickFromElementAction extends WebDriverTouchAction implements We
         );
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction', 'PhpWebDriver\Interactions\Touch\WebDriverFlickFromElementAction');

--- a/lib/Interactions/Touch/WebDriverLongPressAction.php
+++ b/lib/Interactions/Touch/WebDriverLongPressAction.php
@@ -11,3 +11,5 @@ class WebDriverLongPressAction extends WebDriverTouchAction implements WebDriver
         $this->touchScreen->longPress($this->locationProvider);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverLongPressAction', 'PhpWebDriver\Interactions\Touch\WebDriverLongPressAction');

--- a/lib/Interactions/Touch/WebDriverMoveAction.php
+++ b/lib/Interactions/Touch/WebDriverMoveAction.php
@@ -26,3 +26,5 @@ class WebDriverMoveAction extends WebDriverTouchAction implements WebDriverActio
         $this->touchScreen->move($this->x, $this->y);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverMoveAction', 'PhpWebDriver\Interactions\Touch\WebDriverMoveAction');

--- a/lib/Interactions/Touch/WebDriverScrollAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollAction.php
@@ -26,3 +26,5 @@ class WebDriverScrollAction extends WebDriverTouchAction implements WebDriverAct
         $this->touchScreen->scroll($this->x, $this->y);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverScrollAction', 'PhpWebDriver\Interactions\Touch\WebDriverScrollAction');

--- a/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
@@ -36,3 +36,5 @@ class WebDriverScrollFromElementAction extends WebDriverTouchAction implements W
         );
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction', 'PhpWebDriver\Interactions\Touch\WebDriverScrollFromElementAction');

--- a/lib/Interactions/Touch/WebDriverTapAction.php
+++ b/lib/Interactions/Touch/WebDriverTapAction.php
@@ -11,3 +11,5 @@ class WebDriverTapAction extends WebDriverTouchAction implements WebDriverAction
         $this->touchScreen->tap($this->locationProvider);
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverTapAction', 'PhpWebDriver\Interactions\Touch\WebDriverTapAction');

--- a/lib/Interactions/Touch/WebDriverTouchAction.php
+++ b/lib/Interactions/Touch/WebDriverTouchAction.php
@@ -40,3 +40,5 @@ abstract class WebDriverTouchAction
             ? $this->locationProvider->getCoordinates() : null;
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverTouchAction', 'PhpWebDriver\Interactions\Touch\WebDriverTouchAction');

--- a/lib/Interactions/Touch/WebDriverTouchScreen.php
+++ b/lib/Interactions/Touch/WebDriverTouchScreen.php
@@ -112,3 +112,5 @@ interface WebDriverTouchScreen
      */
     public function up($x, $y);
 }
+
+class_alias('Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen', 'PhpWebDriver\Interactions\Touch\WebDriverTouchScreen');

--- a/lib/Interactions/WebDriverActions.php
+++ b/lib/Interactions/WebDriverActions.php
@@ -266,3 +266,5 @@ class WebDriverActions
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\WebDriverActions', 'PhpWebDriver\Interactions\WebDriverActions');

--- a/lib/Interactions/WebDriverCompositeAction.php
+++ b/lib/Interactions/WebDriverCompositeAction.php
@@ -47,3 +47,5 @@ class WebDriverCompositeAction implements WebDriverAction
         }
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\WebDriverCompositeAction', 'PhpWebDriver\Interactions\WebDriverCompositeAction');

--- a/lib/Interactions/WebDriverTouchActions.php
+++ b/lib/Interactions/WebDriverTouchActions.php
@@ -178,3 +178,5 @@ class WebDriverTouchActions extends WebDriverActions
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\Interactions\WebDriverTouchActions', 'PhpWebDriver\Interactions\WebDriverTouchActions');

--- a/lib/Internal/WebDriverLocatable.php
+++ b/lib/Internal/WebDriverLocatable.php
@@ -14,3 +14,5 @@ interface WebDriverLocatable
      */
     public function getCoordinates();
 }
+
+class_alias('Facebook\WebDriver\Internal\WebDriverLocatable', 'PhpWebDriver\Internal\WebDriverLocatable');

--- a/lib/JavaScriptExecutor.php
+++ b/lib/JavaScriptExecutor.php
@@ -33,3 +33,5 @@ interface JavaScriptExecutor
      */
     public function executeAsyncScript($script, array $arguments = []);
 }
+
+class_alias('Facebook\WebDriver\JavaScriptExecutor', 'PhpWebDriver\JavaScriptExecutor');

--- a/lib/Local/LocalWebDriver.php
+++ b/lib/Local/LocalWebDriver.php
@@ -53,3 +53,5 @@ abstract class LocalWebDriver extends RemoteWebDriver
         throw new WebDriverException('Use start() method to start local WebDriver.');
     }
 }
+
+class_alias('Facebook\WebDriver\Local\LocalWebDriver', 'PhpWebDriver\Local\LocalWebDriver');

--- a/lib/Net/URLChecker.php
+++ b/lib/Net/URLChecker.php
@@ -70,3 +70,5 @@ class URLChecker
         return $code;
     }
 }
+
+class_alias('Facebook\WebDriver\Net\URLChecker', 'PhpWebDriver\Net\URLChecker');

--- a/lib/Remote/CustomWebDriverCommand.php
+++ b/lib/Remote/CustomWebDriverCommand.php
@@ -80,3 +80,5 @@ class CustomWebDriverCommand extends WebDriverCommand
         $this->customUrl = $custom_url;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\CustomWebDriverCommand', 'PhpWebDriver\Remote\CustomWebDriverCommand');

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -438,3 +438,5 @@ class DesiredCapabilities implements WebDriverCapabilities
             : $default;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\DesiredCapabilities', 'PhpWebDriver\Remote\DesiredCapabilities');

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -148,3 +148,5 @@ class DriverCommand
     {
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\DriverCommand', 'PhpWebDriver\Remote\DriverCommand');

--- a/lib/Remote/ExecuteMethod.php
+++ b/lib/Remote/ExecuteMethod.php
@@ -11,3 +11,5 @@ interface ExecuteMethod
      */
     public function execute($command_name, array $parameters = []);
 }
+
+class_alias('Facebook\WebDriver\Remote\ExecuteMethod', 'PhpWebDriver\Remote\ExecuteMethod');

--- a/lib/Remote/FileDetector.php
+++ b/lib/Remote/FileDetector.php
@@ -14,3 +14,5 @@ interface FileDetector
      */
     public function getLocalFile($file);
 }
+
+class_alias('Facebook\WebDriver\Remote\FileDetector', 'PhpWebDriver\Remote\FileDetector');

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -424,3 +424,5 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         ];
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\HttpCommandExecutor', 'PhpWebDriver\Remote\HttpCommandExecutor');

--- a/lib/Remote/JsonWireCompat.php
+++ b/lib/Remote/JsonWireCompat.php
@@ -87,3 +87,5 @@ abstract class JsonWireCompat
         }, $selector);
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\JsonWireCompat', 'PhpWebDriver\Remote\JsonWireCompat');

--- a/lib/Remote/LocalFileDetector.php
+++ b/lib/Remote/LocalFileDetector.php
@@ -18,3 +18,5 @@ class LocalFileDetector implements FileDetector
         return null;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\LocalFileDetector', 'PhpWebDriver\Remote\LocalFileDetector');

--- a/lib/Remote/RemoteExecuteMethod.php
+++ b/lib/Remote/RemoteExecuteMethod.php
@@ -27,3 +27,5 @@ class RemoteExecuteMethod implements ExecuteMethod
         return $this->driver->execute($command_name, $parameters);
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteExecuteMethod', 'PhpWebDriver\Remote\RemoteExecuteMethod');

--- a/lib/Remote/RemoteKeyboard.php
+++ b/lib/Remote/RemoteKeyboard.php
@@ -103,3 +103,5 @@ class RemoteKeyboard implements WebDriverKeyboard
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteKeyboard', 'PhpWebDriver\Remote\RemoteKeyboard');

--- a/lib/Remote/RemoteMouse.php
+++ b/lib/Remote/RemoteMouse.php
@@ -304,3 +304,5 @@ class RemoteMouse implements WebDriverMouse
         ];
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteMouse', 'PhpWebDriver\Remote\RemoteMouse');

--- a/lib/Remote/RemoteStatus.php
+++ b/lib/Remote/RemoteStatus.php
@@ -78,3 +78,5 @@ class RemoteStatus
         $this->meta = $meta;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteStatus', 'PhpWebDriver\Remote\RemoteStatus');

--- a/lib/Remote/RemoteTargetLocator.php
+++ b/lib/Remote/RemoteTargetLocator.php
@@ -147,3 +147,5 @@ class RemoteTargetLocator implements WebDriverTargetLocator
         return new RemoteWebElement($method, JsonWireCompat::getElement($response), $this->isW3cCompliant);
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteTargetLocator', 'PhpWebDriver\Remote\RemoteTargetLocator');

--- a/lib/Remote/RemoteTouchScreen.php
+++ b/lib/Remote/RemoteTouchScreen.php
@@ -186,3 +186,5 @@ class RemoteTouchScreen implements WebDriverTouchScreen
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteTouchScreen', 'PhpWebDriver\Remote\RemoteTouchScreen');

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -727,3 +727,5 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         return $desired_capabilities;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteWebDriver', 'PhpWebDriver\Remote\RemoteWebDriver');

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -606,3 +606,5 @@ HTXT;
         return $tempZipPath;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\RemoteWebElement', 'PhpWebDriver\Remote\RemoteWebElement');

--- a/lib/Remote/Service/DriverCommandExecutor.php
+++ b/lib/Remote/Service/DriverCommandExecutor.php
@@ -53,3 +53,5 @@ class DriverCommandExecutor extends HttpCommandExecutor
         }
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\Service\DriverCommandExecutor', 'PhpWebDriver\Remote\Service\DriverCommandExecutor');

--- a/lib/Remote/Service/DriverService.php
+++ b/lib/Remote/Service/DriverService.php
@@ -207,3 +207,5 @@ class DriverService
         return false;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\Service\DriverService', 'PhpWebDriver\Remote\Service\DriverService');

--- a/lib/Remote/UselessFileDetector.php
+++ b/lib/Remote/UselessFileDetector.php
@@ -9,3 +9,5 @@ class UselessFileDetector implements FileDetector
         return null;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\UselessFileDetector', 'PhpWebDriver\Remote\UselessFileDetector');

--- a/lib/Remote/WebDriverBrowserType.php
+++ b/lib/Remote/WebDriverBrowserType.php
@@ -38,3 +38,5 @@ class WebDriverBrowserType
     {
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\WebDriverBrowserType', 'PhpWebDriver\Remote\WebDriverBrowserType');

--- a/lib/Remote/WebDriverCapabilityType.php
+++ b/lib/Remote/WebDriverCapabilityType.php
@@ -30,3 +30,5 @@ class WebDriverCapabilityType
     {
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\WebDriverCapabilityType', 'PhpWebDriver\Remote\WebDriverCapabilityType');

--- a/lib/Remote/WebDriverCommand.php
+++ b/lib/Remote/WebDriverCommand.php
@@ -48,3 +48,5 @@ class WebDriverCommand
         return $this->parameters;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\WebDriverCommand', 'PhpWebDriver\Remote\WebDriverCommand');

--- a/lib/Remote/WebDriverResponse.php
+++ b/lib/Remote/WebDriverResponse.php
@@ -82,3 +82,5 @@ class WebDriverResponse
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\Remote\WebDriverResponse', 'PhpWebDriver\Remote\WebDriverResponse');

--- a/lib/Support/Events/EventFiringWebDriver.php
+++ b/lib/Support/Events/EventFiringWebDriver.php
@@ -402,3 +402,5 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
         $this->dispatch('onException', $exception, $this);
     }
 }
+
+class_alias('Facebook\WebDriver\Support\Events\EventFiringWebDriver', 'PhpWebDriver\Support\Events\EventFiringWebDriver');

--- a/lib/Support/Events/EventFiringWebDriverNavigation.php
+++ b/lib/Support/Events/EventFiringWebDriverNavigation.php
@@ -138,3 +138,5 @@ class EventFiringWebDriverNavigation implements WebDriverNavigationInterface
         $this->dispatch('onException', $exception);
     }
 }
+
+class_alias('Facebook\WebDriver\Support\Events\EventFiringWebDriverNavigation', 'PhpWebDriver\Support\Events\EventFiringWebDriverNavigation');

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -399,3 +399,5 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
         return new static($element, $this->getDispatcher());
     }
 }
+
+class_alias('Facebook\WebDriver\Support\Events\EventFiringWebElement', 'PhpWebDriver\Support\Events\EventFiringWebElement');

--- a/lib/Support/XPathEscaper.php
+++ b/lib/Support/XPathEscaper.php
@@ -30,3 +30,5 @@ class XPathEscaper
         );
     }
 }
+
+class_alias('Facebook\WebDriver\Support\XPathEscaper', 'PhpWebDriver\Support\XPathEscaper');

--- a/lib/WebDriver.php
+++ b/lib/WebDriver.php
@@ -141,3 +141,5 @@ interface WebDriver extends WebDriverSearchContext
     // */
     //public function executeCustomCommand($endpointUrl, $method = 'GET', $params = []);
 }
+
+class_alias('Facebook\WebDriver\WebDriver', 'PhpWebDriver\WebDriver');

--- a/lib/WebDriverAction.php
+++ b/lib/WebDriverAction.php
@@ -9,3 +9,5 @@ interface WebDriverAction
 {
     public function perform();
 }
+
+class_alias('Facebook\WebDriver\WebDriverAction', 'PhpWebDriver\WebDriverAction');

--- a/lib/WebDriverAlert.php
+++ b/lib/WebDriverAlert.php
@@ -70,3 +70,5 @@ class WebDriverAlert
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverAlert', 'PhpWebDriver\WebDriverAlert');

--- a/lib/WebDriverBy.php
+++ b/lib/WebDriverBy.php
@@ -132,3 +132,5 @@ class WebDriverBy
         return new static('xpath', $xpath);
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverBy', 'PhpWebDriver\WebDriverBy');

--- a/lib/WebDriverCapabilities.php
+++ b/lib/WebDriverCapabilities.php
@@ -44,3 +44,5 @@ interface WebDriverCapabilities
     // */
     //public function toArray();
 }
+
+class_alias('Facebook\WebDriver\WebDriverCapabilities', 'PhpWebDriver\WebDriverCapabilities');

--- a/lib/WebDriverCheckboxes.php
+++ b/lib/WebDriverCheckboxes.php
@@ -51,3 +51,5 @@ class WebDriverCheckboxes extends AbstractWebDriverCheckboxOrRadio
         $this->byVisibleText($text, true, false);
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverCheckboxes', 'PhpWebDriver\WebDriverCheckboxes');

--- a/lib/WebDriverCommandExecutor.php
+++ b/lib/WebDriverCommandExecutor.php
@@ -17,3 +17,5 @@ interface WebDriverCommandExecutor
      */
     public function execute(WebDriverCommand $command);
 }
+
+class_alias('Facebook\WebDriver\WebDriverCommandExecutor', 'PhpWebDriver\WebDriverCommandExecutor');

--- a/lib/WebDriverDimension.php
+++ b/lib/WebDriverDimension.php
@@ -57,3 +57,5 @@ class WebDriverDimension
         return $this->height === $dimension->getHeight() && $this->width === $dimension->getWidth();
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverDimension', 'PhpWebDriver\WebDriverDimension');

--- a/lib/WebDriverDispatcher.php
+++ b/lib/WebDriverDispatcher.php
@@ -76,3 +76,5 @@ class WebDriverDispatcher
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverDispatcher', 'PhpWebDriver\WebDriverDispatcher');

--- a/lib/WebDriverElement.php
+++ b/lib/WebDriverElement.php
@@ -129,3 +129,5 @@ interface WebDriverElement extends WebDriverSearchContext
      */
     //public function takeElementScreenshot($save_as = null);
 }
+
+class_alias('Facebook\WebDriver\WebDriverElement', 'PhpWebDriver\WebDriverElement');

--- a/lib/WebDriverEventListener.php
+++ b/lib/WebDriverEventListener.php
@@ -92,3 +92,5 @@ interface WebDriverEventListener
      */
     public function onException(WebDriverException $exception, EventFiringWebDriver $driver = null);
 }
+
+class_alias('Facebook\WebDriver\WebDriverEventListener', 'PhpWebDriver\WebDriverEventListener');

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -584,3 +584,5 @@ class WebDriverExpectedCondition
         );
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverExpectedCondition', 'PhpWebDriver\WebDriverExpectedCondition');

--- a/lib/WebDriverHasInputDevices.php
+++ b/lib/WebDriverHasInputDevices.php
@@ -17,3 +17,5 @@ interface WebDriverHasInputDevices
      */
     public function getMouse();
 }
+
+class_alias('Facebook\WebDriver\WebDriverHasInputDevices', 'PhpWebDriver\WebDriverHasInputDevices');

--- a/lib/WebDriverKeyboard.php
+++ b/lib/WebDriverKeyboard.php
@@ -30,3 +30,5 @@ interface WebDriverKeyboard
      */
     public function releaseKey($key);
 }
+
+class_alias('Facebook\WebDriver\WebDriverKeyboard', 'PhpWebDriver\WebDriverKeyboard');

--- a/lib/WebDriverKeys.php
+++ b/lib/WebDriverKeys.php
@@ -130,3 +130,5 @@ class WebDriverKeys
         return implode('', $encoded);
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverKeys', 'PhpWebDriver\WebDriverKeys');

--- a/lib/WebDriverMouse.php
+++ b/lib/WebDriverMouse.php
@@ -51,3 +51,5 @@ interface WebDriverMouse
      */
     public function mouseUp(WebDriverCoordinates $where);
 }
+
+class_alias('Facebook\WebDriver\WebDriverMouse', 'PhpWebDriver\WebDriverMouse');

--- a/lib/WebDriverNavigation.php
+++ b/lib/WebDriverNavigation.php
@@ -43,3 +43,5 @@ class WebDriverNavigation implements WebDriverNavigationInterface
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverNavigation', 'PhpWebDriver\WebDriverNavigation');

--- a/lib/WebDriverNavigationInterface.php
+++ b/lib/WebDriverNavigationInterface.php
@@ -41,3 +41,5 @@ interface WebDriverNavigationInterface
      */
     public function to($url);
 }
+
+class_alias('Facebook\WebDriver\WebDriverNavigationInterface', 'PhpWebDriver\WebDriverNavigationInterface');

--- a/lib/WebDriverOptions.php
+++ b/lib/WebDriverOptions.php
@@ -178,3 +178,5 @@ class WebDriverOptions
         return $this->executor->execute(DriverCommand::GET_AVAILABLE_LOG_TYPES);
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverOptions', 'PhpWebDriver\WebDriverOptions');

--- a/lib/WebDriverPlatform.php
+++ b/lib/WebDriverPlatform.php
@@ -23,3 +23,5 @@ class WebDriverPlatform
     {
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverPlatform', 'PhpWebDriver\WebDriverPlatform');

--- a/lib/WebDriverPoint.php
+++ b/lib/WebDriverPoint.php
@@ -78,3 +78,5 @@ class WebDriverPoint
         $this->y === $point->getY();
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverPoint', 'PhpWebDriver\WebDriverPoint');

--- a/lib/WebDriverRadios.php
+++ b/lib/WebDriverRadios.php
@@ -50,3 +50,5 @@ class WebDriverRadios extends AbstractWebDriverCheckboxOrRadio
         throw new UnsupportedOperationException('You cannot deselect radio buttons');
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverRadios', 'PhpWebDriver\WebDriverRadios');

--- a/lib/WebDriverSearchContext.php
+++ b/lib/WebDriverSearchContext.php
@@ -29,3 +29,5 @@ interface WebDriverSearchContext
      */
     public function findElements(WebDriverBy $locator);
 }
+
+class_alias('Facebook\WebDriver\WebDriverSearchContext', 'PhpWebDriver\WebDriverSearchContext');

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -243,3 +243,5 @@ class WebDriverSelect implements WebDriverSelectInterface
         }
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverSelect', 'PhpWebDriver\WebDriverSelect');

--- a/lib/WebDriverSelectInterface.php
+++ b/lib/WebDriverSelectInterface.php
@@ -126,3 +126,5 @@ interface WebDriverSelectInterface
      */
     public function deselectByVisiblePartialText($text);
 }
+
+class_alias('Facebook\WebDriver\WebDriverSelectInterface', 'PhpWebDriver\WebDriverSelectInterface');

--- a/lib/WebDriverTargetLocator.php
+++ b/lib/WebDriverTargetLocator.php
@@ -67,3 +67,5 @@ interface WebDriverTargetLocator
      */
     public function activeElement();
 }
+
+class_alias('Facebook\WebDriver\WebDriverTargetLocator', 'PhpWebDriver\WebDriverTargetLocator');

--- a/lib/WebDriverTimeouts.php
+++ b/lib/WebDriverTimeouts.php
@@ -100,3 +100,5 @@ class WebDriverTimeouts
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverTimeouts', 'PhpWebDriver\WebDriverTimeouts');

--- a/lib/WebDriverUpAction.php
+++ b/lib/WebDriverUpAction.php
@@ -27,3 +27,5 @@ class WebDriverUpAction extends WebDriverTouchAction implements WebDriverAction
         $this->touchScreen->up($this->x, $this->y);
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverUpAction', 'PhpWebDriver\WebDriverUpAction');

--- a/lib/WebDriverWait.php
+++ b/lib/WebDriverWait.php
@@ -71,3 +71,5 @@ class WebDriverWait
         throw new TimeoutException($message);
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverWait', 'PhpWebDriver\WebDriverWait');

--- a/lib/WebDriverWindow.php
+++ b/lib/WebDriverWindow.php
@@ -189,3 +189,5 @@ class WebDriverWindow
         return $this;
     }
 }
+
+class_alias('Facebook\WebDriver\WebDriverWindow', 'PhpWebDriver\WebDriverWindow');

--- a/src/AbstractWebDriverCheckboxOrRadio.php
+++ b/src/AbstractWebDriverCheckboxOrRadio.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\AbstractWebDriverCheckboxOrRadio');
+
+if (\false) {
+    class AbstractWebDriverCheckboxOrRadio extends \Facebook\WebDriver\AbstractWebDriverCheckboxOrRadio
+    {
+    }
+}

--- a/src/Chrome/ChromeDevToolsDriver.php
+++ b/src/Chrome/ChromeDevToolsDriver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Chrome;
+
+class_exists('Facebook\WebDriver\Chrome\ChromeDevToolsDriver');
+
+if (\false) {
+    class ChromeDevToolsDriver extends \Facebook\WebDriver\Chrome\ChromeDevToolsDriver
+    {
+    }
+}

--- a/src/Chrome/ChromeDriver.php
+++ b/src/Chrome/ChromeDriver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Chrome;
+
+class_exists('Facebook\WebDriver\Chrome\ChromeDriver');
+
+if (\false) {
+    class ChromeDriver extends \Facebook\WebDriver\Chrome\ChromeDriver
+    {
+    }
+}

--- a/src/Chrome/ChromeDriverService.php
+++ b/src/Chrome/ChromeDriverService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Chrome;
+
+class_exists('Facebook\WebDriver\Chrome\ChromeDriverService');
+
+if (\false) {
+    class ChromeDriverService extends \Facebook\WebDriver\Chrome\ChromeDriverService
+    {
+    }
+}

--- a/src/Chrome/ChromeOptions.php
+++ b/src/Chrome/ChromeOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Chrome;
+
+class_exists('Facebook\WebDriver\Chrome\ChromeOptions');
+
+if (\false) {
+    class ChromeOptions extends \Facebook\WebDriver\Chrome\ChromeOptions
+    {
+    }
+}

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\Cookie');
+
+if (\false) {
+    class Cookie extends \Facebook\WebDriver\Cookie
+    {
+    }
+}

--- a/src/Exception/DriverServerDiedException.php
+++ b/src/Exception/DriverServerDiedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\DriverServerDiedException');
+
+if (\false) {
+    class DriverServerDiedException extends \Facebook\WebDriver\Exception\DriverServerDiedException
+    {
+    }
+}

--- a/src/Exception/ElementClickInterceptedException.php
+++ b/src/Exception/ElementClickInterceptedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\ElementClickInterceptedException');
+
+if (\false) {
+    class ElementClickInterceptedException extends \Facebook\WebDriver\Exception\ElementClickInterceptedException
+    {
+    }
+}

--- a/src/Exception/ElementNotInteractableException.php
+++ b/src/Exception/ElementNotInteractableException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\ElementNotInteractableException');
+
+if (\false) {
+    class ElementNotInteractableException extends \Facebook\WebDriver\Exception\ElementNotInteractableException
+    {
+    }
+}

--- a/src/Exception/InsecureCertificateException.php
+++ b/src/Exception/InsecureCertificateException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\InsecureCertificateException');
+
+if (\false) {
+    class InsecureCertificateException extends \Facebook\WebDriver\Exception\InsecureCertificateException
+    {
+    }
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\InvalidArgumentException');
+
+if (\false) {
+    class InvalidArgumentException extends \Facebook\WebDriver\Exception\InvalidArgumentException
+    {
+    }
+}

--- a/src/Exception/InvalidCookieDomainException.php
+++ b/src/Exception/InvalidCookieDomainException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\InvalidCookieDomainException');
+
+if (\false) {
+    class InvalidCookieDomainException extends \Facebook\WebDriver\Exception\InvalidCookieDomainException
+    {
+    }
+}

--- a/src/Exception/InvalidElementStateException.php
+++ b/src/Exception/InvalidElementStateException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\InvalidElementStateException');
+
+if (\false) {
+    class InvalidElementStateException extends \Facebook\WebDriver\Exception\InvalidElementStateException
+    {
+    }
+}

--- a/src/Exception/InvalidSelectorException.php
+++ b/src/Exception/InvalidSelectorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\InvalidSelectorException');
+
+if (\false) {
+    class InvalidSelectorException extends \Facebook\WebDriver\Exception\InvalidSelectorException
+    {
+    }
+}

--- a/src/Exception/InvalidSessionIdException.php
+++ b/src/Exception/InvalidSessionIdException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\InvalidSessionIdException');
+
+if (\false) {
+    class InvalidSessionIdException extends \Facebook\WebDriver\Exception\InvalidSessionIdException
+    {
+    }
+}

--- a/src/Exception/JavascriptErrorException.php
+++ b/src/Exception/JavascriptErrorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\JavascriptErrorException');
+
+if (\false) {
+    class JavascriptErrorException extends \Facebook\WebDriver\Exception\JavascriptErrorException
+    {
+    }
+}

--- a/src/Exception/MoveTargetOutOfBoundsException.php
+++ b/src/Exception/MoveTargetOutOfBoundsException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\MoveTargetOutOfBoundsException');
+
+if (\false) {
+    class MoveTargetOutOfBoundsException extends \Facebook\WebDriver\Exception\MoveTargetOutOfBoundsException
+    {
+    }
+}

--- a/src/Exception/NoSuchAlertException.php
+++ b/src/Exception/NoSuchAlertException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\NoSuchAlertException');
+
+if (\false) {
+    class NoSuchAlertException extends \Facebook\WebDriver\Exception\NoSuchAlertException
+    {
+    }
+}

--- a/src/Exception/NoSuchCookieException.php
+++ b/src/Exception/NoSuchCookieException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\NoSuchCookieException');
+
+if (\false) {
+    class NoSuchCookieException extends \Facebook\WebDriver\Exception\NoSuchCookieException
+    {
+    }
+}

--- a/src/Exception/NoSuchElementException.php
+++ b/src/Exception/NoSuchElementException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\NoSuchElementException');
+
+if (\false) {
+    class NoSuchElementException extends \Facebook\WebDriver\Exception\NoSuchElementException
+    {
+    }
+}

--- a/src/Exception/NoSuchFrameException.php
+++ b/src/Exception/NoSuchFrameException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\NoSuchFrameException');
+
+if (\false) {
+    class NoSuchFrameException extends \Facebook\WebDriver\Exception\NoSuchFrameException
+    {
+    }
+}

--- a/src/Exception/NoSuchWindowException.php
+++ b/src/Exception/NoSuchWindowException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\NoSuchWindowException');
+
+if (\false) {
+    class NoSuchWindowException extends \Facebook\WebDriver\Exception\NoSuchWindowException
+    {
+    }
+}

--- a/src/Exception/ScriptTimeoutException.php
+++ b/src/Exception/ScriptTimeoutException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\ScriptTimeoutException');
+
+if (\false) {
+    class ScriptTimeoutException extends \Facebook\WebDriver\Exception\ScriptTimeoutException
+    {
+    }
+}

--- a/src/Exception/SessionNotCreatedException.php
+++ b/src/Exception/SessionNotCreatedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\SessionNotCreatedException');
+
+if (\false) {
+    class SessionNotCreatedException extends \Facebook\WebDriver\Exception\SessionNotCreatedException
+    {
+    }
+}

--- a/src/Exception/StaleElementReferenceException.php
+++ b/src/Exception/StaleElementReferenceException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\StaleElementReferenceException');
+
+if (\false) {
+    class StaleElementReferenceException extends \Facebook\WebDriver\Exception\StaleElementReferenceException
+    {
+    }
+}

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\TimeoutException');
+
+if (\false) {
+    class TimeoutException extends \Facebook\WebDriver\Exception\TimeoutException
+    {
+    }
+}

--- a/src/Exception/UnableToCaptureScreenException.php
+++ b/src/Exception/UnableToCaptureScreenException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnableToCaptureScreenException');
+
+if (\false) {
+    class UnableToCaptureScreenException extends \Facebook\WebDriver\Exception\UnableToCaptureScreenException
+    {
+    }
+}

--- a/src/Exception/UnableToSetCookieException.php
+++ b/src/Exception/UnableToSetCookieException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnableToSetCookieException');
+
+if (\false) {
+    class UnableToSetCookieException extends \Facebook\WebDriver\Exception\UnableToSetCookieException
+    {
+    }
+}

--- a/src/Exception/UnexpectedAlertOpenException.php
+++ b/src/Exception/UnexpectedAlertOpenException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnexpectedAlertOpenException');
+
+if (\false) {
+    class UnexpectedAlertOpenException extends \Facebook\WebDriver\Exception\UnexpectedAlertOpenException
+    {
+    }
+}

--- a/src/Exception/UnexpectedTagNameException.php
+++ b/src/Exception/UnexpectedTagNameException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnexpectedTagNameException');
+
+if (\false) {
+    class UnexpectedTagNameException extends \Facebook\WebDriver\Exception\UnexpectedTagNameException
+    {
+    }
+}

--- a/src/Exception/UnknownCommandException.php
+++ b/src/Exception/UnknownCommandException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnknownCommandException');
+
+if (\false) {
+    class UnknownCommandException extends \Facebook\WebDriver\Exception\UnknownCommandException
+    {
+    }
+}

--- a/src/Exception/UnknownErrorException.php
+++ b/src/Exception/UnknownErrorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnknownErrorException');
+
+if (\false) {
+    class UnknownErrorException extends \Facebook\WebDriver\Exception\UnknownErrorException
+    {
+    }
+}

--- a/src/Exception/UnknownMethodException.php
+++ b/src/Exception/UnknownMethodException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnknownMethodException');
+
+if (\false) {
+    class UnknownMethodException extends \Facebook\WebDriver\Exception\UnknownMethodException
+    {
+    }
+}

--- a/src/Exception/UnrecognizedExceptionException.php
+++ b/src/Exception/UnrecognizedExceptionException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnrecognizedExceptionException');
+
+if (\false) {
+    class UnrecognizedExceptionException extends \Facebook\WebDriver\Exception\UnrecognizedExceptionException
+    {
+    }
+}

--- a/src/Exception/UnsupportedOperationException.php
+++ b/src/Exception/UnsupportedOperationException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\UnsupportedOperationException');
+
+if (\false) {
+    class UnsupportedOperationException extends \Facebook\WebDriver\Exception\UnsupportedOperationException
+    {
+    }
+}

--- a/src/Exception/WebDriverCurlException.php
+++ b/src/Exception/WebDriverCurlException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\WebDriverCurlException');
+
+if (\false) {
+    class WebDriverCurlException extends \Facebook\WebDriver\Exception\WebDriverCurlException
+    {
+    }
+}

--- a/src/Exception/WebDriverException.php
+++ b/src/Exception/WebDriverException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Exception;
+
+class_exists('Facebook\WebDriver\Exception\WebDriverException');
+
+if (\false) {
+    class WebDriverException extends \Facebook\WebDriver\Exception\WebDriverException
+    {
+    }
+}

--- a/src/Firefox/FirefoxDriver.php
+++ b/src/Firefox/FirefoxDriver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Firefox;
+
+class_exists('Facebook\WebDriver\Firefox\FirefoxDriver');
+
+if (\false) {
+    class FirefoxDriver extends \Facebook\WebDriver\Firefox\FirefoxDriver
+    {
+    }
+}

--- a/src/Firefox/FirefoxDriverService.php
+++ b/src/Firefox/FirefoxDriverService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Firefox;
+
+class_exists('Facebook\WebDriver\Firefox\FirefoxDriverService');
+
+if (\false) {
+    class FirefoxDriverService extends \Facebook\WebDriver\Firefox\FirefoxDriverService
+    {
+    }
+}

--- a/src/Firefox/FirefoxOptions.php
+++ b/src/Firefox/FirefoxOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Firefox;
+
+class_exists('Facebook\WebDriver\Firefox\FirefoxOptions');
+
+if (\false) {
+    class FirefoxOptions extends \Facebook\WebDriver\Firefox\FirefoxOptions
+    {
+    }
+}

--- a/src/Firefox/FirefoxPreferences.php
+++ b/src/Firefox/FirefoxPreferences.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Firefox;
+
+class_exists('Facebook\WebDriver\Firefox\FirefoxPreferences');
+
+if (\false) {
+    class FirefoxPreferences extends \Facebook\WebDriver\Firefox\FirefoxPreferences
+    {
+    }
+}

--- a/src/Firefox/FirefoxProfile.php
+++ b/src/Firefox/FirefoxProfile.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Firefox;
+
+class_exists('Facebook\WebDriver\Firefox\FirefoxProfile');
+
+if (\false) {
+    class FirefoxProfile extends \Facebook\WebDriver\Firefox\FirefoxProfile
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverButtonReleaseAction.php
+++ b/src/Interactions/Internal/WebDriverButtonReleaseAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction');
+
+if (\false) {
+    class WebDriverButtonReleaseAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverClickAction.php
+++ b/src/Interactions/Internal/WebDriverClickAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverClickAction');
+
+if (\false) {
+    class WebDriverClickAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverClickAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverClickAndHoldAction.php
+++ b/src/Interactions/Internal/WebDriverClickAndHoldAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction');
+
+if (\false) {
+    class WebDriverClickAndHoldAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverContextClickAction.php
+++ b/src/Interactions/Internal/WebDriverContextClickAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverContextClickAction');
+
+if (\false) {
+    class WebDriverContextClickAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverContextClickAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverCoordinates.php
+++ b/src/Interactions/Internal/WebDriverCoordinates.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates');
+
+if (\false) {
+    class WebDriverCoordinates extends \Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverDoubleClickAction.php
+++ b/src/Interactions/Internal/WebDriverDoubleClickAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverDoubleClickAction');
+
+if (\false) {
+    class WebDriverDoubleClickAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverDoubleClickAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverKeyDownAction.php
+++ b/src/Interactions/Internal/WebDriverKeyDownAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverKeyDownAction');
+
+if (\false) {
+    class WebDriverKeyDownAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverKeyDownAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverKeyUpAction.php
+++ b/src/Interactions/Internal/WebDriverKeyUpAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverKeyUpAction');
+
+if (\false) {
+    class WebDriverKeyUpAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverKeyUpAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverKeysRelatedAction.php
+++ b/src/Interactions/Internal/WebDriverKeysRelatedAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction');
+
+if (\false) {
+    class WebDriverKeysRelatedAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverMouseAction.php
+++ b/src/Interactions/Internal/WebDriverMouseAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverMouseAction');
+
+if (\false) {
+    class WebDriverMouseAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverMouseAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverMouseMoveAction.php
+++ b/src/Interactions/Internal/WebDriverMouseMoveAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverMouseMoveAction');
+
+if (\false) {
+    class WebDriverMouseMoveAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverMouseMoveAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverMoveToOffsetAction.php
+++ b/src/Interactions/Internal/WebDriverMoveToOffsetAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction');
+
+if (\false) {
+    class WebDriverMoveToOffsetAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverSendKeysAction.php
+++ b/src/Interactions/Internal/WebDriverSendKeysAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverSendKeysAction');
+
+if (\false) {
+    class WebDriverSendKeysAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverSendKeysAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverSingleKeyAction.php
+++ b/src/Interactions/Internal/WebDriverSingleKeyAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Internal;
+
+class_exists('Facebook\WebDriver\Interactions\Internal\WebDriverSingleKeyAction');
+
+if (\false) {
+    class WebDriverSingleKeyAction extends \Facebook\WebDriver\Interactions\Internal\WebDriverSingleKeyAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverDoubleTapAction.php
+++ b/src/Interactions/Touch/WebDriverDoubleTapAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverDoubleTapAction');
+
+if (\false) {
+    class WebDriverDoubleTapAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverDoubleTapAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverDownAction.php
+++ b/src/Interactions/Touch/WebDriverDownAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverDownAction');
+
+if (\false) {
+    class WebDriverDownAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverDownAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverFlickAction.php
+++ b/src/Interactions/Touch/WebDriverFlickAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverFlickAction');
+
+if (\false) {
+    class WebDriverFlickAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverFlickAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverFlickFromElementAction.php
+++ b/src/Interactions/Touch/WebDriverFlickFromElementAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction');
+
+if (\false) {
+    class WebDriverFlickFromElementAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverLongPressAction.php
+++ b/src/Interactions/Touch/WebDriverLongPressAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverLongPressAction');
+
+if (\false) {
+    class WebDriverLongPressAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverLongPressAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverMoveAction.php
+++ b/src/Interactions/Touch/WebDriverMoveAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverMoveAction');
+
+if (\false) {
+    class WebDriverMoveAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverMoveAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverScrollAction.php
+++ b/src/Interactions/Touch/WebDriverScrollAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverScrollAction');
+
+if (\false) {
+    class WebDriverScrollAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverScrollAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverScrollFromElementAction.php
+++ b/src/Interactions/Touch/WebDriverScrollFromElementAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction');
+
+if (\false) {
+    class WebDriverScrollFromElementAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverTapAction.php
+++ b/src/Interactions/Touch/WebDriverTapAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverTapAction');
+
+if (\false) {
+    class WebDriverTapAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverTapAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverTouchAction.php
+++ b/src/Interactions/Touch/WebDriverTouchAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverTouchAction');
+
+if (\false) {
+    class WebDriverTouchAction extends \Facebook\WebDriver\Interactions\Touch\WebDriverTouchAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverTouchScreen.php
+++ b/src/Interactions/Touch/WebDriverTouchScreen.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions\Touch;
+
+class_exists('Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen');
+
+if (\false) {
+    class WebDriverTouchScreen extends \Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen
+    {
+    }
+}

--- a/src/Interactions/WebDriverActions.php
+++ b/src/Interactions/WebDriverActions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions;
+
+class_exists('Facebook\WebDriver\Interactions\WebDriverActions');
+
+if (\false) {
+    class WebDriverActions extends \Facebook\WebDriver\Interactions\WebDriverActions
+    {
+    }
+}

--- a/src/Interactions/WebDriverCompositeAction.php
+++ b/src/Interactions/WebDriverCompositeAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions;
+
+class_exists('Facebook\WebDriver\Interactions\WebDriverCompositeAction');
+
+if (\false) {
+    class WebDriverCompositeAction extends \Facebook\WebDriver\Interactions\WebDriverCompositeAction
+    {
+    }
+}

--- a/src/Interactions/WebDriverTouchActions.php
+++ b/src/Interactions/WebDriverTouchActions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Interactions;
+
+class_exists('Facebook\WebDriver\Interactions\WebDriverTouchActions');
+
+if (\false) {
+    class WebDriverTouchActions extends \Facebook\WebDriver\Interactions\WebDriverTouchActions
+    {
+    }
+}

--- a/src/Internal/WebDriverLocatable.php
+++ b/src/Internal/WebDriverLocatable.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Internal;
+
+class_exists('Facebook\WebDriver\Internal\WebDriverLocatable');
+
+if (\false) {
+    class WebDriverLocatable extends \Facebook\WebDriver\Internal\WebDriverLocatable
+    {
+    }
+}

--- a/src/JavaScriptExecutor.php
+++ b/src/JavaScriptExecutor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\JavaScriptExecutor');
+
+if (\false) {
+    class JavaScriptExecutor extends \Facebook\WebDriver\JavaScriptExecutor
+    {
+    }
+}

--- a/src/Local/LocalWebDriver.php
+++ b/src/Local/LocalWebDriver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Local;
+
+class_exists('Facebook\WebDriver\Local\LocalWebDriver');
+
+if (\false) {
+    class LocalWebDriver extends \Facebook\WebDriver\Local\LocalWebDriver
+    {
+    }
+}

--- a/src/Net/URLChecker.php
+++ b/src/Net/URLChecker.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Net;
+
+class_exists('Facebook\WebDriver\Net\URLChecker');
+
+if (\false) {
+    class URLChecker extends \Facebook\WebDriver\Net\URLChecker
+    {
+    }
+}

--- a/src/Remote/CustomWebDriverCommand.php
+++ b/src/Remote/CustomWebDriverCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\CustomWebDriverCommand');
+
+if (\false) {
+    class CustomWebDriverCommand extends \Facebook\WebDriver\Remote\CustomWebDriverCommand
+    {
+    }
+}

--- a/src/Remote/DesiredCapabilities.php
+++ b/src/Remote/DesiredCapabilities.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\DesiredCapabilities');
+
+if (\false) {
+    class DesiredCapabilities extends \Facebook\WebDriver\Remote\DesiredCapabilities
+    {
+    }
+}

--- a/src/Remote/DriverCommand.php
+++ b/src/Remote/DriverCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\DriverCommand');
+
+if (\false) {
+    class DriverCommand extends \Facebook\WebDriver\Remote\DriverCommand
+    {
+    }
+}

--- a/src/Remote/ExecuteMethod.php
+++ b/src/Remote/ExecuteMethod.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\ExecuteMethod');
+
+if (\false) {
+    class ExecuteMethod extends \Facebook\WebDriver\Remote\ExecuteMethod
+    {
+    }
+}

--- a/src/Remote/FileDetector.php
+++ b/src/Remote/FileDetector.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\FileDetector');
+
+if (\false) {
+    class FileDetector extends \Facebook\WebDriver\Remote\FileDetector
+    {
+    }
+}

--- a/src/Remote/HttpCommandExecutor.php
+++ b/src/Remote/HttpCommandExecutor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\HttpCommandExecutor');
+
+if (\false) {
+    class HttpCommandExecutor extends \Facebook\WebDriver\Remote\HttpCommandExecutor
+    {
+    }
+}

--- a/src/Remote/JsonWireCompat.php
+++ b/src/Remote/JsonWireCompat.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\JsonWireCompat');
+
+if (\false) {
+    class JsonWireCompat extends \Facebook\WebDriver\Remote\JsonWireCompat
+    {
+    }
+}

--- a/src/Remote/LocalFileDetector.php
+++ b/src/Remote/LocalFileDetector.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\LocalFileDetector');
+
+if (\false) {
+    class LocalFileDetector extends \Facebook\WebDriver\Remote\LocalFileDetector
+    {
+    }
+}

--- a/src/Remote/RemoteExecuteMethod.php
+++ b/src/Remote/RemoteExecuteMethod.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteExecuteMethod');
+
+if (\false) {
+    class RemoteExecuteMethod extends \Facebook\WebDriver\Remote\RemoteExecuteMethod
+    {
+    }
+}

--- a/src/Remote/RemoteKeyboard.php
+++ b/src/Remote/RemoteKeyboard.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteKeyboard');
+
+if (\false) {
+    class RemoteKeyboard extends \Facebook\WebDriver\Remote\RemoteKeyboard
+    {
+    }
+}

--- a/src/Remote/RemoteMouse.php
+++ b/src/Remote/RemoteMouse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteMouse');
+
+if (\false) {
+    class RemoteMouse extends \Facebook\WebDriver\Remote\RemoteMouse
+    {
+    }
+}

--- a/src/Remote/RemoteStatus.php
+++ b/src/Remote/RemoteStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteStatus');
+
+if (\false) {
+    class RemoteStatus extends \Facebook\WebDriver\Remote\RemoteStatus
+    {
+    }
+}

--- a/src/Remote/RemoteTargetLocator.php
+++ b/src/Remote/RemoteTargetLocator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteTargetLocator');
+
+if (\false) {
+    class RemoteTargetLocator extends \Facebook\WebDriver\Remote\RemoteTargetLocator
+    {
+    }
+}

--- a/src/Remote/RemoteTouchScreen.php
+++ b/src/Remote/RemoteTouchScreen.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteTouchScreen');
+
+if (\false) {
+    class RemoteTouchScreen extends \Facebook\WebDriver\Remote\RemoteTouchScreen
+    {
+    }
+}

--- a/src/Remote/RemoteWebDriver.php
+++ b/src/Remote/RemoteWebDriver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteWebDriver');
+
+if (\false) {
+    class RemoteWebDriver extends \Facebook\WebDriver\Remote\RemoteWebDriver
+    {
+    }
+}

--- a/src/Remote/RemoteWebElement.php
+++ b/src/Remote/RemoteWebElement.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\RemoteWebElement');
+
+if (\false) {
+    class RemoteWebElement extends \Facebook\WebDriver\Remote\RemoteWebElement
+    {
+    }
+}

--- a/src/Remote/Service/DriverCommandExecutor.php
+++ b/src/Remote/Service/DriverCommandExecutor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote\Service;
+
+class_exists('Facebook\WebDriver\Remote\Service\DriverCommandExecutor');
+
+if (\false) {
+    class DriverCommandExecutor extends \Facebook\WebDriver\Remote\Service\DriverCommandExecutor
+    {
+    }
+}

--- a/src/Remote/Service/DriverService.php
+++ b/src/Remote/Service/DriverService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote\Service;
+
+class_exists('Facebook\WebDriver\Remote\Service\DriverService');
+
+if (\false) {
+    class DriverService extends \Facebook\WebDriver\Remote\Service\DriverService
+    {
+    }
+}

--- a/src/Remote/UselessFileDetector.php
+++ b/src/Remote/UselessFileDetector.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\UselessFileDetector');
+
+if (\false) {
+    class UselessFileDetector extends \Facebook\WebDriver\Remote\UselessFileDetector
+    {
+    }
+}

--- a/src/Remote/WebDriverBrowserType.php
+++ b/src/Remote/WebDriverBrowserType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\WebDriverBrowserType');
+
+if (\false) {
+    class WebDriverBrowserType extends \Facebook\WebDriver\Remote\WebDriverBrowserType
+    {
+    }
+}

--- a/src/Remote/WebDriverCapabilityType.php
+++ b/src/Remote/WebDriverCapabilityType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\WebDriverCapabilityType');
+
+if (\false) {
+    class WebDriverCapabilityType extends \Facebook\WebDriver\Remote\WebDriverCapabilityType
+    {
+    }
+}

--- a/src/Remote/WebDriverCommand.php
+++ b/src/Remote/WebDriverCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\WebDriverCommand');
+
+if (\false) {
+    class WebDriverCommand extends \Facebook\WebDriver\Remote\WebDriverCommand
+    {
+    }
+}

--- a/src/Remote/WebDriverResponse.php
+++ b/src/Remote/WebDriverResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Remote;
+
+class_exists('Facebook\WebDriver\Remote\WebDriverResponse');
+
+if (\false) {
+    class WebDriverResponse extends \Facebook\WebDriver\Remote\WebDriverResponse
+    {
+    }
+}

--- a/src/Support/Events/EventFiringWebDriver.php
+++ b/src/Support/Events/EventFiringWebDriver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Support\Events;
+
+class_exists('Facebook\WebDriver\Support\Events\EventFiringWebDriver');
+
+if (\false) {
+    class EventFiringWebDriver extends \Facebook\WebDriver\Support\Events\EventFiringWebDriver
+    {
+    }
+}

--- a/src/Support/Events/EventFiringWebDriverNavigation.php
+++ b/src/Support/Events/EventFiringWebDriverNavigation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Support\Events;
+
+class_exists('Facebook\WebDriver\Support\Events\EventFiringWebDriverNavigation');
+
+if (\false) {
+    class EventFiringWebDriverNavigation extends \Facebook\WebDriver\Support\Events\EventFiringWebDriverNavigation
+    {
+    }
+}

--- a/src/Support/Events/EventFiringWebElement.php
+++ b/src/Support/Events/EventFiringWebElement.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Support\Events;
+
+class_exists('Facebook\WebDriver\Support\Events\EventFiringWebElement');
+
+if (\false) {
+    class EventFiringWebElement extends \Facebook\WebDriver\Support\Events\EventFiringWebElement
+    {
+    }
+}

--- a/src/Support/XPathEscaper.php
+++ b/src/Support/XPathEscaper.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver\Support;
+
+class_exists('Facebook\WebDriver\Support\XPathEscaper');
+
+if (\false) {
+    class XPathEscaper extends \Facebook\WebDriver\Support\XPathEscaper
+    {
+    }
+}

--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriver');
+
+if (\false) {
+    class WebDriver extends \Facebook\WebDriver\WebDriver
+    {
+    }
+}

--- a/src/WebDriverAction.php
+++ b/src/WebDriverAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverAction');
+
+if (\false) {
+    class WebDriverAction extends \Facebook\WebDriver\WebDriverAction
+    {
+    }
+}

--- a/src/WebDriverAlert.php
+++ b/src/WebDriverAlert.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverAlert');
+
+if (\false) {
+    class WebDriverAlert extends \Facebook\WebDriver\WebDriverAlert
+    {
+    }
+}

--- a/src/WebDriverBy.php
+++ b/src/WebDriverBy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverBy');
+
+if (\false) {
+    class WebDriverBy extends \Facebook\WebDriver\WebDriverBy
+    {
+    }
+}

--- a/src/WebDriverCapabilities.php
+++ b/src/WebDriverCapabilities.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverCapabilities');
+
+if (\false) {
+    class WebDriverCapabilities extends \Facebook\WebDriver\WebDriverCapabilities
+    {
+    }
+}

--- a/src/WebDriverCheckboxes.php
+++ b/src/WebDriverCheckboxes.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverCheckboxes');
+
+if (\false) {
+    class WebDriverCheckboxes extends \Facebook\WebDriver\WebDriverCheckboxes
+    {
+    }
+}

--- a/src/WebDriverCommandExecutor.php
+++ b/src/WebDriverCommandExecutor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverCommandExecutor');
+
+if (\false) {
+    class WebDriverCommandExecutor extends \Facebook\WebDriver\WebDriverCommandExecutor
+    {
+    }
+}

--- a/src/WebDriverDimension.php
+++ b/src/WebDriverDimension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverDimension');
+
+if (\false) {
+    class WebDriverDimension extends \Facebook\WebDriver\WebDriverDimension
+    {
+    }
+}

--- a/src/WebDriverDispatcher.php
+++ b/src/WebDriverDispatcher.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverDispatcher');
+
+if (\false) {
+    class WebDriverDispatcher extends \Facebook\WebDriver\WebDriverDispatcher
+    {
+    }
+}

--- a/src/WebDriverElement.php
+++ b/src/WebDriverElement.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverElement');
+
+if (\false) {
+    class WebDriverElement extends \Facebook\WebDriver\WebDriverElement
+    {
+    }
+}

--- a/src/WebDriverEventListener.php
+++ b/src/WebDriverEventListener.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverEventListener');
+
+if (\false) {
+    class WebDriverEventListener extends \Facebook\WebDriver\WebDriverEventListener
+    {
+    }
+}

--- a/src/WebDriverExpectedCondition.php
+++ b/src/WebDriverExpectedCondition.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverExpectedCondition');
+
+if (\false) {
+    class WebDriverExpectedCondition extends \Facebook\WebDriver\WebDriverExpectedCondition
+    {
+    }
+}

--- a/src/WebDriverHasInputDevices.php
+++ b/src/WebDriverHasInputDevices.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverHasInputDevices');
+
+if (\false) {
+    class WebDriverHasInputDevices extends \Facebook\WebDriver\WebDriverHasInputDevices
+    {
+    }
+}

--- a/src/WebDriverKeyboard.php
+++ b/src/WebDriverKeyboard.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverKeyboard');
+
+if (\false) {
+    class WebDriverKeyboard extends \Facebook\WebDriver\WebDriverKeyboard
+    {
+    }
+}

--- a/src/WebDriverKeys.php
+++ b/src/WebDriverKeys.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverKeys');
+
+if (\false) {
+    class WebDriverKeys extends \Facebook\WebDriver\WebDriverKeys
+    {
+    }
+}

--- a/src/WebDriverMouse.php
+++ b/src/WebDriverMouse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverMouse');
+
+if (\false) {
+    class WebDriverMouse extends \Facebook\WebDriver\WebDriverMouse
+    {
+    }
+}

--- a/src/WebDriverNavigation.php
+++ b/src/WebDriverNavigation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverNavigation');
+
+if (\false) {
+    class WebDriverNavigation extends \Facebook\WebDriver\WebDriverNavigation
+    {
+    }
+}

--- a/src/WebDriverNavigationInterface.php
+++ b/src/WebDriverNavigationInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverNavigationInterface');
+
+if (\false) {
+    class WebDriverNavigationInterface extends \Facebook\WebDriver\WebDriverNavigationInterface
+    {
+    }
+}

--- a/src/WebDriverOptions.php
+++ b/src/WebDriverOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverOptions');
+
+if (\false) {
+    class WebDriverOptions extends \Facebook\WebDriver\WebDriverOptions
+    {
+    }
+}

--- a/src/WebDriverPlatform.php
+++ b/src/WebDriverPlatform.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverPlatform');
+
+if (\false) {
+    class WebDriverPlatform extends \Facebook\WebDriver\WebDriverPlatform
+    {
+    }
+}

--- a/src/WebDriverPoint.php
+++ b/src/WebDriverPoint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverPoint');
+
+if (\false) {
+    class WebDriverPoint extends \Facebook\WebDriver\WebDriverPoint
+    {
+    }
+}

--- a/src/WebDriverRadios.php
+++ b/src/WebDriverRadios.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverRadios');
+
+if (\false) {
+    class WebDriverRadios extends \Facebook\WebDriver\WebDriverRadios
+    {
+    }
+}

--- a/src/WebDriverSearchContext.php
+++ b/src/WebDriverSearchContext.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverSearchContext');
+
+if (\false) {
+    class WebDriverSearchContext extends \Facebook\WebDriver\WebDriverSearchContext
+    {
+    }
+}

--- a/src/WebDriverSelect.php
+++ b/src/WebDriverSelect.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverSelect');
+
+if (\false) {
+    class WebDriverSelect extends \Facebook\WebDriver\WebDriverSelect
+    {
+    }
+}

--- a/src/WebDriverSelectInterface.php
+++ b/src/WebDriverSelectInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverSelectInterface');
+
+if (\false) {
+    class WebDriverSelectInterface extends \Facebook\WebDriver\WebDriverSelectInterface
+    {
+    }
+}

--- a/src/WebDriverTargetLocator.php
+++ b/src/WebDriverTargetLocator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverTargetLocator');
+
+if (\false) {
+    class WebDriverTargetLocator extends \Facebook\WebDriver\WebDriverTargetLocator
+    {
+    }
+}

--- a/src/WebDriverTimeouts.php
+++ b/src/WebDriverTimeouts.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverTimeouts');
+
+if (\false) {
+    class WebDriverTimeouts extends \Facebook\WebDriver\WebDriverTimeouts
+    {
+    }
+}

--- a/src/WebDriverUpAction.php
+++ b/src/WebDriverUpAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverUpAction');
+
+if (\false) {
+    class WebDriverUpAction extends \Facebook\WebDriver\WebDriverUpAction
+    {
+    }
+}

--- a/src/WebDriverWait.php
+++ b/src/WebDriverWait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverWait');
+
+if (\false) {
+    class WebDriverWait extends \Facebook\WebDriver\WebDriverWait
+    {
+    }
+}

--- a/src/WebDriverWindow.php
+++ b/src/WebDriverWindow.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpWebDriver;
+
+class_exists('Facebook\WebDriver\WebDriverWindow');
+
+if (\false) {
+    class WebDriverWindow extends \Facebook\WebDriver\WebDriverWindow
+    {
+    }
+}


### PR DESCRIPTION
Adds `PhpWebDriver` as an alias for `Facebook\WebDriver`, except for `@deprecated` classes.

This allows changing the vendor namespace without a backwards compatibility break.

This is similar to how Twig handled the namespace change.