### PR TITLE
Fix PHP 8.1 deprecation in RemoteWebDriver::takeScreenshot

### DIFF
--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -364,6 +364,10 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public function takeScreenshot($save_as = null)
     {
+        if ($this->executor === null) {
+            return '';
+        }
+
         $screenshot = base64_decode($this->execute(DriverCommand::SCREENSHOT), true);
 
         if ($save_as !== null) {


### PR DESCRIPTION
Passing `null` to `base64_decode` on PHP 8.1 triggers a [deprecation](https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg) message.

`base64_decode` returns an empty string when `null` is passed as a parameter. For the next major version of php-webdriver, I think it's better to throw an exception instead of returning an empty string.

- Fixes #969.