### PR TITLE
Disable sauce labs tests on forks

### DIFF
--- a/.github/workflows/sauce-labs.yaml
+++ b/.github/workflows/sauce-labs.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    # Source: https://github.community/t/do-not-run-cron-workflows-in-forks/17636/2?u=williamdes
+    if: (github.event_name == 'schedule' && github.repository == 'php-webdriver/php-webdriver') || (github.event_name != 'schedule')
     env:
       SAUCELABS: 1
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
Source: https://github.com/phpmyadmin/phpmyadmin/commit/8021847847714a6546b6af20579b82ab98da59e5

I have had emails, like every day or so to let me know the sauce labs cron failed on my fork

To avoid this amount of frustration to someone else, I suggest to disable this cron that can not work without the ENV on forks 