### PR TITLE
Add return and param type annotations to Cookie.php to supress deprecations

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -82,7 +82,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_indent' => true,
         'phpdoc_no_access' => true,
-        'phpdoc_no_empty_return' => true,
+        // 'phpdoc_no_empty_return' => true, // disabled to allow forward compatibility with PHP 8.1
         'phpdoc_no_package' => true,
         'phpdoc_order_by_value' => ['annotations' => ['covers', 'group', 'throws']],
         'phpdoc_order' => true,

--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -208,6 +208,7 @@ class Cookie implements \ArrayAccess
     }
 
     /**
+     * @param mixed $offset
      * @return bool
      */
     #[\ReturnTypeWillChange]
@@ -217,6 +218,7 @@ class Cookie implements \ArrayAccess
     }
 
     /**
+     * @param mixed $offset
      * @return mixed
      */
     #[\ReturnTypeWillChange]
@@ -226,6 +228,8 @@ class Cookie implements \ArrayAccess
     }
 
     /**
+     * @param mixed $offset
+     * @param mixed $value
      * @return void
      */
     #[\ReturnTypeWillChange]
@@ -239,6 +243,7 @@ class Cookie implements \ArrayAccess
     }
 
     /**
+     * @param mixed $offset
      * @return void
      */
     #[\ReturnTypeWillChange]

--- a/lib/Cookie.php
+++ b/lib/Cookie.php
@@ -207,18 +207,27 @@ class Cookie implements \ArrayAccess
         return $cookie;
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->cookie[$offset]);
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->cookie[$offset] : null;
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
@@ -229,6 +238,9 @@ class Cookie implements \ArrayAccess
         }
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {


### PR DESCRIPTION
Adding PHPDoc return and param types to ArrayAccess methods, to suppress deprecation warnings in Symfony 5.4/PHP7.4

Pretty sure this should fix for 8.1 (don't have for test here), leaving #958 unnecessary.