### PR TITLE
Fix firefox extension test flakiness

### DIFF
--- a/tests/functional/Firefox/FirefoxProfileTest.php
+++ b/tests/functional/Firefox/FirefoxProfileTest.php
@@ -19,6 +19,7 @@ use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\TestPage;
 use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverExpectedCondition;
 use Facebook\WebDriver\WebDriverTestCase;
 use PHPUnit\Framework\TestCase;
 
@@ -86,7 +87,11 @@ class FirefoxProfileTest extends TestCase
 
         $this->assertInstanceOf(RemoteWebDriver::class, $this->driver);
 
-        $element = $this->driver->findElement(WebDriverBy::id('webDriverExtensionTest'));
+        // it sometimes takes split of a second for the extension to render the element, so we must use wait
+        $element = $this->driver->wait(5, 1)->until(
+            WebDriverExpectedCondition::presenceOfElementLocated(WebDriverBy::id('webDriverExtensionTest'))
+        );
+
         $this->assertEquals('This element was added by browser extension', $element->getText());
     }
 


### PR DESCRIPTION
It sometimes takes split of a second for the extension to render the element causing the test to fail from time to time. This will be fixed using explicit wait.