### PR TITLE
Throw exception instead of fatal error on invalid server response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 - Handle errors when taking screenshots. `WebDriverException` is thrown if WebDriver returns empty or invalid screenshot data.
 - Deprecate `FirefoxDriver::PROFILE` constant. Instead, use `setProfile()` method of `FirefoxOptions` to set Firefox Profile.
 
+### Fixed
+- Throw `UnknownErrorException` instead of fatal error if remote end returns invalid response for `findElement()`/`findElements()` commands.
+
 ## 1.12.1 - 2022-05-03
 ### Fixed
 - Improper PHP documentation for `getAttribute()` and `getDomProperty()`.

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -2,6 +2,7 @@
 
 namespace Facebook\WebDriver\Remote;
 
+use Facebook\WebDriver\Exception\UnknownErrorException;
 use Facebook\WebDriver\Interactions\WebDriverActions;
 use Facebook\WebDriver\JavaScriptExecutor;
 use Facebook\WebDriver\Support\ScreenshotHelper;
@@ -209,6 +210,10 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             JsonWireCompat::getUsing($by, $this->isW3cCompliant)
         );
 
+        if ($raw_element === null) {
+            throw new UnknownErrorException('Unexpected server response to findElement command');
+        }
+
         return $this->newElement(JsonWireCompat::getElement($raw_element));
     }
 
@@ -225,6 +230,10 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             DriverCommand::FIND_ELEMENTS,
             JsonWireCompat::getUsing($by, $this->isW3cCompliant)
         );
+
+        if ($raw_elements === null) {
+            throw new UnknownErrorException('Unexpected server response to findElements command');
+        }
 
         $elements = [];
         foreach ($raw_elements as $raw_element) {


### PR DESCRIPTION
In some hard-to-reproduce scenarios, remote end returns response, however, it contains `null` in value (or does not contain value at all). This causes php-webdriver to fail on fatal/type error. 

Instead, `UnknownErrorException` will be throw, to allow better debugging.

Fixes #944, replaces #945