### PR TITLE
Add new vendor namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $serverUrl = 'http://localhost:4444';
 Now you can start browser of your choice:
 
 ```php
-use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
 
 // Chrome
 $driver = RemoteWebDriver::create($serverUrl, DesiredCapabilities::chrome());
@@ -134,8 +134,8 @@ Desired capabilities define properties of the browser you are about to start.
 They can be customized:
 
 ```php
-use Facebook\WebDriver\Firefox\FirefoxOptions;
-use Facebook\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Firefox\FirefoxOptions;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
 
 $desiredCapabilities = DesiredCapabilities::firefox();
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Facebook\\WebDriver\\": "lib/"
+      "PhpWebDriver\\WebDriver\\": "lib/"
     },
     "files": [
       "lib/Exception/TimeoutException.php"
@@ -48,7 +48,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Facebook\\WebDriver\\": [
+      "PhpWebDriver\\WebDriver\\": [
         "tests/unit",
         "tests/functional"
       ]

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
   },
   "autoload": {
     "psr-4": {
-      "PhpWebDriver\\WebDriver\\": "lib/"
+      "PhpWebDriver\\WebDriver\\": "lib/",
+      "Facebook\\WebDriver\\": "src/"
     },
     "files": [
       "lib/Exception/TimeoutException.php"

--- a/example.php
+++ b/example.php
@@ -3,10 +3,10 @@
 // An example of using php-webdriver.
 // Do not forget to run composer install before. You must also have Selenium server started and listening on port 4444.
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
 
 require_once('vendor/autoload.php');
 

--- a/lib/AbstractWebDriverCheckboxOrRadio.php
+++ b/lib/AbstractWebDriverCheckboxOrRadio.php
@@ -238,3 +238,5 @@ abstract class AbstractWebDriverCheckboxOrRadio implements WebDriverSelectInterf
         }
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\AbstractWebDriverCheckboxOrRadio::class, \Facebook\WebDriver\AbstractWebDriverCheckboxOrRadio::class);

--- a/lib/AbstractWebDriverCheckboxOrRadio.php
+++ b/lib/AbstractWebDriverCheckboxOrRadio.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\UnexpectedTagNameException;
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Support\XPathEscaper;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Support\XPathEscaper;
 
 /**
  * Provides helper methods for checkboxes and radio buttons.

--- a/lib/Chrome/ChromeDevToolsDriver.php
+++ b/lib/Chrome/ChromeDevToolsDriver.php
@@ -44,3 +44,5 @@ class ChromeDevToolsDriver
         );
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Chrome\ChromeDevToolsDriver::class, \Facebook\WebDriver\Chrome\ChromeDevToolsDriver::class);

--- a/lib/Chrome/ChromeDevToolsDriver.php
+++ b/lib/Chrome/ChromeDevToolsDriver.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Chrome;
+namespace PhpWebDriver\WebDriver\Chrome;
 
-use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
 
 /**
  * Provide access to Chrome DevTools Protocol (CDP) commands via HTTP endpoint of Chromedriver.

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -108,3 +108,5 @@ class ChromeDriver extends LocalWebDriver
         return $this->devTools;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Chrome\ChromeDriver::class, \Facebook\WebDriver\Chrome\ChromeDriver::class);

--- a/lib/Chrome/ChromeDriver.php
+++ b/lib/Chrome/ChromeDriver.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Facebook\WebDriver\Chrome;
+namespace PhpWebDriver\WebDriver\Chrome;
 
-use Facebook\WebDriver\Local\LocalWebDriver;
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
-use Facebook\WebDriver\Remote\WebDriverCommand;
+use PhpWebDriver\WebDriver\Local\LocalWebDriver;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor;
+use PhpWebDriver\WebDriver\Remote\WebDriverCommand;
 
 class ChromeDriver extends LocalWebDriver
 {

--- a/lib/Chrome/ChromeDriverService.php
+++ b/lib/Chrome/ChromeDriverService.php
@@ -35,3 +35,5 @@ class ChromeDriverService extends DriverService
         return new static($pathToExecutable, $port, $args);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Chrome\ChromeDriverService::class, \Facebook\WebDriver\Chrome\ChromeDriverService::class);

--- a/lib/Chrome/ChromeDriverService.php
+++ b/lib/Chrome/ChromeDriverService.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Chrome;
+namespace PhpWebDriver\WebDriver\Chrome;
 
-use Facebook\WebDriver\Remote\Service\DriverService;
+use PhpWebDriver\WebDriver\Remote\Service\DriverService;
 
 class ChromeDriverService extends DriverService
 {

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Chrome;
+namespace PhpWebDriver\WebDriver\Chrome;
 
-use Facebook\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
 use JsonSerializable;
 
 /**

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -178,3 +178,5 @@ class ChromeOptions implements JsonSerializable
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Chrome\ChromeOptions::class, \Facebook\WebDriver\Chrome\ChromeOptions::class);

--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -255,3 +255,5 @@ class Cookie implements \ArrayAccess
         }
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Cookie::class, \Facebook\WebDriver\Cookie::class);

--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 use InvalidArgumentException;
 

--- a/lib/Exception/DriverServerDiedException.php
+++ b/lib/Exception/DriverServerDiedException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * The driver server process is unexpectedly no longer available.

--- a/lib/Exception/DriverServerDiedException.php
+++ b/lib/Exception/DriverServerDiedException.php
@@ -13,3 +13,5 @@ class DriverServerDiedException extends WebDriverException
         \Exception::__construct($this->getMessage(), $this->getCode(), $previous);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\DriverServerDiedException::class, \Facebook\WebDriver\Exception\DriverServerDiedException::class);

--- a/lib/Exception/ElementClickInterceptedException.php
+++ b/lib/Exception/ElementClickInterceptedException.php
@@ -9,3 +9,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class ElementClickInterceptedException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\ElementClickInterceptedException::class, \Facebook\WebDriver\Exception\ElementClickInterceptedException::class);

--- a/lib/Exception/ElementClickInterceptedException.php
+++ b/lib/Exception/ElementClickInterceptedException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * The Element Click command could not be completed because the element receiving the events is obscuring the element

--- a/lib/Exception/ElementNotInteractableException.php
+++ b/lib/Exception/ElementNotInteractableException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A command could not be completed because the element is not pointer- or keyboard interactable.

--- a/lib/Exception/ElementNotInteractableException.php
+++ b/lib/Exception/ElementNotInteractableException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class ElementNotInteractableException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\ElementNotInteractableException::class, \Facebook\WebDriver\Exception\ElementNotInteractableException::class);

--- a/lib/Exception/ElementNotSelectableException.php
+++ b/lib/Exception/ElementNotSelectableException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class ElementNotSelectableException extends ElementNotInteractableException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\ElementNotSelectableException::class, \Facebook\WebDriver\Exception\ElementNotSelectableException::class);

--- a/lib/Exception/ElementNotSelectableException.php
+++ b/lib/Exception/ElementNotSelectableException.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
- * @deprecated Use Facebook\WebDriver\Exception\ElementNotInteractableException
+ * @deprecated Use PhpWebDriver\WebDriver\Exception\ElementNotInteractableException
  */
 class ElementNotSelectableException extends ElementNotInteractableException
 {

--- a/lib/Exception/ElementNotVisibleException.php
+++ b/lib/Exception/ElementNotVisibleException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class ElementNotVisibleException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\ElementNotVisibleException::class, \Facebook\WebDriver\Exception\ElementNotVisibleException::class);

--- a/lib/Exception/ElementNotVisibleException.php
+++ b/lib/Exception/ElementNotVisibleException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/ExpectedException.php
+++ b/lib/Exception/ExpectedException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class ExpectedException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\ExpectedException::class, \Facebook\WebDriver\Exception\ExpectedException::class);

--- a/lib/Exception/ExpectedException.php
+++ b/lib/Exception/ExpectedException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/IMEEngineActivationFailedException.php
+++ b/lib/Exception/IMEEngineActivationFailedException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/IMEEngineActivationFailedException.php
+++ b/lib/Exception/IMEEngineActivationFailedException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class IMEEngineActivationFailedException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\IMEEngineActivationFailedException::class, \Facebook\WebDriver\Exception\IMEEngineActivationFailedException::class);

--- a/lib/Exception/IMENotAvailableException.php
+++ b/lib/Exception/IMENotAvailableException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class IMENotAvailableException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\IMENotAvailableException::class, \Facebook\WebDriver\Exception\IMENotAvailableException::class);

--- a/lib/Exception/IMENotAvailableException.php
+++ b/lib/Exception/IMENotAvailableException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/IndexOutOfBoundsException.php
+++ b/lib/Exception/IndexOutOfBoundsException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class IndexOutOfBoundsException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\IndexOutOfBoundsException::class, \Facebook\WebDriver\Exception\IndexOutOfBoundsException::class);

--- a/lib/Exception/IndexOutOfBoundsException.php
+++ b/lib/Exception/IndexOutOfBoundsException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/InsecureCertificateException.php
+++ b/lib/Exception/InsecureCertificateException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * Navigation caused the user agent to hit a certificate warning, which is usually the result of an expired

--- a/lib/Exception/InsecureCertificateException.php
+++ b/lib/Exception/InsecureCertificateException.php
@@ -9,3 +9,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class InsecureCertificateException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\InsecureCertificateException::class, \Facebook\WebDriver\Exception\InsecureCertificateException::class);

--- a/lib/Exception/InvalidArgumentException.php
+++ b/lib/Exception/InvalidArgumentException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class InvalidArgumentException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\InvalidArgumentException::class, \Facebook\WebDriver\Exception\InvalidArgumentException::class);

--- a/lib/Exception/InvalidArgumentException.php
+++ b/lib/Exception/InvalidArgumentException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * The arguments passed to a command are either invalid or malformed.

--- a/lib/Exception/InvalidCookieDomainException.php
+++ b/lib/Exception/InvalidCookieDomainException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class InvalidCookieDomainException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\InvalidCookieDomainException::class, \Facebook\WebDriver\Exception\InvalidCookieDomainException::class);

--- a/lib/Exception/InvalidCookieDomainException.php
+++ b/lib/Exception/InvalidCookieDomainException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * An illegal attempt was made to set a cookie under a different domain than the current page.

--- a/lib/Exception/InvalidCoordinatesException.php
+++ b/lib/Exception/InvalidCoordinatesException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/InvalidCoordinatesException.php
+++ b/lib/Exception/InvalidCoordinatesException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class InvalidCoordinatesException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\InvalidCoordinatesException::class, \Facebook\WebDriver\Exception\InvalidCoordinatesException::class);

--- a/lib/Exception/InvalidElementStateException.php
+++ b/lib/Exception/InvalidElementStateException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A command could not be completed because the element is in an invalid state, e.g. attempting to clear an element

--- a/lib/Exception/InvalidElementStateException.php
+++ b/lib/Exception/InvalidElementStateException.php
@@ -9,3 +9,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class InvalidElementStateException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\InvalidElementStateException::class, \Facebook\WebDriver\Exception\InvalidElementStateException::class);

--- a/lib/Exception/InvalidSelectorException.php
+++ b/lib/Exception/InvalidSelectorException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * Argument was an invalid selector.

--- a/lib/Exception/InvalidSelectorException.php
+++ b/lib/Exception/InvalidSelectorException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class InvalidSelectorException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\InvalidSelectorException::class, \Facebook\WebDriver\Exception\InvalidSelectorException::class);

--- a/lib/Exception/InvalidSessionIdException.php
+++ b/lib/Exception/InvalidSessionIdException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * Occurs if the given session id is not in the list of active sessions, meaning the session either does not exist

--- a/lib/Exception/InvalidSessionIdException.php
+++ b/lib/Exception/InvalidSessionIdException.php
@@ -9,3 +9,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class InvalidSessionIdException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\InvalidSessionIdException::class, \Facebook\WebDriver\Exception\InvalidSessionIdException::class);

--- a/lib/Exception/JavascriptErrorException.php
+++ b/lib/Exception/JavascriptErrorException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class JavascriptErrorException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\JavascriptErrorException::class, \Facebook\WebDriver\Exception\JavascriptErrorException::class);

--- a/lib/Exception/JavascriptErrorException.php
+++ b/lib/Exception/JavascriptErrorException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * An error occurred while executing JavaScript supplied by the user.

--- a/lib/Exception/MoveTargetOutOfBoundsException.php
+++ b/lib/Exception/MoveTargetOutOfBoundsException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class MoveTargetOutOfBoundsException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\MoveTargetOutOfBoundsException::class, \Facebook\WebDriver\Exception\MoveTargetOutOfBoundsException::class);

--- a/lib/Exception/MoveTargetOutOfBoundsException.php
+++ b/lib/Exception/MoveTargetOutOfBoundsException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * The target for mouse interaction is not in the browser’s viewport and cannot be brought into that viewport.

--- a/lib/Exception/NoAlertOpenException.php
+++ b/lib/Exception/NoAlertOpenException.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
- * @deprecated Use Facebook\WebDriver\Exception\NoSuchAlertException
+ * @deprecated Use PhpWebDriver\WebDriver\Exception\NoSuchAlertException
  */
 class NoAlertOpenException extends NoSuchAlertException
 {

--- a/lib/Exception/NoAlertOpenException.php
+++ b/lib/Exception/NoAlertOpenException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoAlertOpenException extends NoSuchAlertException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoAlertOpenException::class, \Facebook\WebDriver\Exception\NoAlertOpenException::class);

--- a/lib/Exception/NoCollectionException.php
+++ b/lib/Exception/NoCollectionException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoCollectionException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoCollectionException::class, \Facebook\WebDriver\Exception\NoCollectionException::class);

--- a/lib/Exception/NoCollectionException.php
+++ b/lib/Exception/NoCollectionException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/NoScriptResultException.php
+++ b/lib/Exception/NoScriptResultException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoScriptResultException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoScriptResultException::class, \Facebook\WebDriver\Exception\NoScriptResultException::class);

--- a/lib/Exception/NoScriptResultException.php
+++ b/lib/Exception/NoScriptResultException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/NoStringException.php
+++ b/lib/Exception/NoStringException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoStringException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoStringException::class, \Facebook\WebDriver\Exception\NoStringException::class);

--- a/lib/Exception/NoStringException.php
+++ b/lib/Exception/NoStringException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/NoStringLengthException.php
+++ b/lib/Exception/NoStringLengthException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoStringLengthException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoStringLengthException::class, \Facebook\WebDriver\Exception\NoStringLengthException::class);

--- a/lib/Exception/NoStringLengthException.php
+++ b/lib/Exception/NoStringLengthException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/NoStringWrapperException.php
+++ b/lib/Exception/NoStringWrapperException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoStringWrapperException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoStringWrapperException::class, \Facebook\WebDriver\Exception\NoStringWrapperException::class);

--- a/lib/Exception/NoStringWrapperException.php
+++ b/lib/Exception/NoStringWrapperException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/NoSuchAlertException.php
+++ b/lib/Exception/NoSuchAlertException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchAlertException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchAlertException::class, \Facebook\WebDriver\Exception\NoSuchAlertException::class);

--- a/lib/Exception/NoSuchAlertException.php
+++ b/lib/Exception/NoSuchAlertException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * An attempt was made to operate on a modal dialog when one was not open.

--- a/lib/Exception/NoSuchCollectionException.php
+++ b/lib/Exception/NoSuchCollectionException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchCollectionException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchCollectionException::class, \Facebook\WebDriver\Exception\NoSuchCollectionException::class);

--- a/lib/Exception/NoSuchCollectionException.php
+++ b/lib/Exception/NoSuchCollectionException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/NoSuchCookieException.php
+++ b/lib/Exception/NoSuchCookieException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * No cookie matching the given path name was found amongst the associated cookies of the current browsing context’s

--- a/lib/Exception/NoSuchCookieException.php
+++ b/lib/Exception/NoSuchCookieException.php
@@ -9,3 +9,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchCookieException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchCookieException::class, \Facebook\WebDriver\Exception\NoSuchCookieException::class);

--- a/lib/Exception/NoSuchDocumentException.php
+++ b/lib/Exception/NoSuchDocumentException.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
- * @deprecated Use Facebook\WebDriver\Exception\NoSuchWindowException
+ * @deprecated Use PhpWebDriver\WebDriver\Exception\NoSuchWindowException
  */
 class NoSuchDocumentException extends NoSuchWindowException
 {

--- a/lib/Exception/NoSuchDocumentException.php
+++ b/lib/Exception/NoSuchDocumentException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchDocumentException extends NoSuchWindowException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchDocumentException::class, \Facebook\WebDriver\Exception\NoSuchDocumentException::class);

--- a/lib/Exception/NoSuchDriverException.php
+++ b/lib/Exception/NoSuchDriverException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchDriverException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchDriverException::class, \Facebook\WebDriver\Exception\NoSuchDriverException::class);

--- a/lib/Exception/NoSuchDriverException.php
+++ b/lib/Exception/NoSuchDriverException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/NoSuchElementException.php
+++ b/lib/Exception/NoSuchElementException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchElementException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchElementException::class, \Facebook\WebDriver\Exception\NoSuchElementException::class);

--- a/lib/Exception/NoSuchElementException.php
+++ b/lib/Exception/NoSuchElementException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * An element could not be located on the page using the given search parameters.

--- a/lib/Exception/NoSuchFrameException.php
+++ b/lib/Exception/NoSuchFrameException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchFrameException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchFrameException::class, \Facebook\WebDriver\Exception\NoSuchFrameException::class);

--- a/lib/Exception/NoSuchFrameException.php
+++ b/lib/Exception/NoSuchFrameException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A command to switch to a frame could not be satisfied because the frame could not be found.

--- a/lib/Exception/NoSuchWindowException.php
+++ b/lib/Exception/NoSuchWindowException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A command to switch to a window could not be satisfied because the window could not be found.

--- a/lib/Exception/NoSuchWindowException.php
+++ b/lib/Exception/NoSuchWindowException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NoSuchWindowException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NoSuchWindowException::class, \Facebook\WebDriver\Exception\NoSuchWindowException::class);

