### PR TITLE
Mark getAllSessions() deprecated in W3C WebDriver

### DIFF
--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -555,6 +555,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     /**
      * Returns a list of the currently active sessions.
      *
+     * @deprecated Removed in W3C WebDriver.
      * @param string $selenium_server_url The url of the remote Selenium WebDriver server
      * @param int $timeout_in_ms
      * @return array


### PR DESCRIPTION
See issue in #986 . The `GET /sessions` endpoint is not part of W3C WebDriver, because of security reasons (so that you cannot get and steal other session id).

Although some remote ends (chromedriver) implement it, it is no longer part of the standard. If someone want to call the command eg. on Chromedriver without deprecation warnings (but on its own responsibility), it could still be achieved using [custom commands](https://github.com/php-webdriver/php-webdriver/wiki/Custom-commands).

```php
$sessions = $driver->executeCustomCommand(
    '/sessions',
    'GET'
);

// ...
```