### PR TITLE
Fix phpdoc for getAttribute and getDomProperty to match the specs

### DIFF
--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -137,7 +137,8 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      * To read a value of a IDL "JavaScript" property (like `innerHTML`), use `getDomProperty()` method.
      *
      * @param string $attribute_name The name of the attribute.
-     * @return string|null The value of the attribute.
+     * @return string|true|null The value of the attribute. If this is boolean attribute, return true if the element
+     *      has it, otherwise return null.
      */
     public function getAttribute($attribute_name)
     {
@@ -171,7 +172,7 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      * @see https://developer.mozilla.org/en-US/docs/Glossary/IDL
      * @see https://developer.mozilla.org/en-US/docs/Web/API/Element#properties
      * @param string $propertyName
-     * @return string|null The property's current value or null if the value is not set or the property does not exist.
+     * @return mixed|null The property's current value or null if the value is not set or the property does not exist.
      */
     public function getDomProperty($propertyName)
     {


### PR DESCRIPTION
According to W3C Specs, [getElementAttribute()](https://w3c.github.io/webdriver/#get-element-attribute) will return `true`, `null` or element value (which will be string, in case of attribute).

And `getDomProperty()` could return [according to specs](https://w3c.github.io/webdriver/#get-element-property) either `null` or "value of property" which does not guarantee anything about type, so lets just use mixed. 