--- a/lib/Exception/NullPointerException.php
+++ b/lib/Exception/NullPointerException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class NullPointerException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\NullPointerException::class, \Facebook\WebDriver\Exception\NullPointerException::class);

--- a/lib/Exception/NullPointerException.php
+++ b/lib/Exception/NullPointerException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Exception/ScriptTimeoutException.php
+++ b/lib/Exception/ScriptTimeoutException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class ScriptTimeoutException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\ScriptTimeoutException::class, \Facebook\WebDriver\Exception\ScriptTimeoutException::class);

--- a/lib/Exception/ScriptTimeoutException.php
+++ b/lib/Exception/ScriptTimeoutException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A script did not complete before its timeout expired.

--- a/lib/Exception/SessionNotCreatedException.php
+++ b/lib/Exception/SessionNotCreatedException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class SessionNotCreatedException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\SessionNotCreatedException::class, \Facebook\WebDriver\Exception\SessionNotCreatedException::class);

--- a/lib/Exception/SessionNotCreatedException.php
+++ b/lib/Exception/SessionNotCreatedException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A new session could not be created.

--- a/lib/Exception/StaleElementReferenceException.php
+++ b/lib/Exception/StaleElementReferenceException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class StaleElementReferenceException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\StaleElementReferenceException::class, \Facebook\WebDriver\Exception\StaleElementReferenceException::class);

--- a/lib/Exception/StaleElementReferenceException.php
+++ b/lib/Exception/StaleElementReferenceException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A command failed because the referenced element is no longer attached to the DOM.

--- a/lib/Exception/TimeoutException.php
+++ b/lib/Exception/TimeoutException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * An operation did not complete before its timeout expired.

--- a/lib/Exception/TimeoutException.php
+++ b/lib/Exception/TimeoutException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class TimeoutException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\TimeoutException::class, \Facebook\WebDriver\Exception\TimeoutException::class);

--- a/lib/Exception/UnableToCaptureScreenException.php
+++ b/lib/Exception/UnableToCaptureScreenException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A screen capture was made impossible.

--- a/lib/Exception/UnableToCaptureScreenException.php
+++ b/lib/Exception/UnableToCaptureScreenException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnableToCaptureScreenException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnableToCaptureScreenException::class, \Facebook\WebDriver\Exception\UnableToCaptureScreenException::class);

--- a/lib/Exception/UnableToSetCookieException.php
+++ b/lib/Exception/UnableToSetCookieException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnableToSetCookieException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnableToSetCookieException::class, \Facebook\WebDriver\Exception\UnableToSetCookieException::class);

--- a/lib/Exception/UnableToSetCookieException.php
+++ b/lib/Exception/UnableToSetCookieException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A command to set a cookie’s value could not be satisfied.

--- a/lib/Exception/UnexpectedAlertOpenException.php
+++ b/lib/Exception/UnexpectedAlertOpenException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A modal dialog was open, blocking this operation.

--- a/lib/Exception/UnexpectedAlertOpenException.php
+++ b/lib/Exception/UnexpectedAlertOpenException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnexpectedAlertOpenException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnexpectedAlertOpenException::class, \Facebook\WebDriver\Exception\UnexpectedAlertOpenException::class);

--- a/lib/Exception/UnexpectedJavascriptException.php
+++ b/lib/Exception/UnexpectedJavascriptException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnexpectedJavascriptException extends JavascriptErrorException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnexpectedJavascriptException::class, \Facebook\WebDriver\Exception\UnexpectedJavascriptException::class);

--- a/lib/Exception/UnexpectedJavascriptException.php
+++ b/lib/Exception/UnexpectedJavascriptException.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
- * @deprecated Use Facebook\WebDriver\Exception\JavascriptErrorException
+ * @deprecated Use PhpWebDriver\WebDriver\Exception\JavascriptErrorException
  */
 class UnexpectedJavascriptException extends JavascriptErrorException
 {

--- a/lib/Exception/UnexpectedTagNameException.php
+++ b/lib/Exception/UnexpectedTagNameException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 class UnexpectedTagNameException extends WebDriverException
 {

--- a/lib/Exception/UnexpectedTagNameException.php
+++ b/lib/Exception/UnexpectedTagNameException.php
@@ -21,3 +21,5 @@ class UnexpectedTagNameException extends WebDriverException
         );
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException::class, \Facebook\WebDriver\Exception\UnexpectedTagNameException::class);

--- a/lib/Exception/UnknownCommandException.php
+++ b/lib/Exception/UnknownCommandException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * A command could not be executed because the remote end is not aware of it.

--- a/lib/Exception/UnknownCommandException.php
+++ b/lib/Exception/UnknownCommandException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnknownCommandException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnknownCommandException::class, \Facebook\WebDriver\Exception\UnknownCommandException::class);

--- a/lib/Exception/UnknownErrorException.php
+++ b/lib/Exception/UnknownErrorException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * An unknown error occurred in the remote end while processing the command.

--- a/lib/Exception/UnknownErrorException.php
+++ b/lib/Exception/UnknownErrorException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnknownErrorException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnknownErrorException::class, \Facebook\WebDriver\Exception\UnknownErrorException::class);

--- a/lib/Exception/UnknownMethodException.php
+++ b/lib/Exception/UnknownMethodException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * The requested command matched a known URL but did not match an method for that URL.

--- a/lib/Exception/UnknownMethodException.php
+++ b/lib/Exception/UnknownMethodException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnknownMethodException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnknownMethodException::class, \Facebook\WebDriver\Exception\UnknownMethodException::class);

--- a/lib/Exception/UnknownServerException.php
+++ b/lib/Exception/UnknownServerException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnknownServerException extends UnknownErrorException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnknownServerException::class, \Facebook\WebDriver\Exception\UnknownServerException::class);

--- a/lib/Exception/UnknownServerException.php
+++ b/lib/Exception/UnknownServerException.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
- * @deprecated Use Facebook\WebDriver\Exception\UnknownErrorException
+ * @deprecated Use PhpWebDriver\WebDriver\Exception\UnknownErrorException
  */
 class UnknownServerException extends UnknownErrorException
 {

--- a/lib/Exception/UnrecognizedExceptionException.php
+++ b/lib/Exception/UnrecognizedExceptionException.php
@@ -5,3 +5,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnrecognizedExceptionException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnrecognizedExceptionException::class, \Facebook\WebDriver\Exception\UnrecognizedExceptionException::class);

--- a/lib/Exception/UnrecognizedExceptionException.php
+++ b/lib/Exception/UnrecognizedExceptionException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 class UnrecognizedExceptionException extends WebDriverException
 {

--- a/lib/Exception/UnsupportedOperationException.php
+++ b/lib/Exception/UnsupportedOperationException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class UnsupportedOperationException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\UnsupportedOperationException::class, \Facebook\WebDriver\Exception\UnsupportedOperationException::class);

--- a/lib/Exception/UnsupportedOperationException.php
+++ b/lib/Exception/UnsupportedOperationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * Indicates that a command that should have executed properly cannot be supported for some reason.

--- a/lib/Exception/WebDriverCurlException.php
+++ b/lib/Exception/WebDriverCurlException.php
@@ -5,3 +5,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class WebDriverCurlException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\WebDriverCurlException::class, \Facebook\WebDriver\Exception\WebDriverCurlException::class);

--- a/lib/Exception/WebDriverCurlException.php
+++ b/lib/Exception/WebDriverCurlException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 class WebDriverCurlException extends WebDriverException
 {

--- a/lib/Exception/WebDriverException.php
+++ b/lib/Exception/WebDriverException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 use Exception;
 

--- a/lib/Exception/WebDriverException.php
+++ b/lib/Exception/WebDriverException.php
@@ -220,3 +220,5 @@ class WebDriverException extends Exception
         }
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\WebDriverException::class, \Facebook\WebDriver\Exception\WebDriverException::class);

--- a/lib/Exception/XPathLookupException.php
+++ b/lib/Exception/XPathLookupException.php
@@ -8,3 +8,5 @@ namespace PhpWebDriver\WebDriver\Exception;
 class XPathLookupException extends WebDriverException
 {
 }
+
+class_alias(\PhpWebDriver\WebDriver\Exception\XPathLookupException::class, \Facebook\WebDriver\Exception\XPathLookupException::class);

--- a/lib/Exception/XPathLookupException.php
+++ b/lib/Exception/XPathLookupException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 /**
  * @deprecated Removed in W3C WebDriver, see https://github.com/php-webdriver/php-webdriver/pull/686

--- a/lib/Firefox/FirefoxDriver.php
+++ b/lib/Firefox/FirefoxDriver.php
@@ -62,3 +62,5 @@ class FirefoxDriver extends LocalWebDriver
         return new static($executor, $sessionId, $returnedCapabilities, true);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Firefox\FirefoxDriver::class, \Facebook\WebDriver\Firefox\FirefoxDriver::class);

--- a/lib/Firefox/FirefoxDriver.php
+++ b/lib/Firefox/FirefoxDriver.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
-use Facebook\WebDriver\Local\LocalWebDriver;
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
-use Facebook\WebDriver\Remote\WebDriverCommand;
+use PhpWebDriver\WebDriver\Local\LocalWebDriver;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor;
+use PhpWebDriver\WebDriver\Remote\WebDriverCommand;
 
 class FirefoxDriver extends LocalWebDriver
 {

--- a/lib/Firefox/FirefoxDriverService.php
+++ b/lib/Firefox/FirefoxDriverService.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
-use Facebook\WebDriver\Remote\Service\DriverService;
+use PhpWebDriver\WebDriver\Remote\Service\DriverService;
 
 class FirefoxDriverService extends DriverService
 {

--- a/lib/Firefox/FirefoxDriverService.php
+++ b/lib/Firefox/FirefoxDriverService.php
@@ -32,3 +32,5 @@ class FirefoxDriverService extends DriverService
         return new static($pathToExecutable, $port, $args);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Firefox\FirefoxDriverService::class, \Facebook\WebDriver\Firefox\FirefoxDriverService::class);

--- a/lib/Firefox/FirefoxOptions.php
+++ b/lib/Firefox/FirefoxOptions.php
@@ -106,3 +106,5 @@ class FirefoxOptions implements \JsonSerializable
         return new \ArrayObject($this->toArray());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Firefox\FirefoxOptions::class, \Facebook\WebDriver\Firefox\FirefoxOptions::class);

--- a/lib/Firefox/FirefoxOptions.php
+++ b/lib/Firefox/FirefoxOptions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
 /**
  * Class to manage Firefox-specific capabilities

--- a/lib/Firefox/FirefoxPreferences.php
+++ b/lib/Firefox/FirefoxPreferences.php
@@ -23,3 +23,5 @@ class FirefoxPreferences
     {
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Firefox\FirefoxPreferences::class, \Facebook\WebDriver\Firefox\FirefoxPreferences::class);

--- a/lib/Firefox/FirefoxPreferences.php
+++ b/lib/Firefox/FirefoxPreferences.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
 /**
  * Constants of common Firefox profile preferences (about:config values).

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
-use Facebook\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
 use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -289,3 +289,5 @@ class FirefoxProfile
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Firefox\FirefoxProfile::class, \Facebook\WebDriver\Firefox\FirefoxProfile::class);

--- a/lib/Interactions/Internal/WebDriverButtonReleaseAction.php
+++ b/lib/Interactions/Internal/WebDriverButtonReleaseAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 /**
  * Move to the location and then release the mouse key.

--- a/lib/Interactions/Internal/WebDriverButtonReleaseAction.php
+++ b/lib/Interactions/Internal/WebDriverButtonReleaseAction.php
@@ -14,3 +14,5 @@ class WebDriverButtonReleaseAction extends WebDriverMouseAction implements WebDr
         $this->mouse->mouseUp($this->getActionLocation());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction::class);

--- a/lib/Interactions/Internal/WebDriverClickAction.php
+++ b/lib/Interactions/Internal/WebDriverClickAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverClickAction extends WebDriverMouseAction implements WebDriverAction
 {

--- a/lib/Interactions/Internal/WebDriverClickAction.php
+++ b/lib/Interactions/Internal/WebDriverClickAction.php
@@ -11,3 +11,5 @@ class WebDriverClickAction extends WebDriverMouseAction implements WebDriverActi
         $this->mouse->click($this->getActionLocation());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverClickAction::class);

--- a/lib/Interactions/Internal/WebDriverClickAndHoldAction.php
+++ b/lib/Interactions/Internal/WebDriverClickAndHoldAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 /**
  * Move the the location, click and hold.

--- a/lib/Interactions/Internal/WebDriverClickAndHoldAction.php
+++ b/lib/Interactions/Internal/WebDriverClickAndHoldAction.php
@@ -14,3 +14,5 @@ class WebDriverClickAndHoldAction extends WebDriverMouseAction implements WebDri
         $this->mouse->mouseDown($this->getActionLocation());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction::class);

--- a/lib/Interactions/Internal/WebDriverContextClickAction.php
+++ b/lib/Interactions/Internal/WebDriverContextClickAction.php
@@ -14,3 +14,5 @@ class WebDriverContextClickAction extends WebDriverMouseAction implements WebDri
         $this->mouse->contextClick($this->getActionLocation());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverContextClickAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverContextClickAction::class);

--- a/lib/Interactions/Internal/WebDriverContextClickAction.php
+++ b/lib/Interactions/Internal/WebDriverContextClickAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 /**
  * You can call it 'Right Click' if you like.

--- a/lib/Interactions/Internal/WebDriverCoordinates.php
+++ b/lib/Interactions/Internal/WebDriverCoordinates.php
@@ -76,3 +76,5 @@ class WebDriverCoordinates
         return $this->auxiliary;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates::class, \Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates::class);

--- a/lib/Interactions/Internal/WebDriverCoordinates.php
+++ b/lib/Interactions/Internal/WebDriverCoordinates.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
-use Facebook\WebDriver\WebDriverPoint;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\WebDriverPoint;
 
 /**
  * Interface representing basic mouse operations.

--- a/lib/Interactions/Internal/WebDriverDoubleClickAction.php
+++ b/lib/Interactions/Internal/WebDriverDoubleClickAction.php
@@ -11,3 +11,5 @@ class WebDriverDoubleClickAction extends WebDriverMouseAction implements WebDriv
         $this->mouse->doubleClick($this->getActionLocation());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverDoubleClickAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverDoubleClickAction::class);

--- a/lib/Interactions/Internal/WebDriverDoubleClickAction.php
+++ b/lib/Interactions/Internal/WebDriverDoubleClickAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverDoubleClickAction extends WebDriverMouseAction implements WebDriverAction
 {

--- a/lib/Interactions/Internal/WebDriverKeyDownAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyDownAction.php
@@ -10,3 +10,5 @@ class WebDriverKeyDownAction extends WebDriverSingleKeyAction
         $this->keyboard->pressKey($this->key);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyDownAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverKeyDownAction::class);

--- a/lib/Interactions/Internal/WebDriverKeyDownAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyDownAction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
 class WebDriverKeyDownAction extends WebDriverSingleKeyAction
 {

--- a/lib/Interactions/Internal/WebDriverKeyUpAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyUpAction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
 class WebDriverKeyUpAction extends WebDriverSingleKeyAction
 {

--- a/lib/Interactions/Internal/WebDriverKeyUpAction.php
+++ b/lib/Interactions/Internal/WebDriverKeyUpAction.php
@@ -10,3 +10,5 @@ class WebDriverKeyUpAction extends WebDriverSingleKeyAction
         $this->keyboard->releaseKey($this->key);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyUpAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverKeyUpAction::class);

--- a/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
+++ b/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 
 /**
  * Base class for all keyboard-related actions.

--- a/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
+++ b/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
@@ -46,3 +46,5 @@ abstract class WebDriverKeysRelatedAction
         }
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction::class);

--- a/lib/Interactions/Internal/WebDriverMouseAction.php
+++ b/lib/Interactions/Internal/WebDriverMouseAction.php
@@ -46,3 +46,5 @@ class WebDriverMouseAction
         $this->mouse->mouseMove($this->locationProvider);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverMouseAction::class);

--- a/lib/Interactions/Internal/WebDriverMouseAction.php
+++ b/lib/Interactions/Internal/WebDriverMouseAction.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 
 /**
  * Base class for all mouse-related actions.

--- a/lib/Interactions/Internal/WebDriverMouseMoveAction.php
+++ b/lib/Interactions/Internal/WebDriverMouseMoveAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverMouseMoveAction extends WebDriverMouseAction implements WebDriverAction
 {

--- a/lib/Interactions/Internal/WebDriverMouseMoveAction.php
+++ b/lib/Interactions/Internal/WebDriverMouseMoveAction.php
@@ -11,3 +11,5 @@ class WebDriverMouseMoveAction extends WebDriverMouseAction implements WebDriver
         $this->mouse->mouseMove($this->getActionLocation());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseMoveAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverMouseMoveAction::class);

--- a/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
+++ b/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
@@ -43,3 +43,5 @@ class WebDriverMoveToOffsetAction extends WebDriverMouseAction implements WebDri
         );
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction::class);

--- a/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
+++ b/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverAction;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 
 class WebDriverMoveToOffsetAction extends WebDriverMouseAction implements WebDriverAction
 {

--- a/lib/Interactions/Internal/WebDriverSendKeysAction.php
+++ b/lib/Interactions/Internal/WebDriverSendKeysAction.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverAction;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 
 class WebDriverSendKeysAction extends WebDriverKeysRelatedAction implements WebDriverAction
 {

--- a/lib/Interactions/Internal/WebDriverSendKeysAction.php
+++ b/lib/Interactions/Internal/WebDriverSendKeysAction.php
@@ -36,3 +36,5 @@ class WebDriverSendKeysAction extends WebDriverKeysRelatedAction implements WebD
         $this->keyboard->sendKeys($this->keys);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSendKeysAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverSendKeysAction::class);

--- a/lib/Interactions/Internal/WebDriverSingleKeyAction.php
+++ b/lib/Interactions/Internal/WebDriverSingleKeyAction.php
@@ -51,3 +51,5 @@ abstract class WebDriverSingleKeyAction extends WebDriverKeysRelatedAction imple
         $this->key = $key;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSingleKeyAction::class, \Facebook\WebDriver\Interactions\Internal\WebDriverSingleKeyAction::class);

--- a/lib/Interactions/Internal/WebDriverSingleKeyAction.php
+++ b/lib/Interactions/Internal/WebDriverSingleKeyAction.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverAction;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverKeys;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverKeys;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 
 abstract class WebDriverSingleKeyAction extends WebDriverKeysRelatedAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverDoubleTapAction.php
+++ b/lib/Interactions/Touch/WebDriverDoubleTapAction.php
@@ -11,3 +11,5 @@ class WebDriverDoubleTapAction extends WebDriverTouchAction implements WebDriver
         $this->touchScreen->doubleTap($this->locationProvider);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDoubleTapAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverDoubleTapAction::class);

--- a/lib/Interactions/Touch/WebDriverDoubleTapAction.php
+++ b/lib/Interactions/Touch/WebDriverDoubleTapAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverDoubleTapAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverDownAction.php
+++ b/lib/Interactions/Touch/WebDriverDownAction.php
@@ -32,3 +32,5 @@ class WebDriverDownAction extends WebDriverTouchAction implements WebDriverActio
         $this->touchScreen->down($this->x, $this->y);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDownAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverDownAction::class);

--- a/lib/Interactions/Touch/WebDriverDownAction.php
+++ b/lib/Interactions/Touch/WebDriverDownAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverDownAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverFlickAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverFlickAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverFlickAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickAction.php
@@ -32,3 +32,5 @@ class WebDriverFlickAction extends WebDriverTouchAction implements WebDriverActi
         $this->touchScreen->flick($this->x, $this->y);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverFlickAction::class);

--- a/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
-use Facebook\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverElement;
 
 class WebDriverFlickFromElementAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
@@ -50,3 +50,5 @@ class WebDriverFlickFromElementAction extends WebDriverTouchAction implements We
         );
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction::class);

--- a/lib/Interactions/Touch/WebDriverLongPressAction.php
+++ b/lib/Interactions/Touch/WebDriverLongPressAction.php
@@ -11,3 +11,5 @@ class WebDriverLongPressAction extends WebDriverTouchAction implements WebDriver
         $this->touchScreen->longPress($this->locationProvider);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverLongPressAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverLongPressAction::class);

--- a/lib/Interactions/Touch/WebDriverLongPressAction.php
+++ b/lib/Interactions/Touch/WebDriverLongPressAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverLongPressAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverMoveAction.php
+++ b/lib/Interactions/Touch/WebDriverMoveAction.php
@@ -26,3 +26,5 @@ class WebDriverMoveAction extends WebDriverTouchAction implements WebDriverActio
         $this->touchScreen->move($this->x, $this->y);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverMoveAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverMoveAction::class);

--- a/lib/Interactions/Touch/WebDriverMoveAction.php
+++ b/lib/Interactions/Touch/WebDriverMoveAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverMoveAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverScrollAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverScrollAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverScrollAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollAction.php
@@ -26,3 +26,5 @@ class WebDriverScrollAction extends WebDriverTouchAction implements WebDriverAct
         $this->touchScreen->scroll($this->x, $this->y);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverScrollAction::class);

--- a/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
-use Facebook\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverElement;
 
 class WebDriverScrollFromElementAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
@@ -36,3 +36,5 @@ class WebDriverScrollFromElementAction extends WebDriverTouchAction implements W
         );
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction::class);

--- a/lib/Interactions/Touch/WebDriverTapAction.php
+++ b/lib/Interactions/Touch/WebDriverTapAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 class WebDriverTapAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/Interactions/Touch/WebDriverTapAction.php
+++ b/lib/Interactions/Touch/WebDriverTapAction.php
@@ -11,3 +11,5 @@ class WebDriverTapAction extends WebDriverTouchAction implements WebDriverAction
         $this->touchScreen->tap($this->locationProvider);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTapAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverTapAction::class);

--- a/lib/Interactions/Touch/WebDriverTouchAction.php
+++ b/lib/Interactions/Touch/WebDriverTouchAction.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
-use Facebook\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
 
 /**
  * Base class for all touch-related actions.

--- a/lib/Interactions/Touch/WebDriverTouchAction.php
+++ b/lib/Interactions/Touch/WebDriverTouchAction.php
@@ -40,3 +40,5 @@ abstract class WebDriverTouchAction
             ? $this->locationProvider->getCoordinates() : null;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchAction::class, \Facebook\WebDriver\Interactions\Touch\WebDriverTouchAction::class);

--- a/lib/Interactions/Touch/WebDriverTouchScreen.php
+++ b/lib/Interactions/Touch/WebDriverTouchScreen.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Touch;
+namespace PhpWebDriver\WebDriver\Interactions\Touch;
 
-use Facebook\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverElement;
 
 /**
  * Interface representing touch screen operations.

--- a/lib/Interactions/Touch/WebDriverTouchScreen.php
+++ b/lib/Interactions/Touch/WebDriverTouchScreen.php
@@ -112,3 +112,5 @@ interface WebDriverTouchScreen
      */
     public function up($x, $y);
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen::class, \Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen::class);

