### PR TITLE
Add getDomProperty method to read JavaScript properties of elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- `RemoteWebElement::getDomProperty()` method to read JavaScript properties of an element (like the value of `innerHTML` etc.) in W3C mode.
+
 ### Changed
 - Allow installation of Symfony 6 components.
 

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -3,6 +3,7 @@
 namespace Facebook\WebDriver\Remote;
 
 use Facebook\WebDriver\Exception\ElementNotInteractableException;
+use Facebook\WebDriver\Exception\UnsupportedOperationException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
@@ -132,6 +133,8 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
 
     /**
      * Get the value of the given attribute of the element.
+     * Attribute is meant what is declared in the HTML markup of the element.
+     * To read a value of a IDL "JavaScript" property (like `innerHTML`), use `getDomProperty()` method.
      *
      * @param string $attribute_name The name of the attribute.
      * @return string|null The value of the attribute.
@@ -160,6 +163,28 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
         }
 
         return $this->executor->execute(DriverCommand::GET_ELEMENT_ATTRIBUTE, $params);
+    }
+
+    /**
+     * Gets the value of a IDL JavaScript property of this element (for example `innerHTML`, `tagName` etc.).
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Glossary/IDL
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Element#properties
+     * @param string $propertyName
+     * @return string|null The property's current value or null if the value is not set or the property does not exist.
+     */
+    public function getDomProperty($propertyName)
+    {
+        if (!$this->isW3cCompliant) {
+            throw new UnsupportedOperationException('This method is only supported in W3C mode');
+        }
+
+        $params = [
+            ':name' => $propertyName,
+            ':id' => $this->id,
+        ];
+
+        return $this->executor->execute(DriverCommand::GET_ELEMENT_PROPERTY, $params);
     }
 
     /**

--- a/lib/WebDriverElement.php
+++ b/lib/WebDriverElement.php
@@ -22,12 +22,25 @@ interface WebDriverElement extends WebDriverSearchContext
     public function click();
 
     /**
-     * Get the value of a the given attribute of the element.
+     * Get the value of the given attribute of the element.
+     * Attribute is meant what is declared in the HTML markup of the element.
+     * To read a value of a IDL "JavaScript" property (like `innerHTML`), use `getDomProperty()` method.
      *
      * @param string $attribute_name The name of the attribute.
      * @return string|null The value of the attribute.
      */
     public function getAttribute($attribute_name);
+
+    /*
+     * Gets the value of a IDL JavaScript property of this element (for example `innerHTML`, `tagName` etc.).
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Glossary/IDL
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Element#properties
+     * @param string $propertyName
+     * @return string|null The property's current value or null if the value is not set or the property does not exist.
+     * @todo Add in next major release (BC)
+     */
+    // public function getDomProperty($propertyName);
 
     /**
      * Get the value of a given CSS property.

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -42,6 +42,29 @@ class RemoteWebElementTest extends WebDriverTestCase
         $this->assertSame('note', $element->getAttribute('role'));
         $this->assertSame('height: 5em; border: 1px solid black;', $element->getAttribute('style'));
         $this->assertSame('text-simple', $element->getAttribute('id'));
+        $this->assertNull($element->getAttribute('notExisting'));
+    }
+
+    /**
+     * @covers ::getDomProperty
+     */
+    public function testShouldGetDomPropertyValue()
+    {
+        self::skipForJsonWireProtocol();
+
+        $this->driver->get($this->getTestPageUrl('index.html'));
+
+        $element = $this->driver->findElement(WebDriverBy::id('div-with-html'));
+
+        $this->assertStringContainsString(
+            ' <p>This <code>div</code> has some more <strong>html</strong> inside.</p>',
+            $element->getDomProperty('innerHTML')
+        );
+        $this->assertSame('foo bar', $element->getDomProperty('className')); // IDL property
+        $this->assertSame('foo bar', $element->getAttribute('class')); // HTML attribute should be the same
+        $this->assertSame('DIV', $element->getDomProperty('tagName'));
+        $this->assertSame(2, $element->getDomProperty('childElementCount'));
+        $this->assertNull($element->getDomProperty('notExistingProperty'));
     }
 
     /**
@@ -56,7 +79,7 @@ class RemoteWebElementTest extends WebDriverTestCase
         $elementLocation = $element->getLocation();
         $this->assertInstanceOf(WebDriverPoint::class, $elementLocation);
         $this->assertSame(33, $elementLocation->getX());
-        $this->assertSame(500, $elementLocation->getY());
+        $this->assertSame(550, $elementLocation->getY());
     }
 
     /**

--- a/tests/functional/web/index.html
+++ b/tests/functional/web/index.html
@@ -60,7 +60,12 @@
     stripped
 </p>
 
-<div id="element-with-location" style="position: absolute; top: 500px; left: 33px; width: 333px; height: 66px;">
+<div id="div-with-html" style="font-size: inherit;" title="Title" class="foo bar">
+    <p>This <code>div</code> has some more <strong>html</strong> inside.</p>
+    <hr />
+</div>
+
+<div id="element-with-location" style="position: absolute; top: 550px; left: 33px; width: 333px; height: 66px;">
     Foo
 </div>
 


### PR DESCRIPTION
This method uses [WebDriver's Get Element Property](https://w3c.github.io/webdriver/#get-element-property) endpoint, which allows to read [IDL properties](https://developer.mozilla.org/en-US/docs/Glossary/IDL) (aka "JavaScript" properties) of on element.

Example of of the properties [can be found on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element#properties) - this includes `innerHTML`, `outerHTML`, `childElementCount` etc.

Fixes #929 . Ref. #921 #928.

- [x] Update [wiki](https://github.com/php-webdriver/php-webdriver/wiki/Example-command-reference) with examples and description of difference between attribute and property