### PR TITLE
Fix PHP 8.1 deprecations in the Cookie class

### DIFF
--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -207,16 +207,19 @@ class Cookie implements \ArrayAccess
         return $cookie;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->cookie[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->cookie[$offset] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($value === null) {

--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -229,6 +229,7 @@ class Cookie implements \ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->cookie[$offset]);


### PR DESCRIPTION
This throws deprecation messages when running on PHP 8.1. Because this library also supports very old php versions I guess we cannot just set return types.