--- a/lib/Interactions/WebDriverActions.php
+++ b/lib/Interactions/WebDriverActions.php
@@ -266,3 +266,5 @@ class WebDriverActions
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\WebDriverActions::class, \Facebook\WebDriver\Interactions\WebDriverActions::class);

--- a/lib/Interactions/WebDriverActions.php
+++ b/lib/Interactions/WebDriverActions.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions;
+namespace PhpWebDriver\WebDriver\Interactions;
 
-use Facebook\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverClickAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverContextClickAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverDoubleClickAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverKeyDownAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverKeyUpAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverMouseMoveAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction;
-use Facebook\WebDriver\Interactions\Internal\WebDriverSendKeysAction;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverHasInputDevices;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverContextClickAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverDoubleClickAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyDownAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyUpAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseMoveAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSendKeysAction;
+use PhpWebDriver\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverHasInputDevices;
 
 /**
  * WebDriver action builder. It implements the builder pattern.

--- a/lib/Interactions/WebDriverCompositeAction.php
+++ b/lib/Interactions/WebDriverCompositeAction.php
@@ -47,3 +47,5 @@ class WebDriverCompositeAction implements WebDriverAction
         }
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\WebDriverCompositeAction::class, \Facebook\WebDriver\Interactions\WebDriverCompositeAction::class);

--- a/lib/Interactions/WebDriverCompositeAction.php
+++ b/lib/Interactions/WebDriverCompositeAction.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions;
+namespace PhpWebDriver\WebDriver\Interactions;
 
-use Facebook\WebDriver\WebDriverAction;
+use PhpWebDriver\WebDriver\WebDriverAction;
 
 /**
  * An action for aggregating actions and triggering all of them afterwards.

--- a/lib/Interactions/WebDriverTouchActions.php
+++ b/lib/Interactions/WebDriverTouchActions.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions;
+namespace PhpWebDriver\WebDriver\Interactions;
 
-use Facebook\WebDriver\Interactions\Touch\WebDriverDoubleTapAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverDownAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverFlickAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverLongPressAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverMoveAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverScrollAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverTapAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen;
-use Facebook\WebDriver\WebDriver;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverUpAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDoubleTapAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDownAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverLongPressAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverMoveAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTapAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen;
+use PhpWebDriver\WebDriver\WebDriver;
+use PhpWebDriver\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverUpAction;
 
 /**
  * WebDriver action builder for touch events

--- a/lib/Interactions/WebDriverTouchActions.php
+++ b/lib/Interactions/WebDriverTouchActions.php
@@ -178,3 +178,5 @@ class WebDriverTouchActions extends WebDriverActions
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Interactions\WebDriverTouchActions::class, \Facebook\WebDriver\Interactions\WebDriverTouchActions::class);

--- a/lib/Internal/WebDriverLocatable.php
+++ b/lib/Internal/WebDriverLocatable.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Internal;
+namespace PhpWebDriver\WebDriver\Internal;
 
-use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates;
 
 /**
  * Interface representing basic mouse operations.

--- a/lib/Internal/WebDriverLocatable.php
+++ b/lib/Internal/WebDriverLocatable.php
@@ -14,3 +14,5 @@ interface WebDriverLocatable
      */
     public function getCoordinates();
 }
+
+class_alias(\PhpWebDriver\WebDriver\Internal\WebDriverLocatable::class, \Facebook\WebDriver\Internal\WebDriverLocatable::class);

--- a/lib/JavaScriptExecutor.php
+++ b/lib/JavaScriptExecutor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * WebDriver interface implemented by drivers that support JavaScript.

--- a/lib/JavaScriptExecutor.php
+++ b/lib/JavaScriptExecutor.php
@@ -33,3 +33,5 @@ interface JavaScriptExecutor
      */
     public function executeAsyncScript($script, array $arguments = []);
 }
+
+class_alias(\PhpWebDriver\WebDriver\JavaScriptExecutor::class, \Facebook\WebDriver\JavaScriptExecutor::class);

--- a/lib/Local/LocalWebDriver.php
+++ b/lib/Local/LocalWebDriver.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver\Local;
+namespace PhpWebDriver\WebDriver\Local;
 
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
 
 /**
  * @todo Break inheritance from RemoteWebDriver in next major version. (Composition over inheritance!)

--- a/lib/Local/LocalWebDriver.php
+++ b/lib/Local/LocalWebDriver.php
@@ -53,3 +53,5 @@ abstract class LocalWebDriver extends RemoteWebDriver
         throw new WebDriverException('Use start() method to start local WebDriver.');
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Local\LocalWebDriver::class, \Facebook\WebDriver\Local\LocalWebDriver::class);

--- a/lib/Net/URLChecker.php
+++ b/lib/Net/URLChecker.php
@@ -70,3 +70,5 @@ class URLChecker
         return $code;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Net\URLChecker::class, \Facebook\WebDriver\Net\URLChecker::class);

--- a/lib/Net/URLChecker.php
+++ b/lib/Net/URLChecker.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Net;
+namespace PhpWebDriver\WebDriver\Net;
 
 use Exception;
-use Facebook\WebDriver\Exception\TimeoutException;
+use PhpWebDriver\WebDriver\Exception\TimeoutException;
 
 class URLChecker
 {

--- a/lib/Remote/CustomWebDriverCommand.php
+++ b/lib/Remote/CustomWebDriverCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
 
 class CustomWebDriverCommand extends WebDriverCommand
 {

--- a/lib/Remote/CustomWebDriverCommand.php
+++ b/lib/Remote/CustomWebDriverCommand.php
@@ -80,3 +80,5 @@ class CustomWebDriverCommand extends WebDriverCommand
         $this->customUrl = $custom_url;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\CustomWebDriverCommand::class, \Facebook\WebDriver\Remote\CustomWebDriverCommand::class);

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -438,3 +438,5 @@ class DesiredCapabilities implements WebDriverCapabilities
             : $default;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\DesiredCapabilities::class, \Facebook\WebDriver\Remote\DesiredCapabilities::class);

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 use Exception;
-use Facebook\WebDriver\Chrome\ChromeOptions;
-use Facebook\WebDriver\Firefox\FirefoxDriver;
-use Facebook\WebDriver\Firefox\FirefoxOptions;
-use Facebook\WebDriver\Firefox\FirefoxProfile;
-use Facebook\WebDriver\WebDriverCapabilities;
-use Facebook\WebDriver\WebDriverPlatform;
+use PhpWebDriver\WebDriver\Chrome\ChromeOptions;
+use PhpWebDriver\WebDriver\Firefox\FirefoxDriver;
+use PhpWebDriver\WebDriver\Firefox\FirefoxOptions;
+use PhpWebDriver\WebDriver\Firefox\FirefoxProfile;
+use PhpWebDriver\WebDriver\WebDriverCapabilities;
+use PhpWebDriver\WebDriver\WebDriverPlatform;
 
 class DesiredCapabilities implements WebDriverCapabilities
 {

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -148,3 +148,5 @@ class DriverCommand
     {
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\DriverCommand::class, \Facebook\WebDriver\Remote\DriverCommand::class);

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 /**
  * This list of command defined in the WebDriver json wire protocol.

--- a/lib/Remote/ExecuteMethod.php
+++ b/lib/Remote/ExecuteMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 interface ExecuteMethod
 {

--- a/lib/Remote/ExecuteMethod.php
+++ b/lib/Remote/ExecuteMethod.php
@@ -11,3 +11,5 @@ interface ExecuteMethod
      */
     public function execute($command_name, array $parameters = []);
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\ExecuteMethod::class, \Facebook\WebDriver\Remote\ExecuteMethod::class);

--- a/lib/Remote/FileDetector.php
+++ b/lib/Remote/FileDetector.php
@@ -14,3 +14,5 @@ interface FileDetector
      */
     public function getLocalFile($file);
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\FileDetector::class, \Facebook\WebDriver\Remote\FileDetector::class);

--- a/lib/Remote/FileDetector.php
+++ b/lib/Remote/FileDetector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 interface FileDetector
 {

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 use BadMethodCallException;
-use Facebook\WebDriver\Exception\WebDriverCurlException;
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\WebDriverCommandExecutor;
+use PhpWebDriver\WebDriver\Exception\WebDriverCurlException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\WebDriverCommandExecutor;
 use InvalidArgumentException;
 
 /**
@@ -289,7 +289,7 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
 
         curl_setopt($this->curl, CURLOPT_URL, $this->url . $url);
 
-        // https://github.com/facebook/php-webdriver/issues/173
+        // https://github.com/php-webdriver/php-webdriver/issues/173
         if ($command->getName() === DriverCommand::NEW_SESSION) {
             curl_setopt($this->curl, CURLOPT_POST, 1);
         } else {

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -424,3 +424,5 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         ];
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\HttpCommandExecutor::class, \Facebook\WebDriver\Remote\HttpCommandExecutor::class);

--- a/lib/Remote/JsonWireCompat.php
+++ b/lib/Remote/JsonWireCompat.php
@@ -87,3 +87,5 @@ abstract class JsonWireCompat
         }, $selector);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\JsonWireCompat::class, \Facebook\WebDriver\Remote\JsonWireCompat::class);

--- a/lib/Remote/JsonWireCompat.php
+++ b/lib/Remote/JsonWireCompat.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\WebDriverBy;
+use PhpWebDriver\WebDriver\WebDriverBy;
 
 /**
  * Compatibility layer between W3C's WebDriver and the legacy JsonWire protocol.

--- a/lib/Remote/LocalFileDetector.php
+++ b/lib/Remote/LocalFileDetector.php
@@ -18,3 +18,5 @@ class LocalFileDetector implements FileDetector
         return null;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\LocalFileDetector::class, \Facebook\WebDriver\Remote\LocalFileDetector::class);

--- a/lib/Remote/LocalFileDetector.php
+++ b/lib/Remote/LocalFileDetector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 class LocalFileDetector implements FileDetector
 {

--- a/lib/Remote/RemoteExecuteMethod.php
+++ b/lib/Remote/RemoteExecuteMethod.php
@@ -27,3 +27,5 @@ class RemoteExecuteMethod implements ExecuteMethod
         return $this->driver->execute($command_name, $parameters);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteExecuteMethod::class, \Facebook\WebDriver\Remote\RemoteExecuteMethod::class);

--- a/lib/Remote/RemoteExecuteMethod.php
+++ b/lib/Remote/RemoteExecuteMethod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 class RemoteExecuteMethod implements ExecuteMethod
 {

--- a/lib/Remote/RemoteKeyboard.php
+++ b/lib/Remote/RemoteKeyboard.php
@@ -103,3 +103,5 @@ class RemoteKeyboard implements WebDriverKeyboard
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteKeyboard::class, \Facebook\WebDriver\Remote\RemoteKeyboard::class);

--- a/lib/Remote/RemoteKeyboard.php
+++ b/lib/Remote/RemoteKeyboard.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\WebDriver;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverKeys;
+use PhpWebDriver\WebDriver\WebDriver;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverKeys;
 
 /**
  * Execute keyboard commands for RemoteWebDriver.

--- a/lib/Remote/RemoteMouse.php
+++ b/lib/Remote/RemoteMouse.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 
 /**
  * Execute mouse commands for RemoteWebDriver.

--- a/lib/Remote/RemoteMouse.php
+++ b/lib/Remote/RemoteMouse.php
@@ -304,3 +304,5 @@ class RemoteMouse implements WebDriverMouse
         ];
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteMouse::class, \Facebook\WebDriver\Remote\RemoteMouse::class);

--- a/lib/Remote/RemoteStatus.php
+++ b/lib/Remote/RemoteStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 /**
  * Represents status of remote end

--- a/lib/Remote/RemoteStatus.php
+++ b/lib/Remote/RemoteStatus.php
@@ -78,3 +78,5 @@ class RemoteStatus
         $this->meta = $meta;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteStatus::class, \Facebook\WebDriver\Remote\RemoteStatus::class);

--- a/lib/Remote/RemoteTargetLocator.php
+++ b/lib/Remote/RemoteTargetLocator.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
-use Facebook\WebDriver\WebDriverAlert;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverTargetLocator;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\WebDriverAlert;
+use PhpWebDriver\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverTargetLocator;
 
 /**
  * Used to locate a given frame or window for RemoteWebDriver.

--- a/lib/Remote/RemoteTargetLocator.php
+++ b/lib/Remote/RemoteTargetLocator.php
@@ -147,3 +147,5 @@ class RemoteTargetLocator implements WebDriverTargetLocator
         return new RemoteWebElement($method, JsonWireCompat::getElement($response), $this->isW3cCompliant);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteTargetLocator::class, \Facebook\WebDriver\Remote\RemoteTargetLocator::class);

--- a/lib/Remote/RemoteTouchScreen.php
+++ b/lib/Remote/RemoteTouchScreen.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen;
-use Facebook\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen;
+use PhpWebDriver\WebDriver\WebDriverElement;
 
 /**
  * Execute touch commands for RemoteWebDriver.

--- a/lib/Remote/RemoteTouchScreen.php
+++ b/lib/Remote/RemoteTouchScreen.php
@@ -186,3 +186,5 @@ class RemoteTouchScreen implements WebDriverTouchScreen
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteTouchScreen::class, \Facebook\WebDriver\Remote\RemoteTouchScreen::class);

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Interactions\WebDriverActions;
-use Facebook\WebDriver\JavaScriptExecutor;
-use Facebook\WebDriver\WebDriver;
-use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverCapabilities;
-use Facebook\WebDriver\WebDriverCommandExecutor;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverHasInputDevices;
-use Facebook\WebDriver\WebDriverNavigation;
-use Facebook\WebDriver\WebDriverOptions;
-use Facebook\WebDriver\WebDriverWait;
+use PhpWebDriver\WebDriver\Interactions\WebDriverActions;
+use PhpWebDriver\WebDriver\JavaScriptExecutor;
+use PhpWebDriver\WebDriver\WebDriver;
+use PhpWebDriver\WebDriver\WebDriverBy;
+use PhpWebDriver\WebDriver\WebDriverCapabilities;
+use PhpWebDriver\WebDriver\WebDriverCommandExecutor;
+use PhpWebDriver\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverHasInputDevices;
+use PhpWebDriver\WebDriver\WebDriverNavigation;
+use PhpWebDriver\WebDriver\WebDriverOptions;
+use PhpWebDriver\WebDriver\WebDriverWait;
 
 class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInputDevices
 {

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -727,3 +727,5 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
         return $desired_capabilities;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteWebDriver::class, \Facebook\WebDriver\Remote\RemoteWebDriver::class);

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Exception\ElementNotInteractableException;
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverDimension;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverKeys;
-use Facebook\WebDriver\WebDriverPoint;
+use PhpWebDriver\WebDriver\Exception\ElementNotInteractableException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverBy;
+use PhpWebDriver\WebDriver\WebDriverDimension;
+use PhpWebDriver\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverKeys;
+use PhpWebDriver\WebDriver\WebDriverPoint;
 use ZipArchive;
 
 /**

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -606,3 +606,5 @@ HTXT;
         return $tempZipPath;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\RemoteWebElement::class, \Facebook\WebDriver\Remote\RemoteWebElement::class);

--- a/lib/Remote/Service/DriverCommandExecutor.php
+++ b/lib/Remote/Service/DriverCommandExecutor.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Facebook\WebDriver\Remote\Service;
+namespace PhpWebDriver\WebDriver\Remote\Service;
 
-use Facebook\WebDriver\Exception\DriverServerDiedException;
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\HttpCommandExecutor;
-use Facebook\WebDriver\Remote\WebDriverCommand;
-use Facebook\WebDriver\Remote\WebDriverResponse;
+use PhpWebDriver\WebDriver\Exception\DriverServerDiedException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\HttpCommandExecutor;
+use PhpWebDriver\WebDriver\Remote\WebDriverCommand;
+use PhpWebDriver\WebDriver\Remote\WebDriverResponse;
 
 /**
  * A HttpCommandExecutor that talks to a local driver service instead of a remote server.

--- a/lib/Remote/Service/DriverCommandExecutor.php
+++ b/lib/Remote/Service/DriverCommandExecutor.php
@@ -53,3 +53,5 @@ class DriverCommandExecutor extends HttpCommandExecutor
         }
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor::class, \Facebook\WebDriver\Remote\Service\DriverCommandExecutor::class);

--- a/lib/Remote/Service/DriverService.php
+++ b/lib/Remote/Service/DriverService.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Remote\Service;
+namespace PhpWebDriver\WebDriver\Remote\Service;
 
 use Exception;
-use Facebook\WebDriver\Net\URLChecker;
+use PhpWebDriver\WebDriver\Net\URLChecker;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 

--- a/lib/Remote/Service/DriverService.php
+++ b/lib/Remote/Service/DriverService.php
@@ -207,3 +207,5 @@ class DriverService
         return false;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\Service\DriverService::class, \Facebook\WebDriver\Remote\Service\DriverService::class);

--- a/lib/Remote/UselessFileDetector.php
+++ b/lib/Remote/UselessFileDetector.php
@@ -9,3 +9,5 @@ class UselessFileDetector implements FileDetector
         return null;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\UselessFileDetector::class, \Facebook\WebDriver\Remote\UselessFileDetector::class);

--- a/lib/Remote/UselessFileDetector.php
+++ b/lib/Remote/UselessFileDetector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 class UselessFileDetector implements FileDetector
 {

--- a/lib/Remote/WebDriverBrowserType.php
+++ b/lib/Remote/WebDriverBrowserType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 /**
  * All the browsers supported by selenium.

--- a/lib/Remote/WebDriverBrowserType.php
+++ b/lib/Remote/WebDriverBrowserType.php
@@ -38,3 +38,5 @@ class WebDriverBrowserType
     {
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\WebDriverBrowserType::class, \Facebook\WebDriver\Remote\WebDriverBrowserType::class);

--- a/lib/Remote/WebDriverCapabilityType.php
+++ b/lib/Remote/WebDriverCapabilityType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 /**
  * WebDriverCapabilityType contains all constants defined in the WebDriver Wire Protocol.

--- a/lib/Remote/WebDriverCapabilityType.php
+++ b/lib/Remote/WebDriverCapabilityType.php
@@ -30,3 +30,5 @@ class WebDriverCapabilityType
     {
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\WebDriverCapabilityType::class, \Facebook\WebDriver\Remote\WebDriverCapabilityType::class);

--- a/lib/Remote/WebDriverCommand.php
+++ b/lib/Remote/WebDriverCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 class WebDriverCommand
 {

--- a/lib/Remote/WebDriverCommand.php
+++ b/lib/Remote/WebDriverCommand.php
@@ -48,3 +48,5 @@ class WebDriverCommand
         return $this->parameters;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\WebDriverCommand::class, \Facebook\WebDriver\Remote\WebDriverCommand::class);

--- a/lib/Remote/WebDriverResponse.php
+++ b/lib/Remote/WebDriverResponse.php
@@ -82,3 +82,5 @@ class WebDriverResponse
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Remote\WebDriverResponse::class, \Facebook\WebDriver\Remote\WebDriverResponse::class);

--- a/lib/Remote/WebDriverResponse.php
+++ b/lib/Remote/WebDriverResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 class WebDriverResponse
 {

--- a/lib/Support/Events/EventFiringWebDriver.php
+++ b/lib/Support/Events/EventFiringWebDriver.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Facebook\WebDriver\Support\Events;
+namespace PhpWebDriver\WebDriver\Support\Events;
 
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen;
-use Facebook\WebDriver\JavaScriptExecutor;
-use Facebook\WebDriver\WebDriver;
-use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverDispatcher;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverOptions;
-use Facebook\WebDriver\WebDriverTargetLocator;
-use Facebook\WebDriver\WebDriverWait;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen;
+use PhpWebDriver\WebDriver\JavaScriptExecutor;
+use PhpWebDriver\WebDriver\WebDriver;
+use PhpWebDriver\WebDriver\WebDriverBy;
+use PhpWebDriver\WebDriver\WebDriverDispatcher;
+use PhpWebDriver\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverOptions;
+use PhpWebDriver\WebDriver\WebDriverTargetLocator;
+use PhpWebDriver\WebDriver\WebDriverWait;
 
 class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
 {

--- a/lib/Support/Events/EventFiringWebDriver.php
+++ b/lib/Support/Events/EventFiringWebDriver.php
@@ -402,3 +402,5 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
         $this->dispatch('onException', $exception, $this);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriver::class, \Facebook\WebDriver\Support\Events\EventFiringWebDriver::class);

--- a/lib/Support/Events/EventFiringWebDriverNavigation.php
+++ b/lib/Support/Events/EventFiringWebDriverNavigation.php
@@ -138,3 +138,5 @@ class EventFiringWebDriverNavigation implements WebDriverNavigationInterface
         $this->dispatch('onException', $exception);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriverNavigation::class, \Facebook\WebDriver\Support\Events\EventFiringWebDriverNavigation::class);

--- a/lib/Support/Events/EventFiringWebDriverNavigation.php
+++ b/lib/Support/Events/EventFiringWebDriverNavigation.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver\Support\Events;
+namespace PhpWebDriver\WebDriver\Support\Events;
 
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\WebDriverDispatcher;
-use Facebook\WebDriver\WebDriverNavigationInterface;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\WebDriverDispatcher;
+use PhpWebDriver\WebDriver\WebDriverNavigationInterface;
 
 class EventFiringWebDriverNavigation implements WebDriverNavigationInterface
 {

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -399,3 +399,5 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
         return new static($element, $this->getDispatcher());
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Support\Events\EventFiringWebElement::class, \Facebook\WebDriver\Support\Events\EventFiringWebElement::class);

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Facebook\WebDriver\Support\Events;
+namespace PhpWebDriver\WebDriver\Support\Events;
 
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverDimension;
-use Facebook\WebDriver\WebDriverDispatcher;
-use Facebook\WebDriver\WebDriverElement;
-use Facebook\WebDriver\WebDriverPoint;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverBy;
+use PhpWebDriver\WebDriver\WebDriverDimension;
+use PhpWebDriver\WebDriver\WebDriverDispatcher;
+use PhpWebDriver\WebDriver\WebDriverElement;
+use PhpWebDriver\WebDriver\WebDriverPoint;
 
 class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
 {

--- a/lib/Support/XPathEscaper.php
+++ b/lib/Support/XPathEscaper.php
@@ -30,3 +30,5 @@ class XPathEscaper
         );
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\Support\XPathEscaper::class, \Facebook\WebDriver\Support\XPathEscaper::class);

--- a/lib/Support/XPathEscaper.php
+++ b/lib/Support/XPathEscaper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Support;
+namespace PhpWebDriver\WebDriver\Support;
 
 class XPathEscaper
 {

--- a/lib/WebDriver.php
+++ b/lib/WebDriver.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen;
 
 /**
  * The interface for WebDriver.

--- a/lib/WebDriver.php
+++ b/lib/WebDriver.php
@@ -141,3 +141,5 @@ interface WebDriver extends WebDriverSearchContext
     // */
     //public function executeCustomCommand($endpointUrl, $method = 'GET', $params = []);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriver::class, \Facebook\WebDriver\WebDriver::class);

--- a/lib/WebDriverAction.php
+++ b/lib/WebDriverAction.php
@@ -9,3 +9,5 @@ interface WebDriverAction
 {
     public function perform();
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverAction::class, \Facebook\WebDriver\WebDriverAction::class);

--- a/lib/WebDriverAction.php
+++ b/lib/WebDriverAction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * Interface representing a single user-interaction action.

--- a/lib/WebDriverAlert.php
+++ b/lib/WebDriverAlert.php
@@ -70,3 +70,5 @@ class WebDriverAlert
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverAlert::class, \Facebook\WebDriver\WebDriverAlert::class);

--- a/lib/WebDriverAlert.php
+++ b/lib/WebDriverAlert.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\ExecuteMethod;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\ExecuteMethod;
 
 /**
  * An abstraction allowing the driver to manipulate the javascript alerts

--- a/lib/WebDriverBy.php
+++ b/lib/WebDriverBy.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * The basic 8 mechanisms supported by webdriver to locate a web element.

--- a/lib/WebDriverBy.php
+++ b/lib/WebDriverBy.php
@@ -132,3 +132,5 @@ class WebDriverBy
         return new static('xpath', $xpath);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverBy::class, \Facebook\WebDriver\WebDriverBy::class);

--- a/lib/WebDriverCapabilities.php
+++ b/lib/WebDriverCapabilities.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 interface WebDriverCapabilities
 {

--- a/lib/WebDriverCapabilities.php
+++ b/lib/WebDriverCapabilities.php
@@ -44,3 +44,5 @@ interface WebDriverCapabilities
     // */
     //public function toArray();
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverCapabilities::class, \Facebook\WebDriver\WebDriverCapabilities::class);

--- a/lib/WebDriverCheckboxes.php
+++ b/lib/WebDriverCheckboxes.php
@@ -51,3 +51,5 @@ class WebDriverCheckboxes extends AbstractWebDriverCheckboxOrRadio
         $this->byVisibleText($text, true, false);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverCheckboxes::class, \Facebook\WebDriver\WebDriverCheckboxes::class);

--- a/lib/WebDriverCheckboxes.php
+++ b/lib/WebDriverCheckboxes.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
 
 /**
  * Provides helper methods for checkboxes.

--- a/lib/WebDriverCommandExecutor.php
+++ b/lib/WebDriverCommandExecutor.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\WebDriverCommand;
-use Facebook\WebDriver\Remote\WebDriverResponse;
+use PhpWebDriver\WebDriver\Remote\WebDriverCommand;
+use PhpWebDriver\WebDriver\Remote\WebDriverResponse;
 
 /**
  * Interface for all command executor.

--- a/lib/WebDriverCommandExecutor.php
+++ b/lib/WebDriverCommandExecutor.php
@@ -17,3 +17,5 @@ interface WebDriverCommandExecutor
      */
     public function execute(WebDriverCommand $command);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverCommandExecutor::class, \Facebook\WebDriver\WebDriverCommandExecutor::class);

--- a/lib/WebDriverDimension.php
+++ b/lib/WebDriverDimension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * Represent a dimension.

--- a/lib/WebDriverDimension.php
+++ b/lib/WebDriverDimension.php
@@ -57,3 +57,5 @@ class WebDriverDimension
         return $this->height === $dimension->getHeight() && $this->width === $dimension->getWidth();
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverDimension::class, \Facebook\WebDriver\WebDriverDimension::class);

--- a/lib/WebDriverDispatcher.php
+++ b/lib/WebDriverDispatcher.php
@@ -76,3 +76,5 @@ class WebDriverDispatcher
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverDispatcher::class, \Facebook\WebDriver\WebDriverDispatcher::class);

--- a/lib/WebDriverDispatcher.php
+++ b/lib/WebDriverDispatcher.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Support\Events\EventFiringWebDriver;
+use PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriver;
 
 class WebDriverDispatcher
 {

--- a/lib/WebDriverElement.php
+++ b/lib/WebDriverElement.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * Interface for an HTML element in the WebDriver framework.

--- a/lib/WebDriverElement.php
+++ b/lib/WebDriverElement.php
@@ -129,3 +129,5 @@ interface WebDriverElement extends WebDriverSearchContext
      */
     //public function takeElementScreenshot($save_as = null);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverElement::class, \Facebook\WebDriver\WebDriverElement::class);

--- a/lib/WebDriverEventListener.php
+++ b/lib/WebDriverEventListener.php
@@ -92,3 +92,5 @@ interface WebDriverEventListener
      */
     public function onException(WebDriverException $exception, EventFiringWebDriver $driver = null);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverEventListener::class, \Facebook\WebDriver\WebDriverEventListener::class);

--- a/lib/WebDriverEventListener.php
+++ b/lib/WebDriverEventListener.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Support\Events\EventFiringWebDriver;
-use Facebook\WebDriver\Support\Events\EventFiringWebElement;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriver;
+use PhpWebDriver\WebDriver\Support\Events\EventFiringWebElement;
 
 interface WebDriverEventListener
 {

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchAlertException;
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\NoSuchFrameException;
-use Facebook\WebDriver\Exception\StaleElementReferenceException;
+use PhpWebDriver\WebDriver\Exception\NoSuchAlertException;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\NoSuchFrameException;
+use PhpWebDriver\WebDriver\Exception\StaleElementReferenceException;
 
 /**
  * Canned ExpectedConditions which are generally useful within webdriver tests.

--- a/lib/WebDriverExpectedCondition.php
+++ b/lib/WebDriverExpectedCondition.php
@@ -584,3 +584,5 @@ class WebDriverExpectedCondition
         );
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverExpectedCondition::class, \Facebook\WebDriver\WebDriverExpectedCondition::class);

--- a/lib/WebDriverHasInputDevices.php
+++ b/lib/WebDriverHasInputDevices.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * Interface implemented by each driver that allows access to the input devices.

--- a/lib/WebDriverHasInputDevices.php
+++ b/lib/WebDriverHasInputDevices.php
@@ -17,3 +17,5 @@ interface WebDriverHasInputDevices
      */
     public function getMouse();
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverHasInputDevices::class, \Facebook\WebDriver\WebDriverHasInputDevices::class);

--- a/lib/WebDriverKeyboard.php
+++ b/lib/WebDriverKeyboard.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 interface WebDriverKeyboard
 {

--- a/lib/WebDriverKeyboard.php
+++ b/lib/WebDriverKeyboard.php
@@ -30,3 +30,5 @@ interface WebDriverKeyboard
      */
     public function releaseKey($key);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverKeyboard::class, \Facebook\WebDriver\WebDriverKeyboard::class);

--- a/lib/WebDriverKeys.php
+++ b/lib/WebDriverKeys.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * Representations of pressable keys that aren't text.

--- a/lib/WebDriverKeys.php
+++ b/lib/WebDriverKeys.php
@@ -130,3 +130,5 @@ class WebDriverKeys
         return implode('', $encoded);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverKeys::class, \Facebook\WebDriver\WebDriverKeys::class);

--- a/lib/WebDriverMouse.php
+++ b/lib/WebDriverMouse.php
@@ -51,3 +51,5 @@ interface WebDriverMouse
      */
     public function mouseUp(WebDriverCoordinates $where);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverMouse::class, \Facebook\WebDriver\WebDriverMouse::class);

--- a/lib/WebDriverMouse.php
+++ b/lib/WebDriverMouse.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
+use PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates;
 
 /**
  * Interface representing basic mouse operations.

--- a/lib/WebDriverNavigation.php
+++ b/lib/WebDriverNavigation.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\ExecuteMethod;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\ExecuteMethod;
 
 class WebDriverNavigation implements WebDriverNavigationInterface
 {

--- a/lib/WebDriverNavigation.php
+++ b/lib/WebDriverNavigation.php
@@ -43,3 +43,5 @@ class WebDriverNavigation implements WebDriverNavigationInterface
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverNavigation::class, \Facebook\WebDriver\WebDriverNavigation::class);

--- a/lib/WebDriverNavigationInterface.php
+++ b/lib/WebDriverNavigationInterface.php
@@ -41,3 +41,5 @@ interface WebDriverNavigationInterface
      */
     public function to($url);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverNavigationInterface::class, \Facebook\WebDriver\WebDriverNavigationInterface::class);

--- a/lib/WebDriverNavigationInterface.php
+++ b/lib/WebDriverNavigationInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * An abstraction allowing the driver to access the browser's history and to

--- a/lib/WebDriverOptions.php
+++ b/lib/WebDriverOptions.php
@@ -178,3 +178,5 @@ class WebDriverOptions
         return $this->executor->execute(DriverCommand::GET_AVAILABLE_LOG_TYPES);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverOptions::class, \Facebook\WebDriver\WebDriverOptions::class);

--- a/lib/WebDriverOptions.php
+++ b/lib/WebDriverOptions.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchCookieException;
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\ExecuteMethod;
+use PhpWebDriver\WebDriver\Exception\NoSuchCookieException;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\ExecuteMethod;
 use InvalidArgumentException;
 
 /**

--- a/lib/WebDriverPlatform.php
+++ b/lib/WebDriverPlatform.php
@@ -23,3 +23,5 @@ class WebDriverPlatform
     {
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverPlatform::class, \Facebook\WebDriver\WebDriverPlatform::class);

--- a/lib/WebDriverPlatform.php
+++ b/lib/WebDriverPlatform.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * The platforms supported by WebDriver.

--- a/lib/WebDriverPoint.php
+++ b/lib/WebDriverPoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * Represent a point.

--- a/lib/WebDriverPoint.php
+++ b/lib/WebDriverPoint.php
@@ -78,3 +78,5 @@ class WebDriverPoint
         $this->y === $point->getY();
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverPoint::class, \Facebook\WebDriver\WebDriverPoint::class);

--- a/lib/WebDriverRadios.php
+++ b/lib/WebDriverRadios.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
-use Facebook\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
 
 /**
  * Provides helper methods for radio buttons.

--- a/lib/WebDriverRadios.php
+++ b/lib/WebDriverRadios.php
@@ -50,3 +50,5 @@ class WebDriverRadios extends AbstractWebDriverCheckboxOrRadio
         throw new UnsupportedOperationException('You cannot deselect radio buttons');
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverRadios::class, \Facebook\WebDriver\WebDriverRadios::class);

--- a/lib/WebDriverSearchContext.php
+++ b/lib/WebDriverSearchContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * The interface for WebDriver and WebDriverElement which is able to search for

--- a/lib/WebDriverSearchContext.php
+++ b/lib/WebDriverSearchContext.php
@@ -29,3 +29,5 @@ interface WebDriverSearchContext
      */
     public function findElements(WebDriverBy $locator);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverSearchContext::class, \Facebook\WebDriver\WebDriverSearchContext::class);

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -243,3 +243,5 @@ class WebDriverSelect implements WebDriverSelectInterface
         }
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverSelect::class, \Facebook\WebDriver\WebDriverSelect::class);

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\UnexpectedTagNameException;
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
-use Facebook\WebDriver\Support\XPathEscaper;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\Support\XPathEscaper;
 
 /**
  * Models a default HTML `<select>` tag, providing helper methods to select and deselect options.

--- a/lib/WebDriverSelectInterface.php
+++ b/lib/WebDriverSelectInterface.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
 
 /**
  * Models an element of select type, providing helper methods to select and deselect options.

--- a/lib/WebDriverSelectInterface.php
+++ b/lib/WebDriverSelectInterface.php
@@ -126,3 +126,5 @@ interface WebDriverSelectInterface
      */
     public function deselectByVisiblePartialText($text);
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverSelectInterface::class, \Facebook\WebDriver\WebDriverSelectInterface::class);

--- a/lib/WebDriverTargetLocator.php
+++ b/lib/WebDriverTargetLocator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
  * Used to locate a given frame or window.

--- a/lib/WebDriverTargetLocator.php
+++ b/lib/WebDriverTargetLocator.php
@@ -67,3 +67,5 @@ interface WebDriverTargetLocator
      */
     public function activeElement();
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverTargetLocator::class, \Facebook\WebDriver\WebDriverTargetLocator::class);

--- a/lib/WebDriverTimeouts.php
+++ b/lib/WebDriverTimeouts.php
@@ -100,3 +100,5 @@ class WebDriverTimeouts
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverTimeouts::class, \Facebook\WebDriver\WebDriverTimeouts::class);

--- a/lib/WebDriverTimeouts.php
+++ b/lib/WebDriverTimeouts.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\ExecuteMethod;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\ExecuteMethod;
 
 /**
  * Managing timeout behavior for WebDriver instances.

--- a/lib/WebDriverUpAction.php
+++ b/lib/WebDriverUpAction.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Interactions\Touch\WebDriverTouchAction;
-use Facebook\WebDriver\Interactions\Touch\WebDriverTouchScreen;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchAction;
+use PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen;
 
 class WebDriverUpAction extends WebDriverTouchAction implements WebDriverAction
 {

--- a/lib/WebDriverUpAction.php
+++ b/lib/WebDriverUpAction.php
@@ -27,3 +27,5 @@ class WebDriverUpAction extends WebDriverTouchAction implements WebDriverAction
         $this->touchScreen->up($this->x, $this->y);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverUpAction::class, \Facebook\WebDriver\WebDriverUpAction::class);

--- a/lib/WebDriverWait.php
+++ b/lib/WebDriverWait.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\TimeoutException;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\TimeoutException;
 
 /**
  * A utility class, designed to help the user to wait until a condition turns true.

--- a/lib/WebDriverWait.php
+++ b/lib/WebDriverWait.php
@@ -71,3 +71,5 @@ class WebDriverWait
         throw new TimeoutException($message);
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverWait::class, \Facebook\WebDriver\WebDriverWait::class);

--- a/lib/WebDriverWindow.php
+++ b/lib/WebDriverWindow.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\IndexOutOfBoundsException;
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\ExecuteMethod;
+use PhpWebDriver\WebDriver\Exception\IndexOutOfBoundsException;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\ExecuteMethod;
 
 /**
  * An abstraction allowing the driver to manipulate the browser's window

--- a/lib/WebDriverWindow.php
+++ b/lib/WebDriverWindow.php
@@ -189,3 +189,5 @@ class WebDriverWindow
         return $this;
     }
 }
+
+class_alias(\PhpWebDriver\WebDriver\WebDriverWindow::class, \Facebook\WebDriver\WebDriverWindow::class);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,9 +6,9 @@ parameters:
 
     ignoreErrors:
         # To be fixed:
-        - '#Call to an undefined method Facebook\\WebDriver\\WebDriver::getTouch\(\)#'
-        - '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::getCoordinates\(\)#'
-        - '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::equals\(\)#'
+        - '#Call to an undefined method PhpWebDriver\\WebDriver\\WebDriver::getTouch\(\)#'
+        - '#Call to an undefined method PhpWebDriver\\WebDriver\\WebDriverElement::getCoordinates\(\)#'
+        - '#Call to an undefined method PhpWebDriver\\WebDriver\\WebDriverElement::equals\(\)#'
         - '#Unsafe usage of new static\(\)#'
 
         # Parameter is intentionally not part of signature to not break BC

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,7 @@
     </filter>
 
     <listeners>
-        <listener class="Facebook\WebDriver\ReportSauceLabsStatusListener"/>
+        <listener class="PhpWebDriver\WebDriver\ReportSauceLabsStatusListener"/>
     </listeners>
 
 </phpunit>

--- a/src/AbstractWebDriverCheckboxOrRadio.php
+++ b/src/AbstractWebDriverCheckboxOrRadio.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\AbstractWebDriverCheckboxOrRadio::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\AbstractWebDriverCheckboxOrRadio" instead. */
+    class AbstractWebDriverCheckboxOrRadio extends \PhpWebDriver\WebDriver\AbstractWebDriverCheckboxOrRadio
+    {
+    }
+}

--- a/src/Chrome/ChromeDevToolsDriver.php
+++ b/src/Chrome/ChromeDevToolsDriver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Chrome;
+
+class_exists(\PhpWebDriver\WebDriver\Chrome\ChromeDevToolsDriver::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Chrome\ChromeDevToolsDriver" instead. */
+    class ChromeDevToolsDriver extends \PhpWebDriver\WebDriver\Chrome\ChromeDevToolsDriver
+    {
+    }
+}

--- a/src/Chrome/ChromeDriver.php
+++ b/src/Chrome/ChromeDriver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Chrome;
+
+class_exists(\PhpWebDriver\WebDriver\Chrome\ChromeDriver::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Chrome\ChromeDriver" instead. */
+    class ChromeDriver extends \PhpWebDriver\WebDriver\Chrome\ChromeDriver
+    {
+    }
+}

--- a/src/Chrome/ChromeDriverService.php
+++ b/src/Chrome/ChromeDriverService.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Chrome;
+
+class_exists(\PhpWebDriver\WebDriver\Chrome\ChromeDriverService::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Chrome\ChromeDriverService" instead. */
+    class ChromeDriverService extends \PhpWebDriver\WebDriver\Chrome\ChromeDriverService
+    {
+    }
+}

--- a/src/Chrome/ChromeOptions.php
+++ b/src/Chrome/ChromeOptions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Chrome;
+
+class_exists(\PhpWebDriver\WebDriver\Chrome\ChromeOptions::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Chrome\ChromeOptions" instead. */
+    class ChromeOptions extends \PhpWebDriver\WebDriver\Chrome\ChromeOptions
+    {
+    }
+}

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\Cookie::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Cookie" instead. */
+    class Cookie extends \PhpWebDriver\WebDriver\Cookie
+    {
+    }
+}

--- a/src/Exception/DriverServerDiedException.php
+++ b/src/Exception/DriverServerDiedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\DriverServerDiedException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\DriverServerDiedException" instead. */
+    class DriverServerDiedException extends \PhpWebDriver\WebDriver\Exception\DriverServerDiedException
+    {
+    }
+}

--- a/src/Exception/ElementClickInterceptedException.php
+++ b/src/Exception/ElementClickInterceptedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\ElementClickInterceptedException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\ElementClickInterceptedException" instead. */
+    class ElementClickInterceptedException extends \PhpWebDriver\WebDriver\Exception\ElementClickInterceptedException
+    {
+    }
+}

--- a/src/Exception/ElementNotInteractableException.php
+++ b/src/Exception/ElementNotInteractableException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\ElementNotInteractableException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\ElementNotInteractableException" instead. */
+    class ElementNotInteractableException extends \PhpWebDriver\WebDriver\Exception\ElementNotInteractableException
+    {
+    }
+}

--- a/src/Exception/ElementNotSelectableException.php
+++ b/src/Exception/ElementNotSelectableException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\ElementNotSelectableException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\ElementNotSelectableException" instead. */
+    class ElementNotSelectableException extends \PhpWebDriver\WebDriver\Exception\ElementNotSelectableException
+    {
+    }
+}

--- a/src/Exception/ElementNotVisibleException.php
+++ b/src/Exception/ElementNotVisibleException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\ElementNotVisibleException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\ElementNotVisibleException" instead. */
+    class ElementNotVisibleException extends \PhpWebDriver\WebDriver\Exception\ElementNotVisibleException
+    {
+    }
+}

--- a/src/Exception/ExpectedException.php
+++ b/src/Exception/ExpectedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\ExpectedException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\ExpectedException" instead. */
+    class ExpectedException extends \PhpWebDriver\WebDriver\Exception\ExpectedException
+    {
+    }
+}

--- a/src/Exception/IMEEngineActivationFailedException.php
+++ b/src/Exception/IMEEngineActivationFailedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\IMEEngineActivationFailedException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\IMEEngineActivationFailedException" instead. */
+    class IMEEngineActivationFailedException extends \PhpWebDriver\WebDriver\Exception\IMEEngineActivationFailedException
+    {
+    }
+}

--- a/src/Exception/IMENotAvailableException.php
+++ b/src/Exception/IMENotAvailableException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\IMENotAvailableException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\IMENotAvailableException" instead. */
+    class IMENotAvailableException extends \PhpWebDriver\WebDriver\Exception\IMENotAvailableException
+    {
+    }
+}

--- a/src/Exception/IndexOutOfBoundsException.php
+++ b/src/Exception/IndexOutOfBoundsException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\IndexOutOfBoundsException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\IndexOutOfBoundsException" instead. */
+    class IndexOutOfBoundsException extends \PhpWebDriver\WebDriver\Exception\IndexOutOfBoundsException
+    {
+    }
+}

--- a/src/Exception/InsecureCertificateException.php
+++ b/src/Exception/InsecureCertificateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\InsecureCertificateException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\InsecureCertificateException" instead. */
+    class InsecureCertificateException extends \PhpWebDriver\WebDriver\Exception\InsecureCertificateException
+    {
+    }
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\InvalidArgumentException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\InvalidArgumentException" instead. */
+    class InvalidArgumentException extends \PhpWebDriver\WebDriver\Exception\InvalidArgumentException
+    {
+    }
+}

--- a/src/Exception/InvalidCookieDomainException.php
+++ b/src/Exception/InvalidCookieDomainException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\InvalidCookieDomainException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\InvalidCookieDomainException" instead. */
+    class InvalidCookieDomainException extends \PhpWebDriver\WebDriver\Exception\InvalidCookieDomainException
+    {
+    }
+}

--- a/src/Exception/InvalidCoordinatesException.php
+++ b/src/Exception/InvalidCoordinatesException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\InvalidCoordinatesException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\InvalidCoordinatesException" instead. */
+    class InvalidCoordinatesException extends \PhpWebDriver\WebDriver\Exception\InvalidCoordinatesException
+    {
+    }
+}

--- a/src/Exception/InvalidElementStateException.php
+++ b/src/Exception/InvalidElementStateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\InvalidElementStateException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\InvalidElementStateException" instead. */
+    class InvalidElementStateException extends \PhpWebDriver\WebDriver\Exception\InvalidElementStateException
+    {
+    }
+}

--- a/src/Exception/InvalidSelectorException.php
+++ b/src/Exception/InvalidSelectorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\InvalidSelectorException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\InvalidSelectorException" instead. */
+    class InvalidSelectorException extends \PhpWebDriver\WebDriver\Exception\InvalidSelectorException
+    {
+    }
+}

--- a/src/Exception/InvalidSessionIdException.php
+++ b/src/Exception/InvalidSessionIdException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\InvalidSessionIdException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\InvalidSessionIdException" instead. */
+    class InvalidSessionIdException extends \PhpWebDriver\WebDriver\Exception\InvalidSessionIdException
+    {
+    }
+}

--- a/src/Exception/JavascriptErrorException.php
+++ b/src/Exception/JavascriptErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\JavascriptErrorException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\JavascriptErrorException" instead. */
+    class JavascriptErrorException extends \PhpWebDriver\WebDriver\Exception\JavascriptErrorException
+    {
+    }
+}

--- a/src/Exception/MoveTargetOutOfBoundsException.php
+++ b/src/Exception/MoveTargetOutOfBoundsException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\MoveTargetOutOfBoundsException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\MoveTargetOutOfBoundsException" instead. */
+    class MoveTargetOutOfBoundsException extends \PhpWebDriver\WebDriver\Exception\MoveTargetOutOfBoundsException
+    {
+    }
+}

--- a/src/Exception/NoAlertOpenException.php
+++ b/src/Exception/NoAlertOpenException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoAlertOpenException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoAlertOpenException" instead. */
+    class NoAlertOpenException extends \PhpWebDriver\WebDriver\Exception\NoAlertOpenException
+    {
+    }
+}

--- a/src/Exception/NoCollectionException.php
+++ b/src/Exception/NoCollectionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoCollectionException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoCollectionException" instead. */
+    class NoCollectionException extends \PhpWebDriver\WebDriver\Exception\NoCollectionException
+    {
+    }
+}

--- a/src/Exception/NoScriptResultException.php
+++ b/src/Exception/NoScriptResultException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoScriptResultException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoScriptResultException" instead. */
+    class NoScriptResultException extends \PhpWebDriver\WebDriver\Exception\NoScriptResultException
+    {
+    }
+}

--- a/src/Exception/NoStringException.php
+++ b/src/Exception/NoStringException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoStringException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoStringException" instead. */
+    class NoStringException extends \PhpWebDriver\WebDriver\Exception\NoStringException
+    {
+    }
+}

--- a/src/Exception/NoStringLengthException.php
+++ b/src/Exception/NoStringLengthException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoStringLengthException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoStringLengthException" instead. */
+    class NoStringLengthException extends \PhpWebDriver\WebDriver\Exception\NoStringLengthException
+    {
+    }
+}

--- a/src/Exception/NoStringWrapperException.php
+++ b/src/Exception/NoStringWrapperException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoStringWrapperException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoStringWrapperException" instead. */
+    class NoStringWrapperException extends \PhpWebDriver\WebDriver\Exception\NoStringWrapperException
+    {
+    }
+}

--- a/src/Exception/NoSuchAlertException.php
+++ b/src/Exception/NoSuchAlertException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchAlertException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchAlertException" instead. */
+    class NoSuchAlertException extends \PhpWebDriver\WebDriver\Exception\NoSuchAlertException
+    {
+    }
+}

--- a/src/Exception/NoSuchCollectionException.php
+++ b/src/Exception/NoSuchCollectionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchCollectionException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchCollectionException" instead. */
+    class NoSuchCollectionException extends \PhpWebDriver\WebDriver\Exception\NoSuchCollectionException
+    {
+    }
+}

--- a/src/Exception/NoSuchCookieException.php
+++ b/src/Exception/NoSuchCookieException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchCookieException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchCookieException" instead. */
+    class NoSuchCookieException extends \PhpWebDriver\WebDriver\Exception\NoSuchCookieException
+    {
+    }
+}

--- a/src/Exception/NoSuchDocumentException.php
+++ b/src/Exception/NoSuchDocumentException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchDocumentException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchDocumentException" instead. */
+    class NoSuchDocumentException extends \PhpWebDriver\WebDriver\Exception\NoSuchDocumentException
+    {
+    }
+}

--- a/src/Exception/NoSuchDriverException.php
+++ b/src/Exception/NoSuchDriverException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchDriverException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchDriverException" instead. */
+    class NoSuchDriverException extends \PhpWebDriver\WebDriver\Exception\NoSuchDriverException
+    {
+    }
+}

--- a/src/Exception/NoSuchElementException.php
+++ b/src/Exception/NoSuchElementException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchElementException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchElementException" instead. */
+    class NoSuchElementException extends \PhpWebDriver\WebDriver\Exception\NoSuchElementException
+    {
+    }
+}

--- a/src/Exception/NoSuchFrameException.php
+++ b/src/Exception/NoSuchFrameException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchFrameException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchFrameException" instead. */
+    class NoSuchFrameException extends \PhpWebDriver\WebDriver\Exception\NoSuchFrameException
+    {
+    }
+}

--- a/src/Exception/NoSuchWindowException.php
+++ b/src/Exception/NoSuchWindowException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NoSuchWindowException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NoSuchWindowException" instead. */
+    class NoSuchWindowException extends \PhpWebDriver\WebDriver\Exception\NoSuchWindowException
+    {
+    }
+}

--- a/src/Exception/NullPointerException.php
+++ b/src/Exception/NullPointerException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\NullPointerException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\NullPointerException" instead. */
+    class NullPointerException extends \PhpWebDriver\WebDriver\Exception\NullPointerException
+    {
+    }
+}

--- a/src/Exception/ScriptTimeoutException.php
+++ b/src/Exception/ScriptTimeoutException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\ScriptTimeoutException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\ScriptTimeoutException" instead. */
+    class ScriptTimeoutException extends \PhpWebDriver\WebDriver\Exception\ScriptTimeoutException
+    {
+    }
+}

--- a/src/Exception/SessionNotCreatedException.php
+++ b/src/Exception/SessionNotCreatedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\SessionNotCreatedException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\SessionNotCreatedException" instead. */
+    class SessionNotCreatedException extends \PhpWebDriver\WebDriver\Exception\SessionNotCreatedException
+    {
+    }
+}

--- a/src/Exception/StaleElementReferenceException.php
+++ b/src/Exception/StaleElementReferenceException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\StaleElementReferenceException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\StaleElementReferenceException" instead. */
+    class StaleElementReferenceException extends \PhpWebDriver\WebDriver\Exception\StaleElementReferenceException
+    {
+    }
+}

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\TimeoutException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\TimeoutException" instead. */
+    class TimeoutException extends \PhpWebDriver\WebDriver\Exception\TimeoutException
+    {
+    }
+}

--- a/src/Exception/UnableToCaptureScreenException.php
+++ b/src/Exception/UnableToCaptureScreenException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnableToCaptureScreenException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnableToCaptureScreenException" instead. */
+    class UnableToCaptureScreenException extends \PhpWebDriver\WebDriver\Exception\UnableToCaptureScreenException
+    {
+    }
+}

--- a/src/Exception/UnableToSetCookieException.php
+++ b/src/Exception/UnableToSetCookieException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnableToSetCookieException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnableToSetCookieException" instead. */
+    class UnableToSetCookieException extends \PhpWebDriver\WebDriver\Exception\UnableToSetCookieException
+    {
+    }
+}

--- a/src/Exception/UnexpectedAlertOpenException.php
+++ b/src/Exception/UnexpectedAlertOpenException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnexpectedAlertOpenException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnexpectedAlertOpenException" instead. */
+    class UnexpectedAlertOpenException extends \PhpWebDriver\WebDriver\Exception\UnexpectedAlertOpenException
+    {
+    }
+}

--- a/src/Exception/UnexpectedJavascriptException.php
+++ b/src/Exception/UnexpectedJavascriptException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnexpectedJavascriptException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnexpectedJavascriptException" instead. */
+    class UnexpectedJavascriptException extends \PhpWebDriver\WebDriver\Exception\UnexpectedJavascriptException
+    {
+    }
+}

--- a/src/Exception/UnexpectedTagNameException.php
+++ b/src/Exception/UnexpectedTagNameException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException" instead. */
+    class UnexpectedTagNameException extends \PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException
+    {
+    }
+}

--- a/src/Exception/UnknownCommandException.php
+++ b/src/Exception/UnknownCommandException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnknownCommandException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnknownCommandException" instead. */
+    class UnknownCommandException extends \PhpWebDriver\WebDriver\Exception\UnknownCommandException
+    {
+    }
+}

--- a/src/Exception/UnknownErrorException.php
+++ b/src/Exception/UnknownErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnknownErrorException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnknownErrorException" instead. */
+    class UnknownErrorException extends \PhpWebDriver\WebDriver\Exception\UnknownErrorException
+    {
+    }
+}

--- a/src/Exception/UnknownMethodException.php
+++ b/src/Exception/UnknownMethodException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnknownMethodException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnknownMethodException" instead. */
+    class UnknownMethodException extends \PhpWebDriver\WebDriver\Exception\UnknownMethodException
+    {
+    }
+}

--- a/src/Exception/UnknownServerException.php
+++ b/src/Exception/UnknownServerException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnknownServerException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnknownServerException" instead. */
+    class UnknownServerException extends \PhpWebDriver\WebDriver\Exception\UnknownServerException
+    {
+    }
+}

--- a/src/Exception/UnrecognizedExceptionException.php
+++ b/src/Exception/UnrecognizedExceptionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnrecognizedExceptionException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnrecognizedExceptionException" instead. */
+    class UnrecognizedExceptionException extends \PhpWebDriver\WebDriver\Exception\UnrecognizedExceptionException
+    {
+    }
+}

--- a/src/Exception/UnsupportedOperationException.php
+++ b/src/Exception/UnsupportedOperationException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\UnsupportedOperationException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\UnsupportedOperationException" instead. */
+    class UnsupportedOperationException extends \PhpWebDriver\WebDriver\Exception\UnsupportedOperationException
+    {
+    }
+}

--- a/src/Exception/WebDriverCurlException.php
+++ b/src/Exception/WebDriverCurlException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\WebDriverCurlException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\WebDriverCurlException" instead. */
+    class WebDriverCurlException extends \PhpWebDriver\WebDriver\Exception\WebDriverCurlException
+    {
+    }
+}

--- a/src/Exception/WebDriverException.php
+++ b/src/Exception/WebDriverException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\WebDriverException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\WebDriverException" instead. */
+    class WebDriverException extends \PhpWebDriver\WebDriver\Exception\WebDriverException
+    {
+    }
+}

--- a/src/Exception/XPathLookupException.php
+++ b/src/Exception/XPathLookupException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+class_exists(\PhpWebDriver\WebDriver\Exception\XPathLookupException::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Exception\XPathLookupException" instead. */
+    class XPathLookupException extends \PhpWebDriver\WebDriver\Exception\XPathLookupException
+    {
+    }
+}

--- a/src/Firefox/FirefoxDriver.php
+++ b/src/Firefox/FirefoxDriver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+class_exists(\PhpWebDriver\WebDriver\Firefox\FirefoxDriver::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Firefox\FirefoxDriver" instead. */
+    class FirefoxDriver extends \PhpWebDriver\WebDriver\Firefox\FirefoxDriver
+    {
+    }
+}

--- a/src/Firefox/FirefoxDriverService.php
+++ b/src/Firefox/FirefoxDriverService.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+class_exists(\PhpWebDriver\WebDriver\Firefox\FirefoxDriverService::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Firefox\FirefoxDriverService" instead. */
+    class FirefoxDriverService extends \PhpWebDriver\WebDriver\Firefox\FirefoxDriverService
+    {
+    }
+}

--- a/src/Firefox/FirefoxOptions.php
+++ b/src/Firefox/FirefoxOptions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+class_exists(\PhpWebDriver\WebDriver\Firefox\FirefoxOptions::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Firefox\FirefoxOptions" instead. */
+    class FirefoxOptions extends \PhpWebDriver\WebDriver\Firefox\FirefoxOptions
+    {
+    }
+}

--- a/src/Firefox/FirefoxPreferences.php
+++ b/src/Firefox/FirefoxPreferences.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+class_exists(\PhpWebDriver\WebDriver\Firefox\FirefoxPreferences::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Firefox\FirefoxPreferences" instead. */
+    class FirefoxPreferences extends \PhpWebDriver\WebDriver\Firefox\FirefoxPreferences
+    {
+    }
+}

--- a/src/Firefox/FirefoxProfile.php
+++ b/src/Firefox/FirefoxProfile.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Firefox;
+
+class_exists(\PhpWebDriver\WebDriver\Firefox\FirefoxProfile::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Firefox\FirefoxProfile" instead. */
+    class FirefoxProfile extends \PhpWebDriver\WebDriver\Firefox\FirefoxProfile
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverButtonReleaseAction.php
+++ b/src/Interactions/Internal/WebDriverButtonReleaseAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction" instead. */
+    class WebDriverButtonReleaseAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverClickAction.php
+++ b/src/Interactions/Internal/WebDriverClickAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAction" instead. */
+    class WebDriverClickAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverClickAndHoldAction.php
+++ b/src/Interactions/Internal/WebDriverClickAndHoldAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction" instead. */
+    class WebDriverClickAndHoldAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverContextClickAction.php
+++ b/src/Interactions/Internal/WebDriverContextClickAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverContextClickAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverContextClickAction" instead. */
+    class WebDriverContextClickAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverContextClickAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverCoordinates.php
+++ b/src/Interactions/Internal/WebDriverCoordinates.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates" instead. */
+    class WebDriverCoordinates extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverDoubleClickAction.php
+++ b/src/Interactions/Internal/WebDriverDoubleClickAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverDoubleClickAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverDoubleClickAction" instead. */
+    class WebDriverDoubleClickAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverDoubleClickAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverKeyDownAction.php
+++ b/src/Interactions/Internal/WebDriverKeyDownAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyDownAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyDownAction" instead. */
+    class WebDriverKeyDownAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyDownAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverKeyUpAction.php
+++ b/src/Interactions/Internal/WebDriverKeyUpAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyUpAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyUpAction" instead. */
+    class WebDriverKeyUpAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyUpAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverKeysRelatedAction.php
+++ b/src/Interactions/Internal/WebDriverKeysRelatedAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction" instead. */
+    class WebDriverKeysRelatedAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverMouseAction.php
+++ b/src/Interactions/Internal/WebDriverMouseAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseAction" instead. */
+    class WebDriverMouseAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverMouseMoveAction.php
+++ b/src/Interactions/Internal/WebDriverMouseMoveAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseMoveAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseMoveAction" instead. */
+    class WebDriverMouseMoveAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseMoveAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverMoveToOffsetAction.php
+++ b/src/Interactions/Internal/WebDriverMoveToOffsetAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction" instead. */
+    class WebDriverMoveToOffsetAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverSendKeysAction.php
+++ b/src/Interactions/Internal/WebDriverSendKeysAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSendKeysAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSendKeysAction" instead. */
+    class WebDriverSendKeysAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSendKeysAction
+    {
+    }
+}

--- a/src/Interactions/Internal/WebDriverSingleKeyAction.php
+++ b/src/Interactions/Internal/WebDriverSingleKeyAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSingleKeyAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSingleKeyAction" instead. */
+    class WebDriverSingleKeyAction extends \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSingleKeyAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverDoubleTapAction.php
+++ b/src/Interactions/Touch/WebDriverDoubleTapAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDoubleTapAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDoubleTapAction" instead. */
+    class WebDriverDoubleTapAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDoubleTapAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverDownAction.php
+++ b/src/Interactions/Touch/WebDriverDownAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDownAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDownAction" instead. */
+    class WebDriverDownAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverDownAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverFlickAction.php
+++ b/src/Interactions/Touch/WebDriverFlickAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickAction" instead. */
+    class WebDriverFlickAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverFlickFromElementAction.php
+++ b/src/Interactions/Touch/WebDriverFlickFromElementAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction" instead. */
+    class WebDriverFlickFromElementAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverFlickFromElementAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverLongPressAction.php
+++ b/src/Interactions/Touch/WebDriverLongPressAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverLongPressAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverLongPressAction" instead. */
+    class WebDriverLongPressAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverLongPressAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverMoveAction.php
+++ b/src/Interactions/Touch/WebDriverMoveAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverMoveAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverMoveAction" instead. */
+    class WebDriverMoveAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverMoveAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverScrollAction.php
+++ b/src/Interactions/Touch/WebDriverScrollAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollAction" instead. */
+    class WebDriverScrollAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverScrollFromElementAction.php
+++ b/src/Interactions/Touch/WebDriverScrollFromElementAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction" instead. */
+    class WebDriverScrollFromElementAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverScrollFromElementAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverTapAction.php
+++ b/src/Interactions/Touch/WebDriverTapAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTapAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTapAction" instead. */
+    class WebDriverTapAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTapAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverTouchAction.php
+++ b/src/Interactions/Touch/WebDriverTouchAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchAction" instead. */
+    class WebDriverTouchAction extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchAction
+    {
+    }
+}

--- a/src/Interactions/Touch/WebDriverTouchScreen.php
+++ b/src/Interactions/Touch/WebDriverTouchScreen.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions\Touch;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen" instead. */
+    class WebDriverTouchScreen extends \PhpWebDriver\WebDriver\Interactions\Touch\WebDriverTouchScreen
+    {
+    }
+}

--- a/src/Interactions/WebDriverActions.php
+++ b/src/Interactions/WebDriverActions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\WebDriverActions::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\WebDriverActions" instead. */
+    class WebDriverActions extends \PhpWebDriver\WebDriver\Interactions\WebDriverActions
+    {
+    }
+}

--- a/src/Interactions/WebDriverCompositeAction.php
+++ b/src/Interactions/WebDriverCompositeAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\WebDriverCompositeAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\WebDriverCompositeAction" instead. */
+    class WebDriverCompositeAction extends \PhpWebDriver\WebDriver\Interactions\WebDriverCompositeAction
+    {
+    }
+}

--- a/src/Interactions/WebDriverTouchActions.php
+++ b/src/Interactions/WebDriverTouchActions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Interactions;
+
+class_exists(\PhpWebDriver\WebDriver\Interactions\WebDriverTouchActions::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Interactions\WebDriverTouchActions" instead. */
+    class WebDriverTouchActions extends \PhpWebDriver\WebDriver\Interactions\WebDriverTouchActions
+    {
+    }
+}

--- a/src/Internal/WebDriverLocatable.php
+++ b/src/Internal/WebDriverLocatable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Internal;
+
+class_exists(\PhpWebDriver\WebDriver\Internal\WebDriverLocatable::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Internal\WebDriverLocatable" instead. */
+    class WebDriverLocatable extends \PhpWebDriver\WebDriver\Internal\WebDriverLocatable
+    {
+    }
+}

--- a/src/JavaScriptExecutor.php
+++ b/src/JavaScriptExecutor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\JavaScriptExecutor::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\JavaScriptExecutor" instead. */
+    class JavaScriptExecutor extends \PhpWebDriver\WebDriver\JavaScriptExecutor
+    {
+    }
+}

--- a/src/Local/LocalWebDriver.php
+++ b/src/Local/LocalWebDriver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Local;
+
+class_exists(\PhpWebDriver\WebDriver\Local\LocalWebDriver::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Local\LocalWebDriver" instead. */
+    class LocalWebDriver extends \PhpWebDriver\WebDriver\Local\LocalWebDriver
+    {
+    }
+}

--- a/src/Net/URLChecker.php
+++ b/src/Net/URLChecker.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Net;
+
+class_exists(\PhpWebDriver\WebDriver\Net\URLChecker::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Net\URLChecker" instead. */
+    class URLChecker extends \PhpWebDriver\WebDriver\Net\URLChecker
+    {
+    }
+}

--- a/src/Remote/CustomWebDriverCommand.php
+++ b/src/Remote/CustomWebDriverCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\CustomWebDriverCommand::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\CustomWebDriverCommand" instead. */
+    class CustomWebDriverCommand extends \PhpWebDriver\WebDriver\Remote\CustomWebDriverCommand
+    {
+    }
+}

--- a/src/Remote/DesiredCapabilities.php
+++ b/src/Remote/DesiredCapabilities.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\DesiredCapabilities::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\DesiredCapabilities" instead. */
+    class DesiredCapabilities extends \PhpWebDriver\WebDriver\Remote\DesiredCapabilities
+    {
+    }
+}

--- a/src/Remote/DriverCommand.php
+++ b/src/Remote/DriverCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\DriverCommand::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\DriverCommand" instead. */
+    class DriverCommand extends \PhpWebDriver\WebDriver\Remote\DriverCommand
+    {
+    }
+}

--- a/src/Remote/ExecuteMethod.php
+++ b/src/Remote/ExecuteMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\ExecuteMethod::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\ExecuteMethod" instead. */
+    class ExecuteMethod extends \PhpWebDriver\WebDriver\Remote\ExecuteMethod
+    {
+    }
+}

--- a/src/Remote/FileDetector.php
+++ b/src/Remote/FileDetector.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\FileDetector::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\FileDetector" instead. */
+    class FileDetector extends \PhpWebDriver\WebDriver\Remote\FileDetector
+    {
+    }
+}

--- a/src/Remote/HttpCommandExecutor.php
+++ b/src/Remote/HttpCommandExecutor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\HttpCommandExecutor::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\HttpCommandExecutor" instead. */
+    class HttpCommandExecutor extends \PhpWebDriver\WebDriver\Remote\HttpCommandExecutor
+    {
+    }
+}

--- a/src/Remote/JsonWireCompat.php
+++ b/src/Remote/JsonWireCompat.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\JsonWireCompat::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\JsonWireCompat" instead. */
+    class JsonWireCompat extends \PhpWebDriver\WebDriver\Remote\JsonWireCompat
+    {
+    }
+}

--- a/src/Remote/LocalFileDetector.php
+++ b/src/Remote/LocalFileDetector.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\LocalFileDetector::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\LocalFileDetector" instead. */
+    class LocalFileDetector extends \PhpWebDriver\WebDriver\Remote\LocalFileDetector
+    {
+    }
+}

--- a/src/Remote/RemoteExecuteMethod.php
+++ b/src/Remote/RemoteExecuteMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteExecuteMethod::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteExecuteMethod" instead. */
+    class RemoteExecuteMethod extends \PhpWebDriver\WebDriver\Remote\RemoteExecuteMethod
+    {
+    }
+}

--- a/src/Remote/RemoteKeyboard.php
+++ b/src/Remote/RemoteKeyboard.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteKeyboard::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteKeyboard" instead. */
+    class RemoteKeyboard extends \PhpWebDriver\WebDriver\Remote\RemoteKeyboard
+    {
+    }
+}

--- a/src/Remote/RemoteMouse.php
+++ b/src/Remote/RemoteMouse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteMouse::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteMouse" instead. */
+    class RemoteMouse extends \PhpWebDriver\WebDriver\Remote\RemoteMouse
+    {
+    }
+}

--- a/src/Remote/RemoteStatus.php
+++ b/src/Remote/RemoteStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteStatus::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteStatus" instead. */
+    class RemoteStatus extends \PhpWebDriver\WebDriver\Remote\RemoteStatus
+    {
+    }
+}

--- a/src/Remote/RemoteTargetLocator.php
+++ b/src/Remote/RemoteTargetLocator.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteTargetLocator::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteTargetLocator" instead. */
+    class RemoteTargetLocator extends \PhpWebDriver\WebDriver\Remote\RemoteTargetLocator
+    {
+    }
+}

--- a/src/Remote/RemoteTouchScreen.php
+++ b/src/Remote/RemoteTouchScreen.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteTouchScreen::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteTouchScreen" instead. */
+    class RemoteTouchScreen extends \PhpWebDriver\WebDriver\Remote\RemoteTouchScreen
+    {
+    }
+}

--- a/src/Remote/RemoteWebDriver.php
+++ b/src/Remote/RemoteWebDriver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteWebDriver::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteWebDriver" instead. */
+    class RemoteWebDriver extends \PhpWebDriver\WebDriver\Remote\RemoteWebDriver
+    {
+    }
+}

--- a/src/Remote/RemoteWebElement.php
+++ b/src/Remote/RemoteWebElement.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\RemoteWebElement::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\RemoteWebElement" instead. */
+    class RemoteWebElement extends \PhpWebDriver\WebDriver\Remote\RemoteWebElement
+    {
+    }
+}

--- a/src/Remote/Service/DriverCommandExecutor.php
+++ b/src/Remote/Service/DriverCommandExecutor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Service;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor" instead. */
+    class DriverCommandExecutor extends \PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor
+    {
+    }
+}

--- a/src/Remote/Service/DriverService.php
+++ b/src/Remote/Service/DriverService.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote\Service;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\Service\DriverService::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\Service\DriverService" instead. */
+    class DriverService extends \PhpWebDriver\WebDriver\Remote\Service\DriverService
+    {
+    }
+}

--- a/src/Remote/UselessFileDetector.php
+++ b/src/Remote/UselessFileDetector.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\UselessFileDetector::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\UselessFileDetector" instead. */
+    class UselessFileDetector extends \PhpWebDriver\WebDriver\Remote\UselessFileDetector
+    {
+    }
+}

--- a/src/Remote/WebDriverBrowserType.php
+++ b/src/Remote/WebDriverBrowserType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\WebDriverBrowserType::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\WebDriverBrowserType" instead. */
+    class WebDriverBrowserType extends \PhpWebDriver\WebDriver\Remote\WebDriverBrowserType
+    {
+    }
+}

--- a/src/Remote/WebDriverCapabilityType.php
+++ b/src/Remote/WebDriverCapabilityType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\WebDriverCapabilityType::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\WebDriverCapabilityType" instead. */
+    class WebDriverCapabilityType extends \PhpWebDriver\WebDriver\Remote\WebDriverCapabilityType
+    {
+    }
+}

--- a/src/Remote/WebDriverCommand.php
+++ b/src/Remote/WebDriverCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\WebDriverCommand::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\WebDriverCommand" instead. */
+    class WebDriverCommand extends \PhpWebDriver\WebDriver\Remote\WebDriverCommand
+    {
+    }
+}

--- a/src/Remote/WebDriverResponse.php
+++ b/src/Remote/WebDriverResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+class_exists(\PhpWebDriver\WebDriver\Remote\WebDriverResponse::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Remote\WebDriverResponse" instead. */
+    class WebDriverResponse extends \PhpWebDriver\WebDriver\Remote\WebDriverResponse
+    {
+    }
+}

--- a/src/Support/Events/EventFiringWebDriver.php
+++ b/src/Support/Events/EventFiringWebDriver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Support\Events;
+
+class_exists(\PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriver::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriver" instead. */
+    class EventFiringWebDriver extends \PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriver
+    {
+    }
+}

--- a/src/Support/Events/EventFiringWebDriverNavigation.php
+++ b/src/Support/Events/EventFiringWebDriverNavigation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Support\Events;
+
+class_exists(\PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriverNavigation::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriverNavigation" instead. */
+    class EventFiringWebDriverNavigation extends \PhpWebDriver\WebDriver\Support\Events\EventFiringWebDriverNavigation
+    {
+    }
+}

--- a/src/Support/Events/EventFiringWebElement.php
+++ b/src/Support/Events/EventFiringWebElement.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Support\Events;
+
+class_exists(\PhpWebDriver\WebDriver\Support\Events\EventFiringWebElement::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Support\Events\EventFiringWebElement" instead. */
+    class EventFiringWebElement extends \PhpWebDriver\WebDriver\Support\Events\EventFiringWebElement
+    {
+    }
+}

--- a/src/Support/XPathEscaper.php
+++ b/src/Support/XPathEscaper.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver\Support;
+
+class_exists(\PhpWebDriver\WebDriver\Support\XPathEscaper::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\Support\XPathEscaper" instead. */
+    class XPathEscaper extends \PhpWebDriver\WebDriver\Support\XPathEscaper
+    {
+    }
+}

--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriver::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriver" instead. */
+    class WebDriver extends \PhpWebDriver\WebDriver\WebDriver
+    {
+    }
+}

--- a/src/WebDriverAction.php
+++ b/src/WebDriverAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverAction" instead. */
+    class WebDriverAction extends \PhpWebDriver\WebDriver\WebDriverAction
+    {
+    }
+}

--- a/src/WebDriverAlert.php
+++ b/src/WebDriverAlert.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverAlert::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverAlert" instead. */
+    class WebDriverAlert extends \PhpWebDriver\WebDriver\WebDriverAlert
+    {
+    }
+}

--- a/src/WebDriverBy.php
+++ b/src/WebDriverBy.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverBy::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverBy" instead. */
+    class WebDriverBy extends \PhpWebDriver\WebDriver\WebDriverBy
+    {
+    }
+}

--- a/src/WebDriverCapabilities.php
+++ b/src/WebDriverCapabilities.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverCapabilities::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverCapabilities" instead. */
+    class WebDriverCapabilities extends \PhpWebDriver\WebDriver\WebDriverCapabilities
+    {
+    }
+}

--- a/src/WebDriverCheckboxes.php
+++ b/src/WebDriverCheckboxes.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverCheckboxes::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverCheckboxes" instead. */
+    class WebDriverCheckboxes extends \PhpWebDriver\WebDriver\WebDriverCheckboxes
+    {
+    }
+}

--- a/src/WebDriverCommandExecutor.php
+++ b/src/WebDriverCommandExecutor.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverCommandExecutor::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverCommandExecutor" instead. */
+    class WebDriverCommandExecutor extends \PhpWebDriver\WebDriver\WebDriverCommandExecutor
+    {
+    }
+}

--- a/src/WebDriverDimension.php
+++ b/src/WebDriverDimension.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverDimension::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverDimension" instead. */
+    class WebDriverDimension extends \PhpWebDriver\WebDriver\WebDriverDimension
+    {
+    }
+}

--- a/src/WebDriverDispatcher.php
+++ b/src/WebDriverDispatcher.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverDispatcher::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverDispatcher" instead. */
+    class WebDriverDispatcher extends \PhpWebDriver\WebDriver\WebDriverDispatcher
+    {
+    }
+}

--- a/src/WebDriverElement.php
+++ b/src/WebDriverElement.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverElement::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverElement" instead. */
+    class WebDriverElement extends \PhpWebDriver\WebDriver\WebDriverElement
+    {
+    }
+}

--- a/src/WebDriverEventListener.php
+++ b/src/WebDriverEventListener.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverEventListener::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverEventListener" instead. */
+    class WebDriverEventListener extends \PhpWebDriver\WebDriver\WebDriverEventListener
+    {
+    }
+}

--- a/src/WebDriverExpectedCondition.php
+++ b/src/WebDriverExpectedCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverExpectedCondition::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverExpectedCondition" instead. */
+    class WebDriverExpectedCondition extends \PhpWebDriver\WebDriver\WebDriverExpectedCondition
+    {
+    }
+}

--- a/src/WebDriverHasInputDevices.php
+++ b/src/WebDriverHasInputDevices.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverHasInputDevices::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverHasInputDevices" instead. */
+    class WebDriverHasInputDevices extends \PhpWebDriver\WebDriver\WebDriverHasInputDevices
+    {
+    }
+}

--- a/src/WebDriverKeyboard.php
+++ b/src/WebDriverKeyboard.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverKeyboard::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverKeyboard" instead. */
+    class WebDriverKeyboard extends \PhpWebDriver\WebDriver\WebDriverKeyboard
+    {
+    }
+}

--- a/src/WebDriverKeys.php
+++ b/src/WebDriverKeys.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverKeys::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverKeys" instead. */
+    class WebDriverKeys extends \PhpWebDriver\WebDriver\WebDriverKeys
+    {
+    }
+}

--- a/src/WebDriverMouse.php
+++ b/src/WebDriverMouse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverMouse::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverMouse" instead. */
+    class WebDriverMouse extends \PhpWebDriver\WebDriver\WebDriverMouse
+    {
+    }
+}

--- a/src/WebDriverNavigation.php
+++ b/src/WebDriverNavigation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverNavigation::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverNavigation" instead. */
+    class WebDriverNavigation extends \PhpWebDriver\WebDriver\WebDriverNavigation
+    {
+    }
+}

--- a/src/WebDriverNavigationInterface.php
+++ b/src/WebDriverNavigationInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverNavigationInterface::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverNavigationInterface" instead. */
+    class WebDriverNavigationInterface extends \PhpWebDriver\WebDriver\WebDriverNavigationInterface
+    {
+    }
+}

--- a/src/WebDriverOptions.php
+++ b/src/WebDriverOptions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverOptions::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverOptions" instead. */
+    class WebDriverOptions extends \PhpWebDriver\WebDriver\WebDriverOptions
+    {
+    }
+}

--- a/src/WebDriverPlatform.php
+++ b/src/WebDriverPlatform.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverPlatform::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverPlatform" instead. */
+    class WebDriverPlatform extends \PhpWebDriver\WebDriver\WebDriverPlatform
+    {
+    }
+}

--- a/src/WebDriverPoint.php
+++ b/src/WebDriverPoint.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverPoint::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverPoint" instead. */
+    class WebDriverPoint extends \PhpWebDriver\WebDriver\WebDriverPoint
+    {
+    }
+}

--- a/src/WebDriverRadios.php
+++ b/src/WebDriverRadios.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverRadios::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverRadios" instead. */
+    class WebDriverRadios extends \PhpWebDriver\WebDriver\WebDriverRadios
+    {
+    }
+}

--- a/src/WebDriverSearchContext.php
+++ b/src/WebDriverSearchContext.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverSearchContext::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverSearchContext" instead. */
+    class WebDriverSearchContext extends \PhpWebDriver\WebDriver\WebDriverSearchContext
+    {
+    }
+}

--- a/src/WebDriverSelect.php
+++ b/src/WebDriverSelect.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverSelect::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverSelect" instead. */
+    class WebDriverSelect extends \PhpWebDriver\WebDriver\WebDriverSelect
+    {
+    }
+}

--- a/src/WebDriverSelectInterface.php
+++ b/src/WebDriverSelectInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverSelectInterface::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverSelectInterface" instead. */
+    class WebDriverSelectInterface extends \PhpWebDriver\WebDriver\WebDriverSelectInterface
+    {
+    }
+}

--- a/src/WebDriverTargetLocator.php
+++ b/src/WebDriverTargetLocator.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverTargetLocator::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverTargetLocator" instead. */
+    class WebDriverTargetLocator extends \PhpWebDriver\WebDriver\WebDriverTargetLocator
+    {
+    }
+}

--- a/src/WebDriverTimeouts.php
+++ b/src/WebDriverTimeouts.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverTimeouts::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverTimeouts" instead. */
+    class WebDriverTimeouts extends \PhpWebDriver\WebDriver\WebDriverTimeouts
+    {
+    }
+}

--- a/src/WebDriverUpAction.php
+++ b/src/WebDriverUpAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverUpAction::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverUpAction" instead. */
+    class WebDriverUpAction extends \PhpWebDriver\WebDriver\WebDriverUpAction
+    {
+    }
+}

--- a/src/WebDriverWait.php
+++ b/src/WebDriverWait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverWait::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverWait" instead. */
+    class WebDriverWait extends \PhpWebDriver\WebDriver\WebDriverWait
+    {
+    }
+}

--- a/src/WebDriverWindow.php
+++ b/src/WebDriverWindow.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+class_exists(\PhpWebDriver\WebDriver\WebDriverWindow::class);
+
+if (\false) {
+    /** @deprecated use "PhpWebDriver\WebDriver\WebDriverWindow" instead. */
+    class WebDriverWindow extends \PhpWebDriver\WebDriver\WebDriverWindow
+    {
+    }
+}

--- a/tests/functional/Chrome/ChromeDevToolsDriverTest.php
+++ b/tests/functional/Chrome/ChromeDevToolsDriverTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Chrome;
+namespace PhpWebDriver\WebDriver\Chrome;
 
-use Facebook\WebDriver\Remote\WebDriverBrowserType;
-use Facebook\WebDriver\WebDriverTestCase;
+use PhpWebDriver\WebDriver\Remote\WebDriverBrowserType;
+use PhpWebDriver\WebDriver\WebDriverTestCase;
 
 /**
  * @group exclude-saucelabs

--- a/tests/functional/Chrome/ChromeDriverServiceTest.php
+++ b/tests/functional/Chrome/ChromeDriverServiceTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Facebook\WebDriver\Chrome;
+namespace PhpWebDriver\WebDriver\Chrome;
 
-use Facebook\WebDriver\WebDriverTestCase;
+use PhpWebDriver\WebDriver\WebDriverTestCase;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @group exclude-saucelabs
- * @covers \Facebook\WebDriver\Chrome\ChromeDriverService
- * @covers \Facebook\WebDriver\Remote\Service\DriverService
+ * @covers \PhpWebDriver\WebDriver\Chrome\ChromeDriverService
+ * @covers \PhpWebDriver\WebDriver\Remote\Service\DriverService
  */
 class ChromeDriverServiceTest extends TestCase
 {

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Facebook\WebDriver\Chrome;
+namespace PhpWebDriver\WebDriver\Chrome;
 
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
-use Facebook\WebDriver\WebDriverTestCase;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor;
+use PhpWebDriver\WebDriver\WebDriverTestCase;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @group exclude-saucelabs
- * @covers \Facebook\WebDriver\Chrome\ChromeDriver
- * @covers \Facebook\WebDriver\Local\LocalWebDriver
+ * @covers \PhpWebDriver\WebDriver\Chrome\ChromeDriver
+ * @covers \PhpWebDriver\WebDriver\Local\LocalWebDriver
  */
 class ChromeDriverTest extends TestCase
 {

--- a/tests/functional/FileUploadTest.php
+++ b/tests/functional/FileUploadTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\LocalFileDetector;
+use PhpWebDriver\WebDriver\Remote\LocalFileDetector;
 
 /**
- * @covers \Facebook\WebDriver\Remote\LocalFileDetector
- * @covers \Facebook\WebDriver\Remote\RemoteWebElement
+ * @covers \PhpWebDriver\WebDriver\Remote\LocalFileDetector
+ * @covers \PhpWebDriver\WebDriver\Remote\RemoteWebElement
  */
 class FileUploadTest extends WebDriverTestCase
 {

--- a/tests/functional/Firefox/FirefoxDriverServiceTest.php
+++ b/tests/functional/Firefox/FirefoxDriverServiceTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
-use Facebook\WebDriver\WebDriverTestCase;
+use PhpWebDriver\WebDriver\WebDriverTestCase;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  * @group exclude-edge
  * @group exclude-chrome
  * @group exclude-safari
- * @covers \Facebook\WebDriver\Firefox\FirefoxDriverService
+ * @covers \PhpWebDriver\WebDriver\Firefox\FirefoxDriverService
  */
 class FirefoxDriverServiceTest extends TestCase
 {

--- a/tests/functional/Firefox/FirefoxDriverTest.php
+++ b/tests/functional/Firefox/FirefoxDriverTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
-use Facebook\WebDriver\WebDriverTestCase;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\Service\DriverCommandExecutor;
+use PhpWebDriver\WebDriver\WebDriverTestCase;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @group exclude-saucelabs
- * @covers \Facebook\WebDriver\Firefox\FirefoxDriver
- * @covers \Facebook\WebDriver\Local\LocalWebDriver
+ * @covers \PhpWebDriver\WebDriver\Firefox\FirefoxDriver
+ * @covers \PhpWebDriver\WebDriver\Local\LocalWebDriver
  */
 class FirefoxDriverTest extends TestCase
 {

--- a/tests/functional/RemoteKeyboardTest.php
+++ b/tests/functional/RemoteKeyboardTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
- * @covers  \Facebook\WebDriver\Remote\RemoteKeyboard
+ * @covers  \PhpWebDriver\WebDriver\Remote\RemoteKeyboard
  */
 class RemoteKeyboardTest extends WebDriverTestCase
 {

--- a/tests/functional/RemoteTargetLocatorTest.php
+++ b/tests/functional/RemoteTargetLocatorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\RemoteWebElement;
+use PhpWebDriver\WebDriver\Remote\RemoteWebElement;
 
 /**
- * @covers \Facebook\WebDriver\Remote\RemoteTargetLocator
+ * @covers \PhpWebDriver\WebDriver\Remote\RemoteTargetLocator
  */
 class RemoteTargetLocatorTest extends WebDriverTestCase
 {

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\HttpCommandExecutor;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Facebook\WebDriver\Remote\WebDriverBrowserType;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\HttpCommandExecutor;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\WebDriverBrowserType;
 
 /**
- * @covers \Facebook\WebDriver\Remote\HttpCommandExecutor
- * @covers \Facebook\WebDriver\Remote\RemoteWebDriver
+ * @covers \PhpWebDriver\WebDriver\Remote\HttpCommandExecutor
+ * @covers \PhpWebDriver\WebDriver\Remote\RemoteWebDriver
  */
 class RemoteWebDriverCreateTest extends WebDriverTestCase
 {

--- a/tests/functional/RemoteWebDriverFindElementTest.php
+++ b/tests/functional/RemoteWebDriverFindElementTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Remote\RemoteWebElement;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Remote\RemoteWebElement;
 
 /**
  * Tests for findElement() and findElements() method of RemoteWebDriver.
- * @covers \Facebook\WebDriver\Remote\RemoteWebDriver
+ * @covers \PhpWebDriver\WebDriver\Remote\RemoteWebDriver
  */
 class RemoteWebDriverFindElementTest extends WebDriverTestCase
 {

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\HttpCommandExecutor;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\HttpCommandExecutor;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
 
 /**
- * @coversDefaultClass \Facebook\WebDriver\Remote\RemoteWebDriver
+ * @coversDefaultClass \PhpWebDriver\WebDriver\Remote\RemoteWebDriver
  */
 class RemoteWebDriverTest extends WebDriverTestCase
 {
@@ -186,7 +186,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
 
     /**
      * @covers ::executeAsyncScript
-     * @covers \Facebook\WebDriver\WebDriverTimeouts::setScriptTimeout
+     * @covers \PhpWebDriver\WebDriver\WebDriverTimeouts::setScriptTimeout
      */
     public function testShouldExecuteAsyncScriptAndWaitUntilItIsFinished()
     {
@@ -308,7 +308,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
 
     /**
      * @covers ::getStatus
-     * @covers \Facebook\WebDriver\Remote\RemoteStatus
+     * @covers \PhpWebDriver\WebDriver\Remote\RemoteStatus
      * @group exclude-saucelabs
      * Status endpoint is not supported on Sauce Labs
      */

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\ElementNotInteractableException;
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Remote\RemoteWebElement;
+use PhpWebDriver\WebDriver\Exception\ElementNotInteractableException;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Remote\RemoteWebElement;
 use OndraM\CiDetector\CiDetector;
 
 /**
- * @coversDefaultClass \Facebook\WebDriver\Remote\RemoteWebElement
+ * @coversDefaultClass \PhpWebDriver\WebDriver\Remote\RemoteWebElement
  */
 class RemoteWebElementTest extends WebDriverTestCase
 {

--- a/tests/functional/ReportSauceLabsStatusListener.php
+++ b/tests/functional/ReportSauceLabsStatusListener.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
 use PHPUnit\Framework\TestListener;
 use Throwable;
 

--- a/tests/functional/RetrieveEventsTrait.php
+++ b/tests/functional/RetrieveEventsTrait.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
 
 trait RetrieveEventsTrait
 {

--- a/tests/functional/WebDriverActionsTest.php
+++ b/tests/functional/WebDriverActionsTest.php
@@ -1,25 +1,25 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\WebDriverBrowserType;
+use PhpWebDriver\WebDriver\Remote\WebDriverBrowserType;
 
 /**
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverClickAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverContextClickAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverDoubleClickAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverKeyDownAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverKeyUpAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverMouseAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverMouseMoveAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverSendKeysAction
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverSingleKeyAction
- * @covers \Facebook\WebDriver\Interactions\WebDriverActions
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverButtonReleaseAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverClickAndHoldAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverContextClickAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverCoordinates
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverDoubleClickAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyDownAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeysRelatedAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverKeyUpAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMouseMoveAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverMoveToOffsetAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSendKeysAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSingleKeyAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\WebDriverActions
  */
 class WebDriverActionsTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverAlertTest.php
+++ b/tests/functional/WebDriverAlertTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoAlertOpenException;
-use Facebook\WebDriver\Exception\NoSuchAlertException;
+use PhpWebDriver\WebDriver\Exception\NoAlertOpenException;
+use PhpWebDriver\WebDriver\Exception\NoSuchAlertException;
 
 /**
- * @covers \Facebook\WebDriver\Remote\RemoteTargetLocator
- * @covers \Facebook\WebDriver\WebDriverAlert
+ * @covers \PhpWebDriver\WebDriver\Remote\RemoteTargetLocator
+ * @covers \PhpWebDriver\WebDriver\WebDriverAlert
  */
 class WebDriverAlertTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverByTest.php
+++ b/tests/functional/WebDriverByTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\RemoteWebElement;
+use PhpWebDriver\WebDriver\Remote\RemoteWebElement;
 
 /**
  * Tests for locator strategies provided by WebDriverBy.
- * @covers \Facebook\WebDriver\WebDriverBy
+ * @covers \PhpWebDriver\WebDriver\WebDriverBy
  */
 class WebDriverByTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverCheckboxesTest.php
+++ b/tests/functional/WebDriverCheckboxesTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
 
 /**
- * @covers \Facebook\WebDriver\AbstractWebDriverCheckboxOrRadio
- * @covers \Facebook\WebDriver\WebDriverCheckboxes
+ * @covers \PhpWebDriver\WebDriver\AbstractWebDriverCheckboxOrRadio
+ * @covers \PhpWebDriver\WebDriver\WebDriverCheckboxes
  * @group exclude-edge
  */
 class WebDriverCheckboxesTest extends WebDriverTestCase

--- a/tests/functional/WebDriverNavigationTest.php
+++ b/tests/functional/WebDriverNavigationTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
- * @coversDefaultClass \Facebook\WebDriver\WebDriverNavigation
+ * @coversDefaultClass \PhpWebDriver\WebDriver\WebDriverNavigation
  */
 class WebDriverNavigationTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverOptionsCookiesTest.php
+++ b/tests/functional/WebDriverOptionsCookiesTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchCookieException;
+use PhpWebDriver\WebDriver\Exception\NoSuchCookieException;
 
 /**
- * @covers \Facebook\WebDriver\WebDriverOptions
+ * @covers \PhpWebDriver\WebDriver\WebDriverOptions
  */
 class WebDriverOptionsCookiesTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverRadiosTest.php
+++ b/tests/functional/WebDriverRadiosTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
 
 /**
- * @covers \Facebook\WebDriver\AbstractWebDriverCheckboxOrRadio
- * @covers \Facebook\WebDriver\WebDriverRadios
+ * @covers \PhpWebDriver\WebDriver\AbstractWebDriverCheckboxOrRadio
+ * @covers \PhpWebDriver\WebDriver\WebDriverRadios
  * @group exclude-edge
  */
 class WebDriverRadiosTest extends WebDriverTestCase

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\UnexpectedTagNameException;
-use Facebook\WebDriver\Exception\UnsupportedOperationException;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException;
+use PhpWebDriver\WebDriver\Exception\UnsupportedOperationException;
 
 /**
  * @group exclude-saucelabs
- * @covers \Facebook\WebDriver\Exception\UnexpectedTagNameException
- * @covers \Facebook\WebDriver\WebDriverSelect
+ * @covers \PhpWebDriver\WebDriver\Exception\UnexpectedTagNameException
+ * @covers \PhpWebDriver\WebDriver\WebDriverSelect
  */
 class WebDriverSelectTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Chrome\ChromeOptions;
-use Facebook\WebDriver\Exception\NoSuchWindowException;
-use Facebook\WebDriver\Exception\WebDriverException;
-use Facebook\WebDriver\Firefox\FirefoxOptions;
-use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Facebook\WebDriver\Remote\WebDriverBrowserType;
+use PhpWebDriver\WebDriver\Chrome\ChromeOptions;
+use PhpWebDriver\WebDriver\Exception\NoSuchWindowException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Firefox\FirefoxOptions;
+use PhpWebDriver\WebDriver\Remote\DesiredCapabilities;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\WebDriverBrowserType;
 use OndraM\CiDetector\CiDetector;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/functional/WebDriverTimeoutsTest.php
+++ b/tests/functional/WebDriverTimeoutsTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\ScriptTimeoutException;
-use Facebook\WebDriver\Exception\TimeoutException;
-use Facebook\WebDriver\Remote\RemoteWebElement;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\ScriptTimeoutException;
+use PhpWebDriver\WebDriver\Exception\TimeoutException;
+use PhpWebDriver\WebDriver\Remote\RemoteWebElement;
 
 /**
- * @coversDefaultClass \Facebook\WebDriver\WebDriverTimeouts
+ * @coversDefaultClass \PhpWebDriver\WebDriver\WebDriverTimeouts
  */
 class WebDriverTimeoutsTest extends WebDriverTestCase
 {

--- a/tests/functional/WebDriverWindowTest.php
+++ b/tests/functional/WebDriverWindowTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 /**
- * @covers \Facebook\WebDriver\WebDriverWindow
+ * @covers \PhpWebDriver\WebDriver\WebDriverWindow
  */
 class WebDriverWindowTest extends WebDriverTestCase
 {

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Facebook\WebDriver\Cookie
+ * @covers \PhpWebDriver\WebDriver\Cookie
  */
 class CookieTest extends TestCase
 {

--- a/tests/unit/Exception/DriverServerDiedExceptionTest.php
+++ b/tests/unit/Exception/DriverServerDiedExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/Exception/WebDriverExceptionTest.php
+++ b/tests/unit/Exception/WebDriverExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Exception;
+namespace PhpWebDriver\WebDriver\Exception;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/Firefox/FirefoxOptionsTest.php
+++ b/tests/unit/Firefox/FirefoxOptionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Firefox;
+namespace PhpWebDriver\WebDriver\Firefox;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverButtonReleaseActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverClickActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverClickAndHoldActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverContextClickActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\WebDriverPoint;
+use PhpWebDriver\WebDriver\WebDriverPoint;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverCoordinatesTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverDoubleClickActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverKeys;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverKeys;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverKeyDownActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverKeys;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverKeys;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverKeyUpActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverMouseMoveActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverMouseToOffsetActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 class WebDriverSendKeysActionTest extends TestCase

--- a/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Facebook\WebDriver\Interactions\Internal;
+namespace PhpWebDriver\WebDriver\Interactions\Internal;
 
-use Facebook\WebDriver\Internal\WebDriverLocatable;
-use Facebook\WebDriver\WebDriverKeyboard;
-use Facebook\WebDriver\WebDriverMouse;
+use PhpWebDriver\WebDriver\Internal\WebDriverLocatable;
+use PhpWebDriver\WebDriver\WebDriverKeyboard;
+use PhpWebDriver\WebDriver\WebDriverMouse;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Facebook\WebDriver\Interactions\Internal\WebDriverSingleKeyAction
+ * @covers \PhpWebDriver\WebDriver\Interactions\Internal\WebDriverSingleKeyAction
  */
 class WebDriverSingleKeyActionTest extends TestCase
 {

--- a/tests/unit/Remote/CustomWebDriverCommandTest.php
+++ b/tests/unit/Remote/CustomWebDriverCommandTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Exception\WebDriverException;
+use PhpWebDriver\WebDriver\Exception\WebDriverException;
 use PHPUnit\Framework\TestCase;
 
 class CustomWebDriverCommandTest extends TestCase

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Chrome\ChromeOptions;
-use Facebook\WebDriver\Firefox\FirefoxDriver;
-use Facebook\WebDriver\Firefox\FirefoxOptions;
-use Facebook\WebDriver\Firefox\FirefoxOptionsTest;
-use Facebook\WebDriver\Firefox\FirefoxProfile;
-use Facebook\WebDriver\WebDriverPlatform;
+use PhpWebDriver\WebDriver\Chrome\ChromeOptions;
+use PhpWebDriver\WebDriver\Firefox\FirefoxDriver;
+use PhpWebDriver\WebDriver\Firefox\FirefoxOptions;
+use PhpWebDriver\WebDriver\Firefox\FirefoxOptionsTest;
+use PhpWebDriver\WebDriver\Firefox\FirefoxProfile;
+use PhpWebDriver\WebDriver\WebDriverPlatform;
 use PHPUnit\Framework\TestCase;
 
 class DesiredCapabilitiesTest extends TestCase

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/Remote/LocalFileDetectorTest.php
+++ b/tests/unit/Remote/LocalFileDetectorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
-use Facebook\WebDriver\Interactions\WebDriverActions;
-use Facebook\WebDriver\WebDriverNavigation;
-use Facebook\WebDriver\WebDriverOptions;
-use Facebook\WebDriver\WebDriverWait;
+use PhpWebDriver\WebDriver\Interactions\WebDriverActions;
+use PhpWebDriver\WebDriver\WebDriverNavigation;
+use PhpWebDriver\WebDriver\WebDriverOptions;
+use PhpWebDriver\WebDriver\WebDriverWait;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Unit part of RemoteWebDriver tests. Ie. tests for behavior which do not interact with the real remote server.
  *
- * @coversDefaultClass \Facebook\WebDriver\Remote\RemoteWebDriver
+ * @coversDefaultClass \PhpWebDriver\WebDriver\Remote\RemoteWebDriver
  */
 class RemoteWebDriverTest extends TestCase
 {

--- a/tests/unit/Remote/RemoteWebElementTest.php
+++ b/tests/unit/Remote/RemoteWebElementTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 use PHPUnit\Framework\TestCase;
 
 /**
  * Unit part of RemoteWebDriver tests. Ie. tests for behavior which do not interact with the real remote server.
  *
- * @coversDefaultClass \Facebook\WebDriver\Remote\RemoteWebElement
+ * @coversDefaultClass \PhpWebDriver\WebDriver\Remote\RemoteWebElement
  */
 class RemoteWebElementTest extends TestCase
 {

--- a/tests/unit/Remote/WebDriverCommandTest.php
+++ b/tests/unit/Remote/WebDriverCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Remote;
+namespace PhpWebDriver\WebDriver\Remote;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/Support/XPathEscaperTest.php
+++ b/tests/unit/Support/XPathEscaperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Facebook\WebDriver\Support;
+namespace PhpWebDriver\WebDriver\Support;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
-use Facebook\WebDriver\Exception\StaleElementReferenceException;
-use Facebook\WebDriver\Remote\RemoteExecuteMethod;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
-use Facebook\WebDriver\Remote\RemoteWebElement;
+use PhpWebDriver\WebDriver\Exception\NoSuchElementException;
+use PhpWebDriver\WebDriver\Exception\StaleElementReferenceException;
+use PhpWebDriver\WebDriver\Remote\RemoteExecuteMethod;
+use PhpWebDriver\WebDriver\Remote\RemoteWebDriver;
+use PhpWebDriver\WebDriver\Remote\RemoteWebElement;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Facebook\WebDriver\WebDriverExpectedCondition
+ * @covers \PhpWebDriver\WebDriver\WebDriverExpectedCondition
  */
 class WebDriverExpectedConditionTest extends TestCase
 {

--- a/tests/unit/WebDriverKeysTest.php
+++ b/tests/unit/WebDriverKeysTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Facebook\WebDriver\WebDriverKeys
+ * @covers \PhpWebDriver\WebDriver\WebDriverKeys
  */
 class WebDriverKeysTest extends TestCase
 {

--- a/tests/unit/WebDriverOptionsTest.php
+++ b/tests/unit/WebDriverOptionsTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Facebook\WebDriver;
+namespace PhpWebDriver\WebDriver;
 
-use Facebook\WebDriver\Remote\DriverCommand;
-use Facebook\WebDriver\Remote\ExecuteMethod;
+use PhpWebDriver\WebDriver\Remote\DriverCommand;
+use PhpWebDriver\WebDriver\Remote\ExecuteMethod;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Facebook\WebDriver\WebDriverOptions
+ * @covers \PhpWebDriver\WebDriver\WebDriverOptions
  */
 class WebDriverOptionsTest extends TestCase
 {


### PR DESCRIPTION
- Renames the `Facebook` vendor namespace to `PhpWebDriver` (including classes with `@deprecated` annotation).
- Adds class aliases for `Facebook` vendor namespace.
- Adds `@deprecated` annotation for classes with `Facebook` vendor namespace.

Related to https://github.com/php-webdriver/php-webdriver/pull/914.

The new files in the `src` directory are used by Composer to generate its class maps. And the fully qualified `\false` is required in PHP 5 to ensure it is a dead code, since it can be overwritten in PHP 5.