### PR TITLE
Do not use unsafe static when accessing private propery

### DIFF
--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -30,7 +30,7 @@ class DesiredCapabilities implements WebDriverCapabilities
 
     public static function createFromW3cCapabilities(array $capabilities = [])
     {
-        $w3cToOss = array_flip(static::$ossToW3c);
+        $w3cToOss = array_flip(self::$ossToW3c);
 
         foreach ($w3cToOss as $w3cCapability => $ossCapability) {
             // Copy W3C capabilities to OSS ones
@@ -229,16 +229,16 @@ class DesiredCapabilities implements WebDriverCapabilities
             }
 
             // Convert capabilities with changed name
-            if (array_key_exists($capabilityKey, static::$ossToW3c)) {
+            if (array_key_exists($capabilityKey, self::$ossToW3c)) {
                 if ($capabilityKey === WebDriverCapabilityType::PLATFORM) {
-                    $w3cCapabilities[static::$ossToW3c[$capabilityKey]] = mb_strtolower($capabilityValue);
+                    $w3cCapabilities[self::$ossToW3c[$capabilityKey]] = mb_strtolower($capabilityValue);
 
                     // Remove platformName if it is set to "any"
-                    if ($w3cCapabilities[static::$ossToW3c[$capabilityKey]] === 'any') {
-                        unset($w3cCapabilities[static::$ossToW3c[$capabilityKey]]);
+                    if ($w3cCapabilities[self::$ossToW3c[$capabilityKey]] === 'any') {
+                        unset($w3cCapabilities[self::$ossToW3c[$capabilityKey]]);
                     }
                 } else {
-                    $w3cCapabilities[static::$ossToW3c[$capabilityKey]] = $capabilityValue;
+                    $w3cCapabilities[self::$ossToW3c[$capabilityKey]] = $capabilityValue;
                 }
             }
 


### PR DESCRIPTION
Phpstan complains:

```
> vendor/bin/phpstan analyze -c phpstan.neon --ansi
 207/207 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------------------------------------------------------- 
  Line   lib/Remote/DesiredCapabilities.php                                                                            
 ------ -------------------------------------------------------------------------------------------------------------- 
  33     Unsafe access to private property Facebook\WebDriver\Remote\DesiredCapabilities::$ossToW3c through static::.  
  232    Unsafe access to private property Facebook\WebDriver\Remote\DesiredCapabilities::$ossToW3c through static::.  
  234    Unsafe access to private property Facebook\WebDriver\Remote\DesiredCapabilities::$ossToW3c through static::.  
  237    Unsafe access to private property Facebook\WebDriver\Remote\DesiredCapabilities::$ossToW3c through static::.  
  238    Unsafe access to private property Facebook\WebDriver\Remote\DesiredCapabilities::$ossToW3c through static::.  
  241    Unsafe access to private property Facebook\WebDriver\Remote\DesiredCapabilities::$ossToW3c through static::.  
```

And that is true. You could overwrite `ossToW3c` in descendant and break the code. Because it must be PHP 5.6 compatibile, there is also no type compatibility guaranteed.

As all of this already private, it should not make any difference.