### PR TITLE
Add return type annotations to Cookie.php

### DIFF
--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -207,16 +207,25 @@ class Cookie implements \ArrayAccess
         return $cookie;
     }
 
+    /**
+     * @return bool
+     */
     public function offsetExists($offset)
     {
         return isset($this->cookie[$offset]);
     }
 
+    /**
+     * @return mixed
+     */
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->cookie[$offset] : null;
     }
 
+    /**
+     * @return void
+     */
     public function offsetSet($offset, $value)
     {
         if ($value === null) {
@@ -226,6 +235,9 @@ class Cookie implements \ArrayAccess
         }
     }
 
+    /**
+     * @return void
+     */
     public function offsetUnset($offset)
     {
         unset($this->cookie[$offset]);


### PR DESCRIPTION
Adding PHPDoc return types to ArrayAccess methods, to suppress deprecation warnings in Symfony 5.4/PHP7.4

Pretty sure this should fix for 8.1 (don't have for test here), leaving https://github.com/php-webdriver/php-webdriver/pull/958 unnecessary.