### PR TITLE
Do not submit coveralls on pull_request event

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,6 +74,7 @@ jobs:
         run: vendor/bin/phpunit --testsuite unit --colors=always --coverage-clover ./logs/clover.xml
 
       - name: Submit coverage to Coveralls
+        if: ${{ github.event_name != 'pull_request' }}
         # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:
         # https://github.com/coverallsapp/github-action/issues/15
         env:
@@ -174,6 +175,7 @@ jobs:
           vendor/bin/phpunit --testsuite functional --colors=always --coverage-clover ./logs/clover.xml $EXTRA_PARAMS
 
       - name: Submit coverage to Coveralls
+        if: ${{ github.event_name != 'pull_request' }}
         # We use php-coveralls library for this, as the official Coveralls GitHub Action lacks support for clover reports:
         # https://github.com/coverallsapp/github-action/issues/15
         env:
@@ -201,6 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Coveralls
+        if: ${{ github.event_name != 'pull_request' }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Apparently, we are impacted by https://github.com/lemurheavy/coveralls-public/issues/1653 , leading to coverage decrease report for *every* pull request (the reported descrease is from 65 % to to 35 %, even when no code changes).

This is attempt for a workaround - do not submit coverage reports for the `pull_request` events, but only for `push`.