### PR TITLE
Separate takeScreenshot logic to better handle errors and to fix PHP 8.1 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Handle errors when taking screenshots. `WebDriverException` is thrown if WebDriver returns empty or invalid screenshot data.
 
 ## 1.12.1 - 2022-05-03
 ### Fixed

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -4,6 +4,7 @@ namespace Facebook\WebDriver\Remote;
 
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\JavaScriptExecutor;
+use Facebook\WebDriver\Support\ScreenshotHelper;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverCapabilities;
@@ -364,19 +365,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
      */
     public function takeScreenshot($save_as = null)
     {
-        $screenshot = base64_decode($this->execute(DriverCommand::SCREENSHOT), true);
-
-        if ($save_as !== null) {
-            $directoryPath = dirname($save_as);
-
-            if (!file_exists($directoryPath)) {
-                mkdir($directoryPath, 0777, true);
-            }
-
-            file_put_contents($save_as, $screenshot);
-        }
-
-        return $screenshot;
+        return (new ScreenshotHelper($this->getExecuteMethod()))->takePageScreenshot($save_as);
     }
 
     /**

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -7,6 +7,7 @@ use Facebook\WebDriver\Exception\UnsupportedOperationException;
 use Facebook\WebDriver\Exception\WebDriverException;
 use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
+use Facebook\WebDriver\Support\ScreenshotHelper;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverDimension;
 use Facebook\WebDriver\WebDriverElement;
@@ -508,24 +509,7 @@ HTXT;
      */
     public function takeElementScreenshot($save_as = null)
     {
-        $screenshot = base64_decode(
-            $this->executor->execute(
-                DriverCommand::TAKE_ELEMENT_SCREENSHOT,
-                [':id' => $this->id]
-            ),
-            true
-        );
-
-        if ($save_as !== null) {
-            $directoryPath = dirname($save_as);
-            if (!file_exists($directoryPath)) {
-                mkdir($directoryPath, 0777, true);
-            }
-
-            file_put_contents($save_as, $screenshot);
-        }
-
-        return $screenshot;
+        return (new ScreenshotHelper($this->executor))->takeElementScreenshot($this->id, $save_as);
     }
 
     /**

--- a/lib/Support/ScreenshotHelper.php
+++ b/lib/Support/ScreenshotHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Facebook\WebDriver\Support;
+
+use Facebook\WebDriver\Exception\WebDriverException;
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+
+/**
+ * Helper class to handle taking, decoding and screenshots using WebDriver.
+ */
+class ScreenshotHelper
+{
+    /** @var RemoteExecuteMethod */
+    private $executor;
+
+    public function __construct(RemoteExecuteMethod $executor)
+    {
+        $this->executor = $executor;
+    }
+
+    /**
+     * @param string|null $saveAs
+     * @throws WebDriverException
+     * @return string
+     */
+    public function takePageScreenshot($saveAs = null)
+    {
+        $commandToExecute = [DriverCommand::SCREENSHOT];
+
+        return $this->takeScreenshot($commandToExecute, $saveAs);
+    }
+
+    public function takeElementScreenshot($elementId, $saveAs = null)
+    {
+        $commandToExecute = [DriverCommand::TAKE_ELEMENT_SCREENSHOT, [':id' => $elementId]];
+
+        return $this->takeScreenshot($commandToExecute, $saveAs);
+    }
+
+    private function takeScreenshot(array $commandToExecute, $saveAs = null)
+    {
+        $response = $this->executor->execute(...$commandToExecute);
+
+        if (!is_string($response)) {
+            throw new WebDriverException('Error taking screenshot, no data received from the remote end');
+        }
+
+        $screenshot = base64_decode($response, true);
+
+        if ($screenshot === false) {
+            throw new WebDriverException('Error decoding screenshot data');
+        }
+
+        if ($saveAs !== null) {
+            $this->saveScreenshotToPath($screenshot, $saveAs);
+        }
+
+        return $screenshot;
+    }
+
+    private function saveScreenshotToPath($screenshot, $path)
+    {
+        $this->createDirectoryIfNotExists(dirname($path));
+
+        file_put_contents($path, $screenshot);
+    }
+
+    private function createDirectoryIfNotExists($directoryPath)
+    {
+        if (!file_exists($directoryPath)) {
+            if (!mkdir($directoryPath, 0777, true) && !is_dir($directoryPath)) {
+                throw new WebDriverException(sprintf('Directory "%s" was not created', $directoryPath));
+            }
+        }
+    }
+}

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -250,6 +250,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
 
     /**
      * @covers ::takeScreenshot
+     * @covers \Facebook\WebDriver\Support\ScreenshotHelper
      */
     public function testShouldTakeScreenshot()
     {
@@ -269,6 +270,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
 
     /**
      * @covers ::takeScreenshot
+     * @covers \Facebook\WebDriver\Support\ScreenshotHelper
      * @group exclude-safari
      *        Safari is returning different color profile and it does not have way to configure "force-color-profile"
      */
@@ -277,7 +279,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
         if (!extension_loaded('gd')) {
             $this->markTestSkipped('GD extension must be enabled');
         }
-        // Intentionally save screenshot to subdirectory to tests it is being created
+
         $screenshotPath = sys_get_temp_dir() . '/' . uniqid('php-webdriver-') . '/selenium-screenshot.png';
 
         $this->driver->get($this->getTestPageUrl('index.html'));

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -455,6 +455,7 @@ class RemoteWebElementTest extends WebDriverTestCase
 
     /**
      * @covers ::takeElementScreenshot
+     * @covers \Facebook\WebDriver\Support\ScreenshotHelper
      * @group exclude-saucelabs
      */
     public function testShouldTakeAndSaveElementScreenshot()
@@ -469,7 +470,6 @@ class RemoteWebElementTest extends WebDriverTestCase
         $isCi = (new CiDetector())->isCiDetected();
         $isSafari = getenv('BROWSER_NAME') === 'safari';
 
-        // Intentionally save screenshot to subdirectory to tests it is being created
         $screenshotPath = sys_get_temp_dir() . '/' . uniqid('php-webdriver-') . '/element-screenshot.png';
 
         $this->driver->get($this->getTestPageUrl('index.html'));

--- a/tests/unit/Support/ScreenshotHelperTest.php
+++ b/tests/unit/Support/ScreenshotHelperTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Facebook\WebDriver\Support;
+
+use Facebook\WebDriver\Exception\WebDriverException;
+use Facebook\WebDriver\Remote\DriverCommand;
+use Facebook\WebDriver\Remote\RemoteExecuteMethod;
+use PHPUnit\Framework\TestCase;
+
+class ScreenshotHelperTest extends TestCase
+{
+    const BLACK_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+    public function testShouldSavePageScreenshotToSubdirectoryIfNotExists()
+    {
+        $fullFilePath = sys_get_temp_dir() . '/' . uniqid('php-webdriver-', true) . '/screenshot.png';
+        $directoryPath = dirname($fullFilePath);
+        $this->assertDirectoryNotExists($directoryPath);
+
+        $executorMock = $this->createMock(RemoteExecuteMethod::class);
+        $executorMock->expects($this->once())
+            ->method('execute')
+            ->with($this->equalTo(DriverCommand::SCREENSHOT))
+            ->willReturn(self::BLACK_PIXEL);
+
+        $helper = new ScreenshotHelper($executorMock);
+        $output = $helper->takePageScreenshot($fullFilePath);
+
+        $this->assertSame(base64_decode(self::BLACK_PIXEL, true), $output);
+
+        $this->assertDirectoryExists($directoryPath);
+        $this->assertFileExists($fullFilePath);
+
+        unlink($fullFilePath);
+        rmdir($directoryPath);
+    }
+
+    public function testShouldOnlyReturnBase64IfDirectoryNotProvided()
+    {
+        $executorMock = $this->createMock(RemoteExecuteMethod::class);
+        $executorMock->expects($this->once())
+            ->method('execute')
+            ->with($this->equalTo(DriverCommand::SCREENSHOT))
+            ->willReturn(self::BLACK_PIXEL);
+
+        $helper = new ScreenshotHelper($executorMock);
+        $output = $helper->takePageScreenshot();
+
+        $this->assertSame(base64_decode(self::BLACK_PIXEL, true), $output);
+    }
+
+    public function testShouldSaveElementScreenshotToSubdirectoryIfNotExists()
+    {
+        $fullFilePath = sys_get_temp_dir() . '/' . uniqid('php-webdriver-', true) . '/screenshot.png';
+        $directoryPath = dirname($fullFilePath);
+        $this->assertDirectoryNotExists($directoryPath);
+        $elementId = 'foo-id';
+
+        $executorMock = $this->createMock(RemoteExecuteMethod::class);
+        $executorMock->expects($this->once())
+            ->method('execute')
+            ->with(DriverCommand::TAKE_ELEMENT_SCREENSHOT, [':id' => $elementId])
+            ->willReturn(self::BLACK_PIXEL);
+
+        $helper = new ScreenshotHelper($executorMock);
+        $output = $helper->takeElementScreenshot($elementId, $fullFilePath);
+
+        $this->assertSame(base64_decode(self::BLACK_PIXEL, true), $output);
+        $this->assertDirectoryExists($directoryPath);
+        $this->assertFileExists($fullFilePath);
+
+        unlink($fullFilePath);
+        rmdir($directoryPath);
+    }
+
+    /**
+     * @dataProvider provideInvalidData
+     * @param mixed $data
+     * @param string $expectedExceptionMessage
+     */
+    public function testShouldThrowExceptionWhenInvalidDataReceived($data, $expectedExceptionMessage)
+    {
+        $executorMock = $this->createMock(RemoteExecuteMethod::class);
+        $executorMock->expects($this->once())
+            ->method('execute')
+            ->with($this->equalTo(DriverCommand::SCREENSHOT))
+            ->willReturn($data);
+
+        $helper = new ScreenshotHelper($executorMock);
+
+        $this->expectException(WebDriverException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $helper->takePageScreenshot();
+    }
+
+    public function provideInvalidData()
+    {
+        return [
+            'empty response' => [null, 'Error taking screenshot, no data received from the remote end'],
+            'not valid base64 response' => ['invalid%base64', 'Error decoding screenshot data'],
+        ];
+    }
+}


### PR DESCRIPTION
Apart from separating screenshot/filesystem logic from two places, this should better handle errors and solve #969 and #983.

The previous behavior was to silently ignore if screenshot command returned empty data. This will now throw an `WebDriverException`.