### PR TITLE
Implement Shadow DOM support

### DIFF
--- a/lib/Exception/DetachedShadowRootException.php
+++ b/lib/Exception/DetachedShadowRootException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+/**
+ * A command failed because the referenced shadow root is no longer attached to the DOM.
+ */
+class DetachedShadowRootException extends WebDriverException
+{
+}

--- a/lib/Exception/NoSuchShadowRootException.php
+++ b/lib/Exception/NoSuchShadowRootException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Facebook\WebDriver\Exception;
+
+/**
+ * The element does not have a shadow root.
+ */
+class NoSuchShadowRootException extends WebDriverException
+{
+}

--- a/lib/Exception/WebDriverException.php
+++ b/lib/Exception/WebDriverException.php
@@ -119,12 +119,16 @@ class WebDriverException extends Exception
                     throw new NoSuchFrameException($message, $results);
                 case 'no such window':
                     throw new NoSuchWindowException($message, $results);
+                case 'no such shadow root':
+                    throw new NoSuchShadowRootException($message, $results);
                 case 'script timeout':
                     throw new ScriptTimeoutException($message, $results);
                 case 'session not created':
                     throw new SessionNotCreatedException($message, $results);
                 case 'stale element reference':
                     throw new StaleElementReferenceException($message, $results);
+                case 'detached shadow root':
+                    throw new DetachedShadowRootException($message, $results);
                 case 'timeout':
                     throw new TimeoutException($message, $results);
                 case 'unable to set cookie':

--- a/lib/Remote/DriverCommand.php
+++ b/lib/Remote/DriverCommand.php
@@ -143,6 +143,9 @@ class DriverCommand
     const NEW_WINDOW = 'newWindow';
     const TAKE_ELEMENT_SCREENSHOT = 'takeElementScreenshot';
     const MINIMIZE_WINDOW = 'minimizeWindow';
+    const GET_ELEMENT_SHADOW_ROOT = 'getElementShadowRoot';
+    const FIND_ELEMENT_FROM_SHADOW_ROOT = 'findElementFromShadowRoot';
+    const FIND_ELEMENTS_FROM_SHADOW_ROOT = 'findElementsFromShadowRoot';
 
     private function __construct()
     {

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -141,6 +141,14 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::DISMISS_ALERT => ['method' => 'POST', 'url' => '/session/:sessionId/alert/dismiss'],
         DriverCommand::EXECUTE_ASYNC_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/async'],
         DriverCommand::EXECUTE_SCRIPT => ['method' => 'POST', 'url' => '/session/:sessionId/execute/sync'],
+        DriverCommand::FIND_ELEMENT_FROM_SHADOW_ROOT => [
+            'method' => 'POST',
+            'url' => '/session/:sessionId/shadow/:id/element',
+        ],
+        DriverCommand::FIND_ELEMENTS_FROM_SHADOW_ROOT => [
+            'method' => 'POST',
+            'url' => '/session/:sessionId/shadow/:id/elements',
+        ],
         DriverCommand::FULLSCREEN_WINDOW => ['method' => 'POST', 'url' => '/session/:sessionId/window/fullscreen'],
         DriverCommand::GET_ACTIVE_ELEMENT => ['method' => 'GET', 'url' => '/session/:sessionId/element/active'],
         DriverCommand::GET_ALERT_TEXT => ['method' => 'GET', 'url' => '/session/:sessionId/alert/text'],
@@ -149,6 +157,10 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
         DriverCommand::GET_ELEMENT_PROPERTY => [
             'method' => 'GET',
             'url' => '/session/:sessionId/element/:id/property/:name',
+        ],
+        DriverCommand::GET_ELEMENT_SHADOW_ROOT => [
+            'method' => 'GET',
+            'url' => '/session/:sessionId/element/:id/shadow',
         ],
         DriverCommand::GET_ELEMENT_SIZE => ['method' => 'GET', 'url' => '/session/:sessionId/element/:id/rect'],
         DriverCommand::GET_WINDOW_HANDLES => ['method' => 'GET', 'url' => '/session/:sessionId/window/handles'],

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -533,6 +533,27 @@ HTXT;
     }
 
     /**
+     * Get representation of an element's shadow root for accessing the shadow DOM of a web component.
+     *
+     * @return ShadowRoot
+     */
+    public function getShadowRoot()
+    {
+        if (!$this->isW3cCompliant) {
+            throw new UnsupportedOperationException('This method is only supported in W3C mode');
+        }
+
+        $response = $this->executor->execute(
+            DriverCommand::GET_ELEMENT_SHADOW_ROOT,
+            [
+                ':id' => $this->id,
+            ]
+        );
+
+        return ShadowRoot::createFromResponse($this->executor, $response);
+    }
+
+    /**
      * Attempt to click on a child level element.
      *
      * This provides a workaround for geckodriver bug 653 whereby a link whose first element is a block-level element

--- a/lib/Remote/ShadowRoot.php
+++ b/lib/Remote/ShadowRoot.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Facebook\WebDriver\Remote;
+
+use Facebook\WebDriver\Exception\UnknownErrorException;
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverElement;
+use Facebook\WebDriver\WebDriverSearchContext;
+
+class ShadowRoot implements WebDriverSearchContext
+{
+    /**
+     * Shadow root identifier defined in the W3CWebDriver protocol.
+     *
+     * @see https://w3c.github.io/webdriver/#shadow-root
+     */
+    const SHADOW_ROOT_IDENTIFIER = 'shadow-6066-11e4-a52e-4f735466cecf';
+
+    /**
+     * @var RemoteExecuteMethod
+     */
+    private $executor;
+
+    /**
+     * @var string
+     */
+    private $id;
+
+    public function __construct(RemoteExecuteMethod $executor, $id)
+    {
+        $this->executor = $executor;
+        $this->id = $id;
+    }
+
+    /**
+     * @param RemoteExecuteMethod $executor
+     * @param array $response
+     * @return self
+     */
+    public static function createFromResponse(RemoteExecuteMethod $executor, array $response)
+    {
+        if (empty($response[self::SHADOW_ROOT_IDENTIFIER])) {
+            throw new UnknownErrorException('Shadow root is missing in server response');
+        }
+
+        return new self($executor, $response[self::SHADOW_ROOT_IDENTIFIER]);
+    }
+
+    /**
+     * @param WebDriverBy $locator
+     * @return RemoteWebElement
+     */
+    public function findElement(WebDriverBy $locator)
+    {
+        $params = JsonWireCompat::getUsing($locator, true);
+        $params[':id'] = $this->id;
+
+        $rawElement = $this->executor->execute(
+            DriverCommand::FIND_ELEMENT_FROM_SHADOW_ROOT,
+            $params
+        );
+
+        return new RemoteWebElement($this->executor, JsonWireCompat::getElement($rawElement), true);
+    }
+
+    /**
+     * @param WebDriverBy $locator
+     * @return WebDriverElement[]
+     */
+    public function findElements(WebDriverBy $locator)
+    {
+        $params = JsonWireCompat::getUsing($locator, true);
+        $params[':id'] = $this->id;
+
+        $rawElements = $this->executor->execute(
+            DriverCommand::FIND_ELEMENTS_FROM_SHADOW_ROOT,
+            $params
+        );
+
+        $elements = [];
+        foreach ($rawElements as $rawElement) {
+            $elements[] = new RemoteWebElement($this->executor, JsonWireCompat::getElement($rawElement), true);
+        }
+
+        return $elements;
+    }
+
+    /**
+     * @return string
+     */
+    public function getID()
+    {
+        return $this->id;
+    }
+}

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -378,6 +378,16 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
         }
     }
 
+    public function getShadowRoot()
+    {
+        try {
+            return $this->element->getShadowRoot();
+        } catch (WebDriverException $exception) {
+            $this->dispatchOnException($exception);
+            throw $exception;
+        }
+    }
+
     /**
      * @param WebDriverException $exception
      */

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -368,6 +368,16 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
         }
     }
 
+    public function takeElementScreenshot($save_as = null)
+    {
+        try {
+            return $this->element->takeElementScreenshot($save_as);
+        } catch (WebDriverException $exception) {
+            $this->dispatchOnException($exception);
+            throw $exception;
+        }
+    }
+
     /**
      * @param WebDriverException $exception
      */

--- a/lib/WebDriverElement.php
+++ b/lib/WebDriverElement.php
@@ -2,6 +2,8 @@
 
 namespace Facebook\WebDriver;
 
+use Facebook\WebDriver\Remote\ShadowRoot;
+
 /**
  * Interface for an HTML element in the WebDriver framework.
  */
@@ -141,4 +143,12 @@ interface WebDriverElement extends WebDriverSearchContext
      * @todo Add in next major release (BC)
      */
     //public function takeElementScreenshot($save_as = null);
+
+    /**
+     * Get representation of an element's shadow root for accessing the shadow DOM of a web component.
+     *
+     * @return ShadowRoot
+     * @todo Add in next major release (BC)
+     */
+    //public function getShadowRoot();
 }

--- a/lib/WebDriverSearchContext.php
+++ b/lib/WebDriverSearchContext.php
@@ -3,18 +3,15 @@
 namespace Facebook\WebDriver;
 
 /**
- * The interface for WebDriver and WebDriverElement which is able to search for
- * WebDriverElement inside.
+ * The interface for WebDriver and WebDriverElement which is able to search for WebDriverElement inside.
  */
 interface WebDriverSearchContext
 {
     /**
-     * Find the first WebDriverElement within this element using the given
-     * mechanism.
+     * Find the first WebDriverElement within this element using the given mechanism.
      *
      * @param WebDriverBy $locator
-     * @return WebDriverElement NoSuchElementException is thrown in
-     *    HttpCommandExecutor if no element is found.
+     * @return WebDriverElement NoSuchElementException is thrown in HttpCommandExecutor if no element is found.
      * @see WebDriverBy
      */
     public function findElement(WebDriverBy $locator);
@@ -23,8 +20,7 @@ interface WebDriverSearchContext
      * Find all WebDriverElements within this element using the given mechanism.
      *
      * @param WebDriverBy $locator
-     * @return WebDriverElement[] A list of all WebDriverElements, or an empty array if
-     *    nothing matches
+     * @return WebDriverElement[] A list of all WebDriverElements, or an empty array if nothing matches
      * @see WebDriverBy
      */
     public function findElements(WebDriverBy $locator);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,10 +5,17 @@ parameters:
         - tests/
 
     ignoreErrors:
-        # To be fixed:
-        - '#Call to an undefined method Facebook\\WebDriver\\WebDriver::getTouch\(\)#'
-        - '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::getCoordinates\(\)#'
-        - '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::equals\(\)#'
+        # To be fixed in next major version:
+        - message: '#Call to an undefined method Facebook\\WebDriver\\WebDriver::getTouch\(\)#'
+          path: 'lib/Interactions/WebDriverTouchActions.php'
+        - message: '#Call to an undefined method Facebook\\WebDriver\\WebDriver::getTouch\(\)#'
+          path: 'lib/Support/Events/EventFiringWebDriver.php'
+        - message: '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::getCoordinates\(\)#'
+          path: 'lib/Support/Events/EventFiringWebElement.php'
+        - message: '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::equals\(\)#'
+          path: 'lib/Support/Events/EventFiringWebElement.php'
+        - message: '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::takeElementScreenshot\(\)#'
+          path: 'lib/Support/Events/EventFiringWebElement.php'
         - '#Unsafe usage of new static\(\)#'
 
         # Parameter is intentionally not part of signature to not break BC

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,8 @@ parameters:
           path: 'lib/Support/Events/EventFiringWebElement.php'
         - message: '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::takeElementScreenshot\(\)#'
           path: 'lib/Support/Events/EventFiringWebElement.php'
+        - message: '#Call to an undefined method Facebook\\WebDriver\\WebDriverElement::getShadowRoot\(\)#'
+          path: 'lib/Support/Events/EventFiringWebElement.php'
         - '#Unsafe usage of new static\(\)#'
 
         # Parameter is intentionally not part of signature to not break BC

--- a/tests/functional/ShadowDomTest.php
+++ b/tests/functional/ShadowDomTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Facebook\WebDriver;
+
+use Facebook\WebDriver\Exception\NoSuchShadowRootException;
+use Facebook\WebDriver\Remote\ShadowRoot;
+
+/**
+ * @group exclude-safari
+ *        Safaridriver does not support Shadow DOM endpoints
+ * @covers \Facebook\WebDriver\Remote\RemoteWebElement
+ * @covers \Facebook\WebDriver\Remote\ShadowRoot
+ */
+class ShadowDomTest extends WebDriverTestCase
+{
+    protected function setUp(): void
+    {
+        self::skipForJsonWireProtocol('Shadow DOM is only part of W3C WebDriver');
+
+        parent::setUp();
+    }
+
+    public function testShouldGetShadowRoot()
+    {
+        $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
+
+        $element = $this->driver->findElement(WebDriverBy::cssSelector('custom-checkbox-element'));
+
+        $shadowRoot = $element->getShadowRoot();
+
+        $this->assertInstanceOf(ShadowRoot::class, $shadowRoot);
+    }
+
+    public function testShouldThrowExceptionWhenGettingShadowRootWithElementNotHavingShadowRoot()
+    {
+        $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
+
+        $element = $this->driver->findElement(WebDriverBy::cssSelector('#no-shadow-root'));
+
+        $this->expectException(NoSuchShadowRootException::class);
+        $element->getShadowRoot();
+    }
+
+    /**
+     * @group exclude-firefox
+     *        https://bugzilla.mozilla.org/show_bug.cgi?id=1700097
+     *        Finding elements in shadow DOM is not implemented in Geckodriver
+     */
+    public function testShouldFindElementUnderShadowRoot()
+    {
+        $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
+
+        $element = $this->driver->findElement(WebDriverBy::cssSelector('custom-checkbox-element'));
+
+        $shadowRoot = $element->getShadowRoot();
+
+        $elementInShadow = $shadowRoot->findElement(WebDriverBy::cssSelector('input'));
+        $this->assertSame('checkbox', $elementInShadow->getAttribute('type'));
+
+        $elementsInShadow = $shadowRoot->findElements(WebDriverBy::cssSelector('div'));
+        $this->assertCount(2, $elementsInShadow);
+    }
+
+    /**
+     * @group exclude-firefox
+     *        https://bugzilla.mozilla.org/show_bug.cgi?id=1700097
+     *        Finding elements in shadow DOM is not implemented in Geckodriver
+     */
+    public function testShouldReferenceTheSameShadowRootAsFromExecuteScript()
+    {
+        $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
+
+        $element = $this->driver->findElement(WebDriverBy::cssSelector('custom-checkbox-element'));
+
+        /** @var WebDriverElement $elementFromScript */
+        $elementFromScript = $this->driver->executeScript(
+            'return arguments[0].shadowRoot;',
+            [$element]
+        );
+
+        $shadowRoot = $element->getShadowRoot();
+
+        $this->assertSame($shadowRoot->getId(), reset($elementFromScript));
+    }
+}

--- a/tests/functional/web/index.html
+++ b/tests/functional/web/index.html
@@ -36,6 +36,8 @@
     <a href="events.html" id="a-drag">Events</a>
     |
     <a href="sortable.html" id="a-sortable">Sortable</a>
+    |
+    <a href="web-components.html" id="a-web-components">WebComponents</a>
 
     <p id="id_test">Test by ID</p>
     <p class="test_class">Test by Class</p>

--- a/tests/functional/web/web_components.html
+++ b/tests/functional/web/web_components.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>WebComponents and Shadow DOM tests</title>
+
+    <style>
+        custom-checkbox-element {
+            margin-top: 1ex;
+            padding: 1ex;
+            display: block;
+            background-color: #eeeeff;
+        }
+    </style>
+</head>
+<body>
+<h1>WebComponents and Shadow DOM tests</h1>
+
+<div><label>Input out of Shadow DOM: <input id="no-shadow-root"/></label></div>
+<div>
+    <custom-checkbox-element></custom-checkbox-element>
+</div>
+<script>
+  customElements.define('custom-checkbox-element',
+      class extends HTMLElement {
+        constructor() {
+          super();
+          this.attachShadow({mode: 'open'}).innerHTML = '<div><label>Checkbox in Shadow DOM: ' +
+              '<input type="checkbox"/></label>' +
+              '<div><p>Paragraph in Shadow DOM</p></div>' +
+              '</div>';
+        }
+      }
+  );
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) support. Fixes #1003 .

Shadow DOM is essential part of Web Components, as it encapsulates the component DOM and styles. This component isolation however mean one cannot access elements which are encapsulated in shadow DOM of a component with usual `$driver->findElement()` and `$driver->findElements()` method. You will basically not by able to find those elements in the default DOM.

Because of this, W3C WebDriver [added support](https://github.com/w3c/webdriver/pull/1565) for endpoints specifically made for accessing Shadow DOM elements.

So far, this has been implemented in Chromedriver and partially in Geckodriver.

### Example usage:

```php
// consider having web component <custom-element>...</custom-element> with its inner DOM

// first, locate the element of the Web Component, which is part of the default DOM
$element = $this->driver->findElement(WebDriverBy::cssSelector('custom-element'));

// locate Shadow Root, which is the base for accessing encapsulated elements
$shadowRoot = $element->getShadowRoot();

// ShadowDom instance now provide findElement() and findElements() method, which will target only elements inside this Shadow DOM
$elementInShadow = $shadowRoot->findElement(WebDriverBy::cssSelector('input'));
```

---

- [ ] Add documentation to wiki