### PR TITLE
Firefox profile improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- `setProfile()` method to `FirefoxOptions`, which is now a preferred way to set Firefox Profile.
+
 ### Changed
 - Handle errors when taking screenshots. `WebDriverException` is thrown if WebDriver returns empty or invalid screenshot data.
+- Deprecate `FirefoxDriver::PROFILE` constant. Instead, use `setProfile()` method of `FirefoxOptions` to set Firefox Profile.
 
 ## 1.12.1 - 2022-05-03
 ### Fixed

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -107,6 +107,9 @@ class ChromeOptions implements JsonSerializable
     /**
      * Sets an experimental option which has not exposed officially.
      *
+     * When using "prefs" to set Chrome preferences, please be aware they are so far not supported by
+     * Chrome running in headless mode, see https://bugs.chromium.org/p/chromium/issues/detail?id=775911
+     *
      * @param string $name
      * @param mixed $value
      * @return ChromeOptions

--- a/lib/Firefox/FirefoxDriver.php
+++ b/lib/Firefox/FirefoxDriver.php
@@ -9,6 +9,13 @@ use Facebook\WebDriver\Remote\WebDriverCommand;
 
 class FirefoxDriver extends LocalWebDriver
 {
+    /**
+     * @deprecated Pass Firefox Profile using FirefoxOptions:
+     * $firefoxOptions = new FirefoxOptions();
+     * $firefoxOptions->setProfile($profile->encode());
+     * $capabilities = DesiredCapabilities::firefox();
+     * $capabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);
+     */
     const PROFILE = 'firefox_profile';
 
     /**

--- a/lib/Firefox/FirefoxOptions.php
+++ b/lib/Firefox/FirefoxOptions.php
@@ -17,6 +17,8 @@ class FirefoxOptions implements \JsonSerializable
     const OPTION_ARGS = 'args';
     /** @var string */
     const OPTION_PREFS = 'prefs';
+    /** @var string */
+    const OPTION_PROFILE = 'profile';
 
     /** @var array */
     private $options = [];
@@ -24,6 +26,8 @@ class FirefoxOptions implements \JsonSerializable
     private $arguments = [];
     /** @var array */
     private $preferences = [];
+    /** @var FirefoxProfile */
+    private $profile;
 
     public function __construct()
     {
@@ -49,6 +53,9 @@ class FirefoxOptions implements \JsonSerializable
         }
         if ($name === self::OPTION_ARGS) {
             throw new \InvalidArgumentException('Use addArguments() method to add Firefox arguments');
+        }
+        if ($name === self::OPTION_PROFILE) {
+            throw new \InvalidArgumentException('Use setProfile() method to set Firefox profile');
         }
 
         $this->options[$name] = $value;
@@ -88,6 +95,18 @@ class FirefoxOptions implements \JsonSerializable
     }
 
     /**
+     * @see https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefox-profile
+     * @param FirefoxProfile $profile
+     * @return self
+     */
+    public function setProfile(FirefoxProfile $profile)
+    {
+        $this->profile = $profile;
+
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
@@ -98,6 +117,9 @@ class FirefoxOptions implements \JsonSerializable
         }
         if (!empty($this->preferences)) {
             $array[self::OPTION_PREFS] = $this->preferences;
+        }
+        if (!empty($this->profile)) {
+            $array[self::OPTION_PROFILE] = $this->profile->encode();
         }
 
         return $array;

--- a/lib/Firefox/FirefoxProfile.php
+++ b/lib/Firefox/FirefoxProfile.php
@@ -201,11 +201,6 @@ class FirefoxProfile
         if (!copy($extension, $extensionDir . $extensionCommonName . '.xpi')) {
             throw new WebDriverException('Cannot install Firefox extension - cannot copy file');
         }
-
-        // extension installation with empty preferences (empty users.js) fails, thus add some dummy data
-        if (empty($this->preferences)) {
-            $this->setPreference('dummy.preference', true);
-        }
     }
 
     /**

--- a/tests/functional/Firefox/FirefoxDriverTest.php
+++ b/tests/functional/Firefox/FirefoxDriverTest.php
@@ -5,10 +5,14 @@ namespace Facebook\WebDriver\Firefox;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\Service\DriverCommandExecutor;
+use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverTestCase;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @group exclude-chrome
+ * @group exclude-edge
+ * @group exclude-safari
  * @group exclude-saucelabs
  * @covers \Facebook\WebDriver\Firefox\FirefoxDriver
  * @covers \Facebook\WebDriver\Local\LocalWebDriver
@@ -49,12 +53,30 @@ class FirefoxDriverTest extends TestCase
         $this->assertSame('http://localhost:8000/', $this->driver->getCurrentURL());
     }
 
-    private function startFirefoxDriver()
+    public function testShouldSetPreferenceWithFirefoxOptions()
+    {
+        $firefoxOptions = new FirefoxOptions();
+        $firefoxOptions->setPreference('javascript.enabled', false);
+
+        $this->startFirefoxDriver($firefoxOptions);
+
+        $this->driver->get('http://localhost:8000/');
+
+        $noScriptElement = $this->driver->findElement(WebDriverBy::id('noscript'));
+        $this->assertEquals(
+            'This element is only shown with JavaScript disabled.',
+            $noScriptElement->getText()
+        );
+    }
+
+    private function startFirefoxDriver(FirefoxOptions $firefoxOptions = null)
     {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(FirefoxDriverService::WEBDRIVER_FIREFOX_DRIVER . '=' . getenv('GECKODRIVER_PATH'));
 
-        $firefoxOptions = new FirefoxOptions();
+        if ($firefoxOptions === null) {
+            $firefoxOptions = new FirefoxOptions();
+        }
         $firefoxOptions->addArguments(['-headless']);
         $desiredCapabilities = DesiredCapabilities::firefox();
         $desiredCapabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);

--- a/tests/functional/Firefox/FirefoxProfileTest.php
+++ b/tests/functional/Firefox/FirefoxProfileTest.php
@@ -125,9 +125,9 @@ class FirefoxProfileTest extends TestCase
 
         $firefoxOptions = new FirefoxOptions();
         $firefoxOptions->addArguments(['-headless']);
+        $firefoxOptions->setProfile($firefoxProfile);
         $desiredCapabilities = DesiredCapabilities::firefox();
         $desiredCapabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);
-        $desiredCapabilities->setCapability(FirefoxDriver::PROFILE, $firefoxProfile);
 
         $this->driver = FirefoxDriver::start($desiredCapabilities);
     }

--- a/tests/functional/Firefox/FirefoxProfileTest.php
+++ b/tests/functional/Firefox/FirefoxProfileTest.php
@@ -97,6 +97,7 @@ class FirefoxProfileTest extends TestCase
         // we recommend using the setPreference() method on FirefoxOptions instead, so that you don't need to
         // create FirefoxProfile.
         $firefoxProfile->setPreference('javascript.enabled', false);
+        $this->assertSame('false', $firefoxProfile->getPreference('javascript.enabled'));
 
         $this->startFirefoxDriverWithProfile($firefoxProfile);
         $this->driver->get('http://localhost:8000/');


### PR DESCRIPTION
Add `setProfile()` method to Firefox, so that setting Firefox Profile is straightforward and type-safe:

```diff
$profile = new FirefoxProfile();
$firefoxOptions = new FirefoxOptions();

-$firefoxOptions->setOption('profile', $profile->encode());
+$firefoxOptions->setProfile($profile);
```

Also setting the profile directly to Capabilities using `FirefoxDriver::PROFILE` constant like this is now deprecated (it is also not W3C WebDriver compatible, because it is not in the vendor namespace):

```php
$profile = new FirefoxProfile();

$capabilities = DesiredCapabilities::firefox();
$capabilities->setCapability(FirefoxDriver::PROFILE, $profile); // deprecated, use $firefoxOptions->setProfile($profile) as above
```
---
- [x] Update [wiki page](https://github.com/php-webdriver/php-webdriver/wiki/Firefox#start-firefox-with-the-profile) with documentation