### PR TITLE
Update sauce connect action

### DIFF
--- a/.github/workflows/sauce-labs.yaml
+++ b/.github/workflows/sauce-labs.yaml
@@ -46,7 +46,7 @@ jobs:
           php -S 127.0.0.1:8000 -t tests/functional/web/ &>>./logs/php-server.log &
 
       - name: Start Sauce Connect
-        uses: saucelabs/sauce-connect-action@v1
+        uses: saucelabs/sauce-connect-action@v2
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: saucelabs/sauce-connect-action, saucelabs/sauce-connect-action
