### PR TITLE
Improve session reusing, require capabilities to be set

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -162,6 +162,7 @@ jobs:
           CHROMEDRIVER_PATH: "${{ (matrix.browser == 'chrome' && !matrix.selenium-server) && '/usr/local/share/chrome_driver/chromedriver' || '' }}"
           GECKODRIVER_PATH: "${{ (matrix.browser == 'firefox' && !matrix.selenium-server) && '/usr/local/share/gecko_driver/geckodriver' || '' }}"
           DISABLE_W3C_PROTOCOL: "${{ matrix.w3c && '0' || '1' }}"
+          SELENIUM_SERVER: "${{ matrix.selenium-server && '1' || '0' }}"
         run: |
           if [ "$BROWSER_NAME" = "chrome" ]; then EXCLUDE_GROUP+="exclude-chrome,"; fi
           if [ "$BROWSER_NAME" = "firefox" ]; then EXCLUDE_GROUP+="exclude-firefox,"; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Require PHP ^7.3.
+- Capabilities must be either explicitly provided or retrievable from Selenium Grid when resuing session with `createBySessionID()`.
 - Throw `UnexpectedResponseException` instead of `UnknownErrorException` in `findElement()` and `findElements()` methods.
 - Throw custom php-webdriver exceptions instead of native PHP SPL exceptions.
-- Do not mix internal non-W3C WebDriver exceptions, separate them into own namespace.
+- Do not mix internal non-W3C WebDriver exceptions, separate them into own namespaces.
 
 ## 1.13.0 - 2022-10-03
 ### Added

--- a/lib/Exception/Internal/UnexpectedResponseException.php
+++ b/lib/Exception/Internal/UnexpectedResponseException.php
@@ -26,4 +26,16 @@ class UnexpectedResponseException extends \RuntimeException implements PhpWebDri
             )
         );
     }
+
+    public static function forCapabilitiesRetrievalError(\Exception $previousException): self
+    {
+        return new self(
+            sprintf(
+                'Existing Capabilities were not provided, and they also cannot be read from Selenium Grid'
+                . ' (error: "%s"). You are probably not using Selenium Grid, so to reuse the previous session,'
+                . ' Capabilities must be explicitly provided to createBySessionID() method.',
+                $previousException->getMessage()
+            )
+        );
+    }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,5 +23,7 @@ parameters:
         # Parameter is intentionally not part of signature to not break BC
         - message: '#PHPDoc tag \@param references unknown parameter: \$isW3cCompliant#'
           path: 'lib/Remote/RemoteWebDriver.php'
+        - message: '#PHPDoc tag \@param references unknown parameter: \$existingCapabilities#'
+          path: 'lib/Remote/RemoteWebDriver.php'
 
     inferPrivatePropertyTypeFromConstructor: true

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -110,6 +110,11 @@ class WebDriverTestCase extends TestCase
         return getenv('DISABLE_W3C_PROTOCOL') !== '1';
     }
 
+    public static function isSeleniumServerUsed(): bool
+    {
+        return getenv('SELENIUM_SERVER') === '1';
+    }
+
     public static function skipForW3cProtocol($message = 'Not supported by W3C specification')
     {
         if (static::isW3cProtocolBuild()) {

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -22,7 +22,14 @@ class RemoteWebDriverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->driver = RemoteWebDriver::createBySessionID('session-id', 'http://foo.bar:4444');
+        $this->driver = RemoteWebDriver::createBySessionID(
+            'session-id',
+            'http://foo.bar:4444',
+            null,
+            null,
+            true,
+            new DesiredCapabilities([])
+        );
     }
 
     /**

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -11,7 +11,7 @@ use Facebook\WebDriver\WebDriverWait;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit part of RemoteWebDriver tests. Ie. tests for behavior which do not interact with the real remote server.
+ * Unit part of RemoteWebDriver tests. I.e. tests for behavior which do not interact with the real remote server.
  *
  * @coversDefaultClass \Facebook\WebDriver\Remote\RemoteWebDriver
  */
@@ -22,6 +22,7 @@ class RemoteWebDriverTest extends TestCase
 
     protected function setUp(): void
     {
+        // `createBySessionID()` is used because it is the simplest way to instantiate real RemoteWebDriver
         $this->driver = RemoteWebDriver::createBySessionID(
             'session-id',
             'http://foo.bar:4444',


### PR DESCRIPTION
This is a proper fix for issues like #1022 etc.

When RemoteWebDriver instance was created using `createBySessionID()`, it was missing value of capabilities (it was null). This lead to various unexpected issues, for example with instance crated like this, you are not able to get the name of the running browser. Which is unexpected, not type-safe and leading to errors.

With this PR, we try to read capabilities from Selenium Grid server (there is no endpoint defined in W3C WebDriver, it is only the API of Selenium Server itself). Alternatively, if you don't use Selenium Grid, you must explicitly provide capabilities using the sixth parameter of `createBySessionID()`, see example. Thank to this, you can always be sure `$driver->getCapabilities()`, `$driver->getCapabilities()->getBrowserName()` etc. will return a sane value.

```php
$originalDriver = RemoteWebDriver::create($serverUrl, $desiredCapabilities);
$sessionId = $originalDriver->getSessionID(); // save sessionId to variable
$originalCapabilities = $originalDriver->getCapabilities(); // save capabilities to variable

// reuse driver using the session ID and capabilities
$driverFromSessionId = RemoteWebDriver::createBySessionID($sessionId, $serverUrl, null, true, $originalCapabilities);
```

If you don't use Selenium Grid and you don't provide capabilities, you won't be able to crate the RemoteWebDriver instance using `createBySessionID()` method.

---

- [x] Add CHANGELOG entry