### PR TITLE
Add typehints where safe, remove superfluous phpdoc

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -62,6 +62,11 @@ return (new PhpCsFixer\Config())
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_singleline_whitespace_before_semicolons' => true,
+        //'no_superfluous_phpdoc_tags' => [
+        //    'allow_mixed' => true,
+        //    'remove_inheritdoc' => true,
+        //    'allow_unused_params' => false,
+        //],
         'no_trailing_comma_in_singleline' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unused_imports' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -62,11 +62,11 @@ return (new PhpCsFixer\Config())
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        //'no_superfluous_phpdoc_tags' => [
-        //    'allow_mixed' => true,
-        //    'remove_inheritdoc' => true,
-        //    'allow_unused_params' => false,
-        //],
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'remove_inheritdoc' => true,
+            'allow_unused_params' => true, // Used in RemoteWebDriver::createBySessionID to maintain BC
+        ],
         'no_trailing_comma_in_singleline' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unused_imports' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -96,6 +96,8 @@ return (new PhpCsFixer\Config())
         'phpdoc_scalar' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
+        //'phpdoc_to_param_type' => true,
+        //'phpdoc_to_return_type' => true,
         'phpdoc_types' => true,
         'phpdoc_var_annotation_correct_order' => true,
         //'pow_to_exponentiation' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -98,6 +98,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
         'phpdoc_var_annotation_correct_order' => true,
+        //'pow_to_exponentiation' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
         'self_accessor' => true,
@@ -118,6 +119,7 @@ return (new PhpCsFixer\Config())
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'visibility_required' => ['elements' => ['method', 'property', 'const']],
+        //'void_return' => true,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
     ])

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -65,7 +65,6 @@ class ChromeOptions implements JsonSerializable
     }
 
     /**
-     * @param array $arguments
      * @return ChromeOptions
      */
     public function addArguments(array $arguments)
@@ -79,7 +78,6 @@ class ChromeOptions implements JsonSerializable
      * Add a Chrome extension to install on browser startup. Each path should be
      * a packed Chrome extension.
      *
-     * @param array $paths
      * @return ChromeOptions
      */
     public function addExtensions(array $paths)

--- a/lib/Exception/Internal/RuntimeException.php
+++ b/lib/Exception/Internal/RuntimeException.php
@@ -15,10 +15,6 @@ class RuntimeException extends \RuntimeException implements PhpWebDriverExceptio
         return new self($message);
     }
 
-    /**
-     * @param Process $process
-     * @return RuntimeException
-     */
     public static function forDriverError(Process $process): self
     {
         return new self(

--- a/lib/Firefox/FirefoxOptions.php
+++ b/lib/Firefox/FirefoxOptions.php
@@ -97,7 +97,6 @@ class FirefoxOptions implements \JsonSerializable
 
     /**
      * @see https://github.com/php-webdriver/php-webdriver/wiki/Firefox#firefox-profile
-     * @param FirefoxProfile $profile
      * @return self
      */
     public function setProfile(FirefoxProfile $profile)

--- a/lib/Interactions/Internal/WebDriverCoordinates.php
+++ b/lib/Interactions/Internal/WebDriverCoordinates.php
@@ -29,8 +29,6 @@ class WebDriverCoordinates
 
     /**
      * @param null $on_screen
-     * @param callable $in_view_port
-     * @param callable $on_page
      * @param string $auxiliary
      */
     public function __construct($on_screen, callable $in_view_port, callable $on_page, $auxiliary)

--- a/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
+++ b/lib/Interactions/Internal/WebDriverKeysRelatedAction.php
@@ -24,11 +24,6 @@ abstract class WebDriverKeysRelatedAction
      */
     protected $locationProvider;
 
-    /**
-     * @param WebDriverKeyboard $keyboard
-     * @param WebDriverMouse $mouse
-     * @param WebDriverLocatable $location_provider
-     */
     public function __construct(
         WebDriverKeyboard $keyboard,
         WebDriverMouse $mouse,

--- a/lib/Interactions/Internal/WebDriverMouseAction.php
+++ b/lib/Interactions/Internal/WebDriverMouseAction.php
@@ -19,10 +19,6 @@ class WebDriverMouseAction
      */
     protected $locationProvider;
 
-    /**
-     * @param WebDriverMouse $mouse
-     * @param WebDriverLocatable|null $location_provider
-     */
     public function __construct(WebDriverMouse $mouse, WebDriverLocatable $location_provider = null)
     {
         $this->mouse = $mouse;

--- a/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
+++ b/lib/Interactions/Internal/WebDriverMoveToOffsetAction.php
@@ -18,8 +18,6 @@ class WebDriverMoveToOffsetAction extends WebDriverMouseAction implements WebDri
     private $yOffset;
 
     /**
-     * @param WebDriverMouse $mouse
-     * @param WebDriverLocatable|null $location_provider
      * @param int|null $x_offset
      * @param int|null $y_offset
      */

--- a/lib/Interactions/Internal/WebDriverSendKeysAction.php
+++ b/lib/Interactions/Internal/WebDriverSendKeysAction.php
@@ -15,9 +15,6 @@ class WebDriverSendKeysAction extends WebDriverKeysRelatedAction implements WebD
     private $keys = '';
 
     /**
-     * @param WebDriverKeyboard $keyboard
-     * @param WebDriverMouse $mouse
-     * @param WebDriverLocatable $location_provider
      * @param string $keys
      */
     public function __construct(

--- a/lib/Interactions/Touch/WebDriverDownAction.php
+++ b/lib/Interactions/Touch/WebDriverDownAction.php
@@ -16,7 +16,6 @@ class WebDriverDownAction extends WebDriverTouchAction implements WebDriverActio
     private $y;
 
     /**
-     * @param WebDriverTouchScreen $touch_screen
      * @param int $x
      * @param int $y
      */

--- a/lib/Interactions/Touch/WebDriverFlickAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickAction.php
@@ -16,7 +16,6 @@ class WebDriverFlickAction extends WebDriverTouchAction implements WebDriverActi
     private $y;
 
     /**
-     * @param WebDriverTouchScreen $touch_screen
      * @param int $x
      * @param int $y
      */

--- a/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverFlickFromElementAction.php
@@ -21,8 +21,6 @@ class WebDriverFlickFromElementAction extends WebDriverTouchAction implements We
     private $speed;
 
     /**
-     * @param WebDriverTouchScreen $touch_screen
-     * @param WebDriverElement $element
      * @param int $x
      * @param int $y
      * @param int $speed

--- a/lib/Interactions/Touch/WebDriverMoveAction.php
+++ b/lib/Interactions/Touch/WebDriverMoveAction.php
@@ -10,7 +10,6 @@ class WebDriverMoveAction extends WebDriverTouchAction implements WebDriverActio
     private $y;
 
     /**
-     * @param WebDriverTouchScreen $touch_screen
      * @param int $x
      * @param int $y
      */

--- a/lib/Interactions/Touch/WebDriverScrollAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollAction.php
@@ -10,7 +10,6 @@ class WebDriverScrollAction extends WebDriverTouchAction implements WebDriverAct
     private $y;
 
     /**
-     * @param WebDriverTouchScreen $touch_screen
      * @param int $x
      * @param int $y
      */

--- a/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
+++ b/lib/Interactions/Touch/WebDriverScrollFromElementAction.php
@@ -11,8 +11,6 @@ class WebDriverScrollFromElementAction extends WebDriverTouchAction implements W
     private $y;
 
     /**
-     * @param WebDriverTouchScreen $touch_screen
-     * @param WebDriverElement $element
      * @param int $x
      * @param int $y
      */

--- a/lib/Interactions/Touch/WebDriverTouchAction.php
+++ b/lib/Interactions/Touch/WebDriverTouchAction.php
@@ -19,10 +19,6 @@ abstract class WebDriverTouchAction
      */
     protected $locationProvider;
 
-    /**
-     * @param WebDriverTouchScreen $touch_screen
-     * @param WebDriverLocatable $location_provider
-     */
     public function __construct(
         WebDriverTouchScreen $touch_screen,
         WebDriverLocatable $location_provider = null

--- a/lib/Interactions/Touch/WebDriverTouchScreen.php
+++ b/lib/Interactions/Touch/WebDriverTouchScreen.php
@@ -12,7 +12,6 @@ interface WebDriverTouchScreen
     /**
      * Single tap on the touch enabled device.
      *
-     * @param WebDriverElement $element
      * @return $this
      */
     public function tap(WebDriverElement $element);
@@ -20,7 +19,6 @@ interface WebDriverTouchScreen
     /**
      * Double tap on the touch screen using finger motion events.
      *
-     * @param WebDriverElement $element
      * @return $this
      */
     public function doubleTap(WebDriverElement $element);
@@ -48,7 +46,6 @@ interface WebDriverTouchScreen
      * Flick on the touch screen using finger motion events.
      * This flickcommand starts at a particular screen location.
      *
-     * @param WebDriverElement $element
      * @param int $xoffset
      * @param int $yoffset
      * @param int $speed
@@ -64,7 +61,6 @@ interface WebDriverTouchScreen
     /**
      * Long press on the touch screen using finger motion events.
      *
-     * @param WebDriverElement $element
      * @return $this
      */
     public function longPress(WebDriverElement $element);
@@ -92,7 +88,6 @@ interface WebDriverTouchScreen
      * Scroll on the touch screen using finger based motion events. Use this
      * command to start scrolling at a particular screen location.
      *
-     * @param WebDriverElement $element
      * @param int $xoffset
      * @param int $yoffset
      * @return $this

--- a/lib/Interactions/WebDriverActions.php
+++ b/lib/Interactions/WebDriverActions.php
@@ -25,9 +25,6 @@ class WebDriverActions
     protected $mouse;
     protected $action;
 
-    /**
-     * @param WebDriverHasInputDevices $driver
-     */
     public function __construct(WebDriverHasInputDevices $driver)
     {
         $this->driver = $driver;
@@ -48,7 +45,6 @@ class WebDriverActions
      * Mouse click.
      * If $element is provided, move to the middle of the element first.
      *
-     * @param WebDriverElement $element
      * @return WebDriverActions
      */
     public function click(WebDriverElement $element = null)
@@ -64,7 +60,6 @@ class WebDriverActions
      * Mouse click and hold.
      * If $element is provided, move to the middle of the element first.
      *
-     * @param WebDriverElement $element
      * @return WebDriverActions
      */
     public function clickAndHold(WebDriverElement $element = null)
@@ -80,7 +75,6 @@ class WebDriverActions
      * Context-click (right click).
      * If $element is provided, move to the middle of the element first.
      *
-     * @param WebDriverElement $element
      * @return WebDriverActions
      */
     public function contextClick(WebDriverElement $element = null)
@@ -96,7 +90,6 @@ class WebDriverActions
      * Double click.
      * If $element is provided, move to the middle of the element first.
      *
-     * @param WebDriverElement $element
      * @return WebDriverActions
      */
     public function doubleClick(WebDriverElement $element = null)
@@ -111,8 +104,6 @@ class WebDriverActions
     /**
      * Drag and drop from $source to $target.
      *
-     * @param WebDriverElement $source
-     * @param WebDriverElement $target
      * @return WebDriverActions
      */
     public function dragAndDrop(WebDriverElement $source, WebDriverElement $target)
@@ -133,7 +124,6 @@ class WebDriverActions
     /**
      * Drag $source and drop by offset ($x_offset, $y_offset).
      *
-     * @param WebDriverElement $source
      * @param int $x_offset
      * @param int $y_offset
      * @return WebDriverActions
@@ -174,7 +164,6 @@ class WebDriverActions
      * Extra shift, calculated from the top-left corner of the element, can be set by passing $x_offset and $y_offset
      * parameters.
      *
-     * @param WebDriverElement $element
      * @param int $x_offset
      * @param int $y_offset
      * @return WebDriverActions
@@ -195,7 +184,6 @@ class WebDriverActions
      * Release the mouse button.
      * If $element is provided, move to the middle of the element first.
      *
-     * @param WebDriverElement $element
      * @return WebDriverActions
      */
     public function release(WebDriverElement $element = null)
@@ -212,7 +200,6 @@ class WebDriverActions
      * If $element is provided, focus on that element first.
      *
      * @see WebDriverKeys for special keys like CONTROL, ALT, etc.
-     * @param WebDriverElement $element
      * @param string $key
      * @return WebDriverActions
      */
@@ -230,7 +217,6 @@ class WebDriverActions
      * If $element is provided, focus on that element first.
      *
      * @see WebDriverKeys for special keys like CONTROL, ALT, etc.
-     * @param WebDriverElement $element
      * @param string $key
      * @return WebDriverActions
      */
@@ -248,7 +234,6 @@ class WebDriverActions
      * If $element is provided, focus on that element first (using single mouse click).
      *
      * @see WebDriverKeys for special keys like CONTROL, ALT, etc.
-     * @param WebDriverElement $element
      * @param string $keys
      * @return WebDriverActions
      */

--- a/lib/Interactions/WebDriverCompositeAction.php
+++ b/lib/Interactions/WebDriverCompositeAction.php
@@ -17,7 +17,6 @@ class WebDriverCompositeAction implements WebDriverAction
     /**
      * Add an WebDriverAction to the sequence.
      *
-     * @param WebDriverAction $action
      * @return WebDriverCompositeAction The current instance.
      */
     public function addAction(WebDriverAction $action)

--- a/lib/Interactions/WebDriverTouchActions.php
+++ b/lib/Interactions/WebDriverTouchActions.php
@@ -33,7 +33,6 @@ class WebDriverTouchActions extends WebDriverActions
     }
 
     /**
-     * @param WebDriverElement $element
      * @return WebDriverTouchActions
      */
     public function tap(WebDriverElement $element)
@@ -102,7 +101,6 @@ class WebDriverTouchActions extends WebDriverActions
     }
 
     /**
-     * @param WebDriverElement $element
      * @param int $x
      * @param int $y
      * @return WebDriverTouchActions
@@ -117,7 +115,6 @@ class WebDriverTouchActions extends WebDriverActions
     }
 
     /**
-     * @param WebDriverElement $element
      * @return WebDriverTouchActions
      */
     public function doubleTap(WebDriverElement $element)
@@ -130,7 +127,6 @@ class WebDriverTouchActions extends WebDriverActions
     }
 
     /**
-     * @param WebDriverElement $element
      * @return WebDriverTouchActions
      */
     public function longPress(WebDriverElement $element)
@@ -157,7 +153,6 @@ class WebDriverTouchActions extends WebDriverActions
     }
 
     /**
-     * @param WebDriverElement $element
      * @param int $x
      * @param int $y
      * @param int $speed

--- a/lib/Local/LocalWebDriver.php
+++ b/lib/Local/LocalWebDriver.php
@@ -19,7 +19,6 @@ abstract class LocalWebDriver extends RemoteWebDriver
      * @param null $request_timeout_in_ms
      * @param null $http_proxy
      * @param null $http_proxy_port
-     * @param DesiredCapabilities|null $required_capabilities
      * @throws LogicException
      * @return RemoteWebDriver
      * @todo Remove in next major version (should not be inherited)

--- a/lib/Remote/CustomWebDriverCommand.php
+++ b/lib/Remote/CustomWebDriverCommand.php
@@ -19,7 +19,6 @@ class CustomWebDriverCommand extends WebDriverCommand
      * @param string $session_id
      * @param string $url
      * @param string $method
-     * @param array $parameters
      */
     public function __construct($session_id, $url, $method, array $parameters)
     {

--- a/lib/Remote/ExecuteMethod.php
+++ b/lib/Remote/ExecuteMethod.php
@@ -6,7 +6,6 @@ interface ExecuteMethod
 {
     /**
      * @param string $command_name
-     * @param array $parameters
      * @return WebDriverResponse
      */
     public function execute($command_name, array $parameters = []);

--- a/lib/Remote/HttpCommandExecutor.php
+++ b/lib/Remote/HttpCommandExecutor.php
@@ -270,8 +270,6 @@ class HttpCommandExecutor implements WebDriverCommandExecutor
     }
 
     /**
-     * @param WebDriverCommand $command
-     *
      * @return WebDriverResponse
      */
     public function execute(WebDriverCommand $command)

--- a/lib/Remote/JsonWireCompat.php
+++ b/lib/Remote/JsonWireCompat.php
@@ -30,7 +30,6 @@ abstract class JsonWireCompat
     }
 
     /**
-     * @param WebDriverBy $by
      * @param bool $isW3cCompliant
      *
      * @return array

--- a/lib/Remote/RemoteExecuteMethod.php
+++ b/lib/Remote/RemoteExecuteMethod.php
@@ -9,9 +9,6 @@ class RemoteExecuteMethod implements ExecuteMethod
      */
     private $driver;
 
-    /**
-     * @param RemoteWebDriver $driver
-     */
     public function __construct(RemoteWebDriver $driver)
     {
         $this->driver = $driver;
@@ -19,7 +16,6 @@ class RemoteExecuteMethod implements ExecuteMethod
 
     /**
      * @param string $command_name
-     * @param array $parameters
      * @return mixed
      */
     public function execute($command_name, array $parameters = [])

--- a/lib/Remote/RemoteMouse.php
+++ b/lib/Remote/RemoteMouse.php
@@ -27,7 +27,6 @@ class RemoteMouse implements WebDriverMouse
     private $isW3cCompliant;
 
     /**
-     * @param RemoteExecuteMethod $executor
      * @param bool $isW3cCompliant
      */
     public function __construct(RemoteExecuteMethod $executor, $isW3cCompliant = false)
@@ -37,8 +36,6 @@ class RemoteMouse implements WebDriverMouse
     }
 
     /**
-     * @param null|WebDriverCoordinates $where
-     *
      * @return RemoteMouse
      */
     public function click(WebDriverCoordinates $where = null)
@@ -68,8 +65,6 @@ class RemoteMouse implements WebDriverMouse
     }
 
     /**
-     * @param WebDriverCoordinates $where
-     *
      * @return RemoteMouse
      */
     public function contextClick(WebDriverCoordinates $where = null)
@@ -108,8 +103,6 @@ class RemoteMouse implements WebDriverMouse
     }
 
     /**
-     * @param WebDriverCoordinates $where
-     *
      * @return RemoteMouse
      */
     public function doubleClick(WebDriverCoordinates $where = null)
@@ -138,8 +131,6 @@ class RemoteMouse implements WebDriverMouse
     }
 
     /**
-     * @param WebDriverCoordinates $where
-     *
      * @return RemoteMouse
      */
     public function mouseDown(WebDriverCoordinates $where = null)
@@ -172,7 +163,6 @@ class RemoteMouse implements WebDriverMouse
     }
 
     /**
-     * @param WebDriverCoordinates $where
      * @param int|null $x_offset
      * @param int|null $y_offset
      *
@@ -215,8 +205,6 @@ class RemoteMouse implements WebDriverMouse
     }
 
     /**
-     * @param WebDriverCoordinates $where
-     *
      * @return RemoteMouse
      */
     public function mouseUp(WebDriverCoordinates $where = null)
@@ -249,9 +237,6 @@ class RemoteMouse implements WebDriverMouse
         return $this;
     }
 
-    /**
-     * @param WebDriverCoordinates $where
-     */
     protected function moveIfNeeded(WebDriverCoordinates $where = null)
     {
         if ($where) {
@@ -260,7 +245,6 @@ class RemoteMouse implements WebDriverMouse
     }
 
     /**
-     * @param WebDriverCoordinates $where
      * @param int|null $x_offset
      * @param int|null $y_offset
      *

--- a/lib/Remote/RemoteStatus.php
+++ b/lib/Remote/RemoteStatus.php
@@ -29,7 +29,6 @@ class RemoteStatus
     }
 
     /**
-     * @param array $responseBody
      * @return RemoteStatus
      */
     public static function createFromResponse(array $responseBody)

--- a/lib/Remote/RemoteTouchScreen.php
+++ b/lib/Remote/RemoteTouchScreen.php
@@ -15,17 +15,12 @@ class RemoteTouchScreen implements WebDriverTouchScreen
      */
     private $executor;
 
-    /**
-     * @param RemoteExecuteMethod $executor
-     */
     public function __construct(RemoteExecuteMethod $executor)
     {
         $this->executor = $executor;
     }
 
     /**
-     * @param WebDriverElement $element
-     *
      * @return RemoteTouchScreen The instance.
      */
     public function tap(WebDriverElement $element)
@@ -39,8 +34,6 @@ class RemoteTouchScreen implements WebDriverTouchScreen
     }
 
     /**
-     * @param WebDriverElement $element
-     *
      * @return RemoteTouchScreen The instance.
      */
     public function doubleTap(WebDriverElement $element)
@@ -86,7 +79,6 @@ class RemoteTouchScreen implements WebDriverTouchScreen
     }
 
     /**
-     * @param WebDriverElement $element
      * @param int $xoffset
      * @param int $yoffset
      * @param int $speed
@@ -106,8 +98,6 @@ class RemoteTouchScreen implements WebDriverTouchScreen
     }
 
     /**
-     * @param WebDriverElement $element
-     *
      * @return RemoteTouchScreen The instance.
      */
     public function longPress(WebDriverElement $element)
@@ -153,7 +143,6 @@ class RemoteTouchScreen implements WebDriverTouchScreen
     }
 
     /**
-     * @param WebDriverElement $element
      * @param int $xoffset
      * @param int $yoffset
      *

--- a/lib/Remote/RemoteWebDriver.php
+++ b/lib/Remote/RemoteWebDriver.php
@@ -54,9 +54,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     protected $isW3cCompliant;
 
     /**
-     * @param HttpCommandExecutor $commandExecutor
      * @param string $sessionId
-     * @param WebDriverCapabilities $capabilities
      * @param bool $isW3cCompliant false to use the legacy JsonWire protocol, true for the W3C WebDriver spec
      */
     protected function __construct(
@@ -176,7 +174,7 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
             $executor->disableW3cCompliance();
         }
 
-        // if  capabilities were not provided, attempt to read them from the Selenium Grid API
+        // if capabilities were not provided, attempt to read them from the Selenium Grid API
         if ($existingCapabilities === null) {
             $existingCapabilities = self::readExistingCapabilitiesFromSeleniumGrid($session_id, $executor);
         }
@@ -211,7 +209,6 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     /**
      * Find the first WebDriverElement using the given mechanism.
      *
-     * @param WebDriverBy $by
      * @return RemoteWebElement NoSuchElementException is thrown in HttpCommandExecutor if no element is found.
      * @see WebDriverBy
      */
@@ -232,7 +229,6 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     /**
      * Find all WebDriverElements within the current page using the given mechanism.
      *
-     * @param WebDriverBy $by
      * @return RemoteWebElement[] A list of all WebDriverElements, or an empty array if nothing matches
      * @see WebDriverBy
      */
@@ -678,7 +674,6 @@ class RemoteWebDriver implements WebDriver, JavaScriptExecutor, WebDriverHasInpu
     /**
      * Prepare arguments for JavaScript injection
      *
-     * @param array $arguments
      * @return array
      */
     protected function prepareScriptArguments(array $arguments)

--- a/lib/Remote/RemoteWebElement.php
+++ b/lib/Remote/RemoteWebElement.php
@@ -40,7 +40,6 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
     protected $isW3cCompliant;
 
     /**
-     * @param RemoteExecuteMethod $executor
      * @param string $id
      * @param bool $isW3cCompliant
      */
@@ -96,7 +95,6 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      * search the entire document from the root, not just the children (relative context) of this current node.
      * Use ".//" to limit your search to the children of this element.
      *
-     * @param WebDriverBy $by
      * @return RemoteWebElement NoSuchElementException is thrown in HttpCommandExecutor if no element is found.
      * @see WebDriverBy
      */
@@ -120,7 +118,6 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      * search the entire document from the root, not just the children (relative context) of this current node.
      * Use ".//" to limit your search to the children of this element.
      *
-     * @param WebDriverBy $by
      * @return RemoteWebElement[] A list of all WebDriverElements, or an empty
      *    array if nothing matches
      * @see WebDriverBy
@@ -441,7 +438,6 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
      *
      *   eg. `$element->setFileDetector(new LocalFileDetector);`
      *
-     * @param FileDetector $detector
      * @return RemoteWebElement
      * @see FileDetector
      * @see LocalFileDetector
@@ -517,7 +513,6 @@ class RemoteWebElement implements WebDriverElement, WebDriverLocatable
     /**
      * Test if two elements IDs refer to the same DOM element.
      *
-     * @param WebDriverElement $other
      * @return bool
      */
     public function equals(WebDriverElement $other)

--- a/lib/Remote/Service/DriverCommandExecutor.php
+++ b/lib/Remote/Service/DriverCommandExecutor.php
@@ -26,8 +26,6 @@ class DriverCommandExecutor extends HttpCommandExecutor
     }
 
     /**
-     * @param WebDriverCommand $command
-     *
      * @throws \Exception
      * @throws WebDriverException
      * @return WebDriverResponse

--- a/lib/Remote/ShadowRoot.php
+++ b/lib/Remote/ShadowRoot.php
@@ -33,8 +33,6 @@ class ShadowRoot implements WebDriverSearchContext
     }
 
     /**
-     * @param RemoteExecuteMethod $executor
-     * @param array $response
      * @return self
      */
     public static function createFromResponse(RemoteExecuteMethod $executor, array $response)
@@ -47,7 +45,6 @@ class ShadowRoot implements WebDriverSearchContext
     }
 
     /**
-     * @param WebDriverBy $locator
      * @return RemoteWebElement
      */
     public function findElement(WebDriverBy $locator)
@@ -64,7 +61,6 @@ class ShadowRoot implements WebDriverSearchContext
     }
 
     /**
-     * @param WebDriverBy $locator
      * @return WebDriverElement[]
      */
     public function findElements(WebDriverBy $locator)

--- a/lib/Support/Events/EventFiringWebDriver.php
+++ b/lib/Support/Events/EventFiringWebDriver.php
@@ -26,10 +26,6 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
      */
     protected $dispatcher;
 
-    /**
-     * @param WebDriver $driver
-     * @param WebDriverDispatcher $dispatcher
-     */
     public function __construct(WebDriver $driver, WebDriverDispatcher $dispatcher = null)
     {
         $this->dispatcher = $dispatcher ?: new WebDriverDispatcher();
@@ -76,7 +72,6 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
     }
 
     /**
-     * @param WebDriverBy $by
      * @throws WebDriverException
      * @return array
      */
@@ -100,7 +95,6 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
     }
 
     /**
-     * @param WebDriverBy $by
      * @throws WebDriverException
      * @return EventFiringWebElement
      */
@@ -122,7 +116,6 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
 
     /**
      * @param string $script
-     * @param array $arguments
      * @throws WebDriverException
      * @return mixed
      */
@@ -150,7 +143,6 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
 
     /**
      * @param string $script
-     * @param array $arguments
      * @throws WebDriverException
      * @return mixed
      */
@@ -375,7 +367,6 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
     }
 
     /**
-     * @param WebDriverElement $element
      * @return EventFiringWebElement
      */
     protected function newElement(WebDriverElement $element)
@@ -396,9 +387,6 @@ class EventFiringWebDriver implements WebDriver, JavaScriptExecutor
         $this->dispatcher->dispatch($method, $arguments);
     }
 
-    /**
-     * @param WebDriverException $exception
-     */
     protected function dispatchOnException(WebDriverException $exception)
     {
         $this->dispatch('onException', $exception, $this);

--- a/lib/Support/Events/EventFiringWebDriverNavigation.php
+++ b/lib/Support/Events/EventFiringWebDriverNavigation.php
@@ -17,10 +17,6 @@ class EventFiringWebDriverNavigation implements WebDriverNavigationInterface
      */
     protected $dispatcher;
 
-    /**
-     * @param WebDriverNavigationInterface $navigator
-     * @param WebDriverDispatcher $dispatcher
-     */
     public function __construct(WebDriverNavigationInterface $navigator, WebDriverDispatcher $dispatcher)
     {
         $this->navigator = $navigator;
@@ -132,9 +128,6 @@ class EventFiringWebDriverNavigation implements WebDriverNavigationInterface
         $this->dispatcher->dispatch($method, $arguments);
     }
 
-    /**
-     * @param WebDriverException $exception
-     */
     protected function dispatchOnException(WebDriverException $exception)
     {
         $this->dispatch('onException', $exception);

--- a/lib/Support/Events/EventFiringWebElement.php
+++ b/lib/Support/Events/EventFiringWebElement.php
@@ -22,10 +22,6 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
      */
     protected $dispatcher;
 
-    /**
-     * @param WebDriverElement $element
-     * @param WebDriverDispatcher $dispatcher
-     */
     public function __construct(WebDriverElement $element, WebDriverDispatcher $dispatcher)
     {
         $this->element = $element;
@@ -88,7 +84,6 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
     }
 
     /**
-     * @param WebDriverBy $by
      * @throws WebDriverException
      * @return EventFiringWebElement
      */
@@ -119,7 +114,6 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
     }
 
     /**
-     * @param WebDriverBy $by
      * @throws WebDriverException
      * @return array
      */
@@ -355,7 +349,6 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
     /**
      * Test if two element IDs refer to the same DOM element.
      *
-     * @param WebDriverElement $other
      * @return bool
      */
     public function equals(WebDriverElement $other)
@@ -388,9 +381,6 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
         }
     }
 
-    /**
-     * @param WebDriverException $exception
-     */
     protected function dispatchOnException(WebDriverException $exception)
     {
         $this->dispatch(
@@ -414,7 +404,6 @@ class EventFiringWebElement implements WebDriverElement, WebDriverLocatable
     }
 
     /**
-     * @param WebDriverElement $element
      * @return static
      */
     protected function newElement(WebDriverElement $element)

--- a/lib/WebDriverCommandExecutor.php
+++ b/lib/WebDriverCommandExecutor.php
@@ -11,8 +11,6 @@ use Facebook\WebDriver\Remote\WebDriverResponse;
 interface WebDriverCommandExecutor
 {
     /**
-     * @param WebDriverCommand $command
-     *
      * @return WebDriverResponse
      */
     public function execute(WebDriverCommand $command);

--- a/lib/WebDriverDispatcher.php
+++ b/lib/WebDriverDispatcher.php
@@ -19,7 +19,6 @@ class WebDriverDispatcher
      * this is needed so that EventFiringWebElement can pass the driver to the
      * exception handling
      *
-     * @param EventFiringWebDriver $driver
      * @return $this
      */
     public function setDefaultDriver(EventFiringWebDriver $driver)
@@ -38,7 +37,6 @@ class WebDriverDispatcher
     }
 
     /**
-     * @param WebDriverEventListener $listener
      * @return $this
      */
     public function register(WebDriverEventListener $listener)
@@ -49,7 +47,6 @@ class WebDriverDispatcher
     }
 
     /**
-     * @param WebDriverEventListener $listener
      * @return $this
      */
     public function unregister(WebDriverEventListener $listener)

--- a/lib/WebDriverEventListener.php
+++ b/lib/WebDriverEventListener.php
@@ -10,85 +10,43 @@ interface WebDriverEventListener
 {
     /**
      * @param string $url
-     * @param EventFiringWebDriver $driver
      */
     public function beforeNavigateTo($url, EventFiringWebDriver $driver);
 
     /**
      * @param string $url
-     * @param EventFiringWebDriver $driver
      */
     public function afterNavigateTo($url, EventFiringWebDriver $driver);
 
-    /**
-     * @param EventFiringWebDriver $driver
-     */
     public function beforeNavigateBack(EventFiringWebDriver $driver);
 
-    /**
-     * @param EventFiringWebDriver $driver
-     */
     public function afterNavigateBack(EventFiringWebDriver $driver);
 
-    /**
-     * @param EventFiringWebDriver $driver
-     */
     public function beforeNavigateForward(EventFiringWebDriver $driver);
 
-    /**
-     * @param EventFiringWebDriver $driver
-     */
     public function afterNavigateForward(EventFiringWebDriver $driver);
 
-    /**
-     * @param WebDriverBy $by
-     * @param EventFiringWebElement|null $element
-     * @param EventFiringWebDriver $driver
-     */
     public function beforeFindBy(WebDriverBy $by, $element, EventFiringWebDriver $driver);
 
-    /**
-     * @param WebDriverBy $by
-     * @param EventFiringWebElement|null $element
-     * @param EventFiringWebDriver $driver
-     */
     public function afterFindBy(WebDriverBy $by, $element, EventFiringWebDriver $driver);
 
     /**
      * @param string $script
-     * @param EventFiringWebDriver $driver
      */
     public function beforeScript($script, EventFiringWebDriver $driver);
 
     /**
      * @param string $script
-     * @param EventFiringWebDriver $driver
      */
     public function afterScript($script, EventFiringWebDriver $driver);
 
-    /**
-     * @param EventFiringWebElement $element
-     */
     public function beforeClickOn(EventFiringWebElement $element);
 
-    /**
-     * @param EventFiringWebElement $element
-     */
     public function afterClickOn(EventFiringWebElement $element);
 
-    /**
-     * @param EventFiringWebElement $element
-     */
     public function beforeChangeValueOf(EventFiringWebElement $element);
 
-    /**
-     * @param EventFiringWebElement $element
-     */
     public function afterChangeValueOf(EventFiringWebElement $element);
 
-    /**
-     * @param WebDriverException $exception
-     * @param EventFiringWebDriver $driver
-     */
     public function onException(WebDriverException $exception, EventFiringWebDriver $driver = null);
 }

--- a/lib/WebDriverMouse.php
+++ b/lib/WebDriverMouse.php
@@ -10,31 +10,26 @@ use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
 interface WebDriverMouse
 {
     /**
-     * @param WebDriverCoordinates $where
      * @return WebDriverMouse
      */
     public function click(WebDriverCoordinates $where);
 
     /**
-     * @param WebDriverCoordinates $where
      * @return WebDriverMouse
      */
     public function contextClick(WebDriverCoordinates $where);
 
     /**
-     * @param WebDriverCoordinates $where
      * @return WebDriverMouse
      */
     public function doubleClick(WebDriverCoordinates $where);
 
     /**
-     * @param WebDriverCoordinates $where
      * @return WebDriverMouse
      */
     public function mouseDown(WebDriverCoordinates $where);
 
     /**
-     * @param WebDriverCoordinates $where
      * @param int $x_offset
      * @param int $y_offset
      * @return WebDriverMouse
@@ -46,7 +41,6 @@ interface WebDriverMouse
     );
 
     /**
-     * @param WebDriverCoordinates $where
      * @return WebDriverMouse
      */
     public function mouseUp(WebDriverCoordinates $where);

--- a/lib/WebDriverSearchContext.php
+++ b/lib/WebDriverSearchContext.php
@@ -10,7 +10,6 @@ interface WebDriverSearchContext
     /**
      * Find the first WebDriverElement within this element using the given mechanism.
      *
-     * @param WebDriverBy $locator
      * @return WebDriverElement NoSuchElementException is thrown in HttpCommandExecutor if no element is found.
      * @see WebDriverBy
      */
@@ -19,7 +18,6 @@ interface WebDriverSearchContext
     /**
      * Find all WebDriverElements within this element using the given mechanism.
      *
-     * @param WebDriverBy $locator
      * @return WebDriverElement[] A list of all WebDriverElements, or an empty array if nothing matches
      * @see WebDriverBy
      */

--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -223,7 +223,6 @@ class WebDriverSelect implements WebDriverSelectInterface
 
     /**
      * Mark option selected
-     * @param WebDriverElement $option
      */
     protected function selectOption(WebDriverElement $option)
     {
@@ -234,7 +233,6 @@ class WebDriverSelect implements WebDriverSelectInterface
 
     /**
      * Mark option not selected
-     * @param WebDriverElement $option
      */
     protected function deselectOption(WebDriverElement $option)
     {

--- a/lib/WebDriverUpAction.php
+++ b/lib/WebDriverUpAction.php
@@ -11,7 +11,6 @@ class WebDriverUpAction extends WebDriverTouchAction implements WebDriverAction
     private $y;
 
     /**
-     * @param WebDriverTouchScreen $touch_screen
      * @param int $x
      * @param int $y
      */

--- a/lib/WebDriverWindow.php
+++ b/lib/WebDriverWindow.php
@@ -121,7 +121,6 @@ class WebDriverWindow
      * Set the size of the current window. This will change the outer window
      * dimension, not just the view port.
      *
-     * @param WebDriverDimension $size
      * @return WebDriverWindow The instance.
      */
     public function setSize(WebDriverDimension $size)
@@ -140,7 +139,6 @@ class WebDriverWindow
      * Set the position of the current window. This is relative to the upper left
      * corner of the screen.
      *
-     * @param WebDriverPoint $position
      * @return WebDriverWindow The instance.
      */
     public function setPosition(WebDriverPoint $position)

--- a/tests/functional/Chrome/ChromeDevToolsDriverTest.php
+++ b/tests/functional/Chrome/ChromeDevToolsDriverTest.php
@@ -22,7 +22,7 @@ class ChromeDevToolsDriverTest extends WebDriverTestCase
         }
     }
 
-    public function testShouldExecuteDevToolsCommandWithoutParameters()
+    public function testShouldExecuteDevToolsCommandWithoutParameters(): void
     {
         $devTools = new ChromeDevToolsDriver($this->driver);
 
@@ -31,7 +31,7 @@ class ChromeDevToolsDriverTest extends WebDriverTestCase
         $this->assertSame([], $result);
     }
 
-    public function testShouldExecuteDevToolsCommandWithParameters()
+    public function testShouldExecuteDevToolsCommandWithParameters(): void
     {
         $devTools = new ChromeDevToolsDriver($this->driver);
 

--- a/tests/functional/Chrome/ChromeDriverServiceTest.php
+++ b/tests/functional/Chrome/ChromeDriverServiceTest.php
@@ -30,7 +30,7 @@ class ChromeDriverServiceTest extends TestCase
         }
     }
 
-    public function testShouldStartAndStopServiceCreatedUsingShortcutConstructor()
+    public function testShouldStartAndStopServiceCreatedUsingShortcutConstructor(): void
     {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=' . getenv('CHROMEDRIVER_PATH'));
@@ -50,7 +50,7 @@ class ChromeDriverServiceTest extends TestCase
         $this->assertInstanceOf(ChromeDriverService::class, $this->driverService->stop());
     }
 
-    public function testShouldStartAndStopServiceCreatedUsingDefaultConstructor()
+    public function testShouldStartAndStopServiceCreatedUsingDefaultConstructor(): void
     {
         $this->driverService = new ChromeDriverService(getenv('CHROMEDRIVER_PATH'), 9515, ['--port=9515']);
 
@@ -63,7 +63,7 @@ class ChromeDriverServiceTest extends TestCase
         $this->assertFalse($this->driverService->isRunning());
     }
 
-    public function testShouldThrowExceptionIfExecutableIsNotExecutable()
+    public function testShouldThrowExceptionIfExecutableIsNotExecutable(): void
     {
         putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=' . __FILE__);
 
@@ -72,7 +72,7 @@ class ChromeDriverServiceTest extends TestCase
         ChromeDriverService::createDefaultService();
     }
 
-    public function testShouldUseDefaultExecutableIfNoneProvided()
+    public function testShouldUseDefaultExecutableIfNoneProvided(): void
     {
         // Put path where ChromeDriver binary is actually located to system PATH, to make sure we can locate it
         putenv('PATH=' . getenv('PATH') . ':' . dirname(getenv('CHROMEDRIVER_PATH')));

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -37,7 +37,7 @@ class ChromeDriverTest extends TestCase
      * @dataProvider provideDialect
      * @param bool $isW3cDialect
      */
-    public function testShouldStartChromeDriver($isW3cDialect)
+    public function testShouldStartChromeDriver($isW3cDialect): void
     {
         $this->startChromeDriver($isW3cDialect);
         $this->assertInstanceOf(ChromeDriver::class, $this->driver);
@@ -55,7 +55,7 @@ class ChromeDriverTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideDialect()
+    public function provideDialect(): array
     {
         return [
             'w3c' => [true],
@@ -63,7 +63,7 @@ class ChromeDriverTest extends TestCase
         ];
     }
 
-    public function testShouldInstantiateDevTools()
+    public function testShouldInstantiateDevTools(): void
     {
         $this->startChromeDriver();
 
@@ -81,7 +81,7 @@ class ChromeDriverTest extends TestCase
         $this->assertSame(['result' => ['type' => 'string', 'value' => 'http://localhost:8000/']], $cdpResult);
     }
 
-    private function startChromeDriver($w3cDialect = true)
+    private function startChromeDriver($w3cDialect = true): void
     {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(ChromeDriverService::CHROME_DRIVER_EXECUTABLE . '=' . getenv('CHROMEDRIVER_PATH'));

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -37,7 +37,7 @@ class ChromeDriverTest extends TestCase
      * @dataProvider provideDialect
      * @param bool $isW3cDialect
      */
-    public function testShouldStartChromeDriver($isW3cDialect): void
+    public function testShouldStartChromeDriver(bool $isW3cDialect): void
     {
         $this->startChromeDriver($isW3cDialect);
         $this->assertInstanceOf(ChromeDriver::class, $this->driver);

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -35,7 +35,6 @@ class ChromeDriverTest extends TestCase
 
     /**
      * @dataProvider provideDialect
-     * @param bool $isW3cDialect
      */
     public function testShouldStartChromeDriver(bool $isW3cDialect): void
     {

--- a/tests/functional/FileUploadTest.php
+++ b/tests/functional/FileUploadTest.php
@@ -16,7 +16,7 @@ class FileUploadTest extends WebDriverTestCase
      * @group exclude-saucelabs
      * W3C protocol does not support remote file upload: https://github.com/w3c/webdriver/issues/1355
      */
-    public function testShouldUploadAFile()
+    public function testShouldUploadAFile(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::UPLOAD));
 
@@ -43,7 +43,7 @@ class FileUploadTest extends WebDriverTestCase
         $this->assertSame('10', $uploadedFileSize);
     }
 
-    private function getTestFilePath()
+    private function getTestFilePath(): string
     {
         return __DIR__ . '/Fixtures/FileUploadTestFile.txt';
     }

--- a/tests/functional/Firefox/FirefoxDriverServiceTest.php
+++ b/tests/functional/Firefox/FirefoxDriverServiceTest.php
@@ -32,7 +32,7 @@ class FirefoxDriverServiceTest extends TestCase
         }
     }
 
-    public function testShouldStartAndStopServiceCreatedUsingShortcutConstructor()
+    public function testShouldStartAndStopServiceCreatedUsingShortcutConstructor(): void
     {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(FirefoxDriverService::WEBDRIVER_FIREFOX_DRIVER . '=' . getenv('GECKODRIVER_PATH'));
@@ -52,7 +52,7 @@ class FirefoxDriverServiceTest extends TestCase
         $this->assertInstanceOf(FirefoxDriverService::class, $this->driverService->stop());
     }
 
-    public function testShouldStartAndStopServiceCreatedUsingDefaultConstructor()
+    public function testShouldStartAndStopServiceCreatedUsingDefaultConstructor(): void
     {
         $this->driverService = new FirefoxDriverService(getenv('GECKODRIVER_PATH'), 9515, ['-p=9515']);
 
@@ -65,7 +65,7 @@ class FirefoxDriverServiceTest extends TestCase
         $this->assertFalse($this->driverService->isRunning());
     }
 
-    public function testShouldUseDefaultExecutableIfNoneProvided()
+    public function testShouldUseDefaultExecutableIfNoneProvided(): void
     {
         // Put path where geckodriver binary is actually located to system PATH, to make sure we can locate it
         putenv('PATH=' . getenv('PATH') . ':' . dirname(getenv('GECKODRIVER_PATH')));

--- a/tests/functional/Firefox/FirefoxDriverTest.php
+++ b/tests/functional/Firefox/FirefoxDriverTest.php
@@ -37,7 +37,7 @@ class FirefoxDriverTest extends TestCase
         }
     }
 
-    public function testShouldStartFirefoxDriver()
+    public function testShouldStartFirefoxDriver(): void
     {
         $this->startFirefoxDriver();
         $this->assertInstanceOf(FirefoxDriver::class, $this->driver);
@@ -53,7 +53,7 @@ class FirefoxDriverTest extends TestCase
         $this->assertSame('http://localhost:8000/', $this->driver->getCurrentURL());
     }
 
-    public function testShouldSetPreferenceWithFirefoxOptions()
+    public function testShouldSetPreferenceWithFirefoxOptions(): void
     {
         $firefoxOptions = new FirefoxOptions();
         $firefoxOptions->setPreference('javascript.enabled', false);
@@ -69,7 +69,7 @@ class FirefoxDriverTest extends TestCase
         );
     }
 
-    private function startFirefoxDriver(FirefoxOptions $firefoxOptions = null)
+    private function startFirefoxDriver(FirefoxOptions $firefoxOptions = null): void
     {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(FirefoxDriverService::WEBDRIVER_FIREFOX_DRIVER . '=' . getenv('GECKODRIVER_PATH'));

--- a/tests/functional/Firefox/FirefoxProfileTest.php
+++ b/tests/functional/Firefox/FirefoxProfileTest.php
@@ -64,7 +64,7 @@ class FirefoxProfileTest extends TestCase
         }
     }
 
-    public function testShouldStartDriverWithEmptyProfile()
+    public function testShouldStartDriverWithEmptyProfile(): void
     {
         $firefoxProfile = new FirefoxProfile();
         $this->startFirefoxDriverWithProfile($firefoxProfile);
@@ -77,7 +77,7 @@ class FirefoxProfileTest extends TestCase
         );
     }
 
-    public function testShouldInstallExtension()
+    public function testShouldInstallExtension(): void
     {
         $firefoxProfile = new FirefoxProfile();
         $firefoxProfile->addExtension($this->firefoxTestExtensionFilename);
@@ -95,7 +95,7 @@ class FirefoxProfileTest extends TestCase
         $this->assertEquals('This element was added by browser extension', $element->getText());
     }
 
-    public function testShouldUseProfilePreferences()
+    public function testShouldUseProfilePreferences(): void
     {
         $firefoxProfile = new FirefoxProfile();
 
@@ -115,7 +115,7 @@ class FirefoxProfileTest extends TestCase
         );
     }
 
-    protected function getTestPageUrl($path)
+    protected function getTestPageUrl($path): string
     {
         $host = 'http://localhost:8000';
         if ($alternateHost = getenv('FIXTURES_HOST')) {
@@ -125,7 +125,7 @@ class FirefoxProfileTest extends TestCase
         return $host . '/' . $path;
     }
 
-    private function startFirefoxDriverWithProfile(FirefoxProfile $firefoxProfile)
+    private function startFirefoxDriverWithProfile(FirefoxProfile $firefoxProfile): void
     {
         // The createDefaultService() method expect path to the executable to be present in the environment variable
         putenv(FirefoxDriverService::WEBDRIVER_FIREFOX_DRIVER . '=' . getenv('GECKODRIVER_PATH'));

--- a/tests/functional/RemoteKeyboardTest.php
+++ b/tests/functional/RemoteKeyboardTest.php
@@ -19,7 +19,7 @@ class RemoteKeyboardTest extends WebDriverTestCase
      * @group exclude-safari
      * https://feedbackassistant.apple.com/feedback/9051272
      */
-    public function testShouldPressSendAndReleaseKeys()
+    public function testShouldPressSendAndReleaseKeys(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::EVENTS));
 

--- a/tests/functional/RemoteTargetLocatorTest.php
+++ b/tests/functional/RemoteTargetLocatorTest.php
@@ -10,7 +10,7 @@ use Facebook\WebDriver\Remote\RemoteWebElement;
  */
 class RemoteTargetLocatorTest extends WebDriverTestCase
 {
-    public function testShouldSwitchToWindow()
+    public function testShouldSwitchToWindow(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::OPEN_NEW_WINDOW));
         $originalWindowHandle = $this->driver->getWindowHandle();
@@ -48,7 +48,7 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
         $this->assertNotSame($originalWindowHandle, $this->driver->getWindowHandle());
     }
 
-    public function testActiveElement()
+    public function testActiveElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -62,7 +62,7 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
         $this->assertSame('test_name', $activeElement->getAttribute('name'));
     }
 
-    public function testShouldSwitchToFrameByItsId()
+    public function testShouldSwitchToFrameByItsId(): void
     {
         $parentPage = 'This is the host page which contains an iFrame';
         $firstChildFrame = 'This is the content of the iFrame';
@@ -91,7 +91,7 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
         $this->assertStringContainsString($parentPage, $this->driver->getPageSource());
     }
 
-    public function testShouldSwitchToParentFrame()
+    public function testShouldSwitchToParentFrame(): void
     {
         $parentPage = 'This is the host page which contains an iFrame';
         $firstChildFrame = 'This is the content of the iFrame';
@@ -107,7 +107,7 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
         $this->assertStringContainsString($parentPage, $this->driver->getPageSource());
     }
 
-    public function testShouldSwitchToFrameByElement()
+    public function testShouldSwitchToFrameByElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::PAGE_WITH_FRAME));
 
@@ -120,7 +120,7 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldCreateNewWindow()
+    public function testShouldCreateNewWindow(): void
     {
         self::skipForJsonWireProtocol('Create new window is not supported in JsonWire protocol');
 
@@ -153,7 +153,7 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldNotAcceptStringAsFrameIdInW3cMode()
+    public function testShouldNotAcceptStringAsFrameIdInW3cMode(): void
     {
         self::skipForJsonWireProtocol();
 
@@ -170,7 +170,7 @@ class RemoteTargetLocatorTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldAcceptStringAsFrameIdInJsonWireMode()
+    public function testShouldAcceptStringAsFrameIdInJsonWireMode(): void
     {
         self::skipForW3cProtocol();
 

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -15,7 +15,7 @@ use Facebook\WebDriver\Remote\WebDriverBrowserType;
  */
 class RemoteWebDriverCreateTest extends WebDriverTestCase
 {
-    public function testShouldStartBrowserAndCreateInstanceOfRemoteWebDriver()
+    public function testShouldStartBrowserAndCreateInstanceOfRemoteWebDriver(): void
     {
         $this->driver = RemoteWebDriver::create(
             $this->serverUrl,
@@ -51,7 +51,7 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
         $this->assertNotEmpty($returnedCapabilities->getVersion());
     }
 
-    public function testShouldAcceptCapabilitiesAsAnArray()
+    public function testShouldAcceptCapabilitiesAsAnArray(): void
     {
         // Method has a side-effect of converting whole content of desiredCapabilities to an array
         $this->desiredCapabilities->toArray();
@@ -66,7 +66,7 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
         $this->assertNotNull($this->driver->getCapabilities());
     }
 
-    public function testShouldCreateWebDriverWithRequiredCapabilities()
+    public function testShouldCreateWebDriverWithRequiredCapabilities(): void
     {
         $requiredCapabilities = new DesiredCapabilities();
 
@@ -89,7 +89,7 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
      * However the the browser driver must be able to create non-headless instance (eg. inside xvfb).
      * @group exclude-saucelabs
      */
-    public function testShouldCreateWebDriverWithoutCapabilities()
+    public function testShouldCreateWebDriverWithoutCapabilities(): void
     {
         if (getenv('GECKODRIVER') !== '1' && empty(getenv('CHROMEDRIVER_PATH'))) {
             $this->markTestSkipped('This test makes sense only when run directly via specific browser driver');
@@ -101,7 +101,7 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
         $this->assertNotEmpty($this->driver->getSessionID());
     }
 
-    public function testShouldCreateInstanceFromExistingSessionId()
+    public function testShouldCreateInstanceFromExistingSessionId(): void
     {
         // Create driver instance and load page "index.html"
         $originalDriver = RemoteWebDriver::create(
@@ -156,7 +156,7 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
         $this->assertNotEmpty($this->driver->findElement(WebDriverBy::id('id_test'))->getText());
     }
 
-    public function testShouldRequireCapabilitiesToBeSetToReuseExistingSession()
+    public function testShouldRequireCapabilitiesToBeSetToReuseExistingSession(): void
     {
         $this->expectException(UnexpectedResponseException::class);
         $this->expectExceptionMessage(
@@ -172,7 +172,7 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
         );
     }
 
-    protected function createWebDriver()
+    protected function createWebDriver(): void
     {
     }
 }

--- a/tests/functional/RemoteWebDriverFindElementTest.php
+++ b/tests/functional/RemoteWebDriverFindElementTest.php
@@ -11,7 +11,7 @@ use Facebook\WebDriver\Remote\RemoteWebElement;
  */
 class RemoteWebDriverFindElementTest extends WebDriverTestCase
 {
-    public function testShouldThrowExceptionIfElementCannotBeFound()
+    public function testShouldThrowExceptionIfElementCannotBeFound(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -19,7 +19,7 @@ class RemoteWebDriverFindElementTest extends WebDriverTestCase
         $this->driver->findElement(WebDriverBy::id('not_existing'));
     }
 
-    public function testShouldFindElementIfExistsOnAPage()
+    public function testShouldFindElementIfExistsOnAPage(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -28,7 +28,7 @@ class RemoteWebDriverFindElementTest extends WebDriverTestCase
         $this->assertInstanceOf(RemoteWebElement::class, $element);
     }
 
-    public function testShouldReturnEmptyArrayIfElementsCannotBeFound()
+    public function testShouldReturnEmptyArrayIfElementsCannotBeFound(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -38,7 +38,7 @@ class RemoteWebDriverFindElementTest extends WebDriverTestCase
         $this->assertCount(0, $elements);
     }
 
-    public function testShouldFindMultipleElements()
+    public function testShouldFindMultipleElements(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -52,7 +52,7 @@ class RemoteWebDriverFindElementTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testEscapeCssSelector()
+    public function testEscapeCssSelector(): void
     {
         self::skipForJsonWireProtocol(
             'CSS selectors containing special characters are not supported by the legacy protocol'

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -13,7 +13,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
     /**
      * @covers ::getTitle
      */
-    public function testShouldGetPageTitle()
+    public function testShouldGetPageTitle(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -27,7 +27,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::get
      * @covers ::getCurrentURL
      */
-    public function testShouldGetCurrentUrl()
+    public function testShouldGetCurrentUrl(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -37,7 +37,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
     /**
      * @covers ::getPageSource
      */
-    public function testShouldGetPageSource()
+    public function testShouldGetPageSource(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -50,7 +50,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::getSessionID
      * @covers ::isW3cCompliant
      */
-    public function testShouldGetSessionId()
+    public function testShouldGetSessionId(): void
     {
         // This tests is intentionally included in another test, to not slow down build.
         // @TODO Remove following in 2.0
@@ -70,7 +70,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @group exclude-saucelabs
      * @covers ::getAllSessions
      */
-    public function testShouldGetAllSessions()
+    public function testShouldGetAllSessions(): void
     {
         self::skipForW3cProtocol();
 
@@ -89,7 +89,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::getCommandExecutor
      * @covers ::quit
      */
-    public function testShouldQuitAndUnsetExecutor()
+    public function testShouldQuitAndUnsetExecutor(): void
     {
         self::skipForW3cProtocol();
 
@@ -116,7 +116,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::getWindowHandle
      * @covers ::getWindowHandles
      */
-    public function testShouldGetWindowHandles()
+    public function testShouldGetWindowHandles(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::OPEN_NEW_WINDOW));
 
@@ -140,7 +140,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
     /**
      * @covers ::close
      */
-    public function testShouldCloseWindow()
+    public function testShouldCloseWindow(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::OPEN_NEW_WINDOW));
         $this->driver->findElement(WebDriverBy::cssSelector('a'))->click();
@@ -158,7 +158,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::executeScript
      * @group exclude-saucelabs
      */
-    public function testShouldExecuteScriptAndDoNotBlockExecution()
+    public function testShouldExecuteScriptAndDoNotBlockExecution(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -188,7 +188,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::executeAsyncScript
      * @covers \Facebook\WebDriver\WebDriverTimeouts::setScriptTimeout
      */
-    public function testShouldExecuteAsyncScriptAndWaitUntilItIsFinished()
+    public function testShouldExecuteAsyncScriptAndWaitUntilItIsFinished(): void
     {
         $this->driver->manage()->timeouts()->setScriptTimeout(1);
 
@@ -228,7 +228,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::prepareScriptArguments
      * @group exclude-saucelabs
      */
-    public function testShouldExecuteScriptWithParamsAndReturnValue()
+    public function testShouldExecuteScriptWithParamsAndReturnValue(): void
     {
         $this->driver->manage()->timeouts()->setScriptTimeout(1);
 
@@ -252,7 +252,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @covers ::takeScreenshot
      * @covers \Facebook\WebDriver\Support\ScreenshotHelper
      */
-    public function testShouldTakeScreenshot()
+    public function testShouldTakeScreenshot(): void
     {
         if (!extension_loaded('gd')) {
             $this->markTestSkipped('GD extension must be enabled');
@@ -274,7 +274,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @group exclude-safari
      *        Safari is returning different color profile and it does not have way to configure "force-color-profile"
      */
-    public function testShouldSaveScreenshotToFile()
+    public function testShouldSaveScreenshotToFile(): void
     {
         if (!extension_loaded('gd')) {
             $this->markTestSkipped('GD extension must be enabled');
@@ -314,7 +314,7 @@ class RemoteWebDriverTest extends WebDriverTestCase
      * @group exclude-saucelabs
      * Status endpoint is not supported on Sauce Labs
      */
-    public function testShouldGetRemoteEndStatus()
+    public function testShouldGetRemoteEndStatus(): void
     {
         $status = $this->driver->getStatus();
 

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -19,7 +19,7 @@ class RemoteWebElementTest extends WebDriverTestCase
      * @group exclude-safari
      *      Safari does not normalize white-spaces
      */
-    public function testShouldGetText()
+    public function testShouldGetText(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
         $elementWithSimpleText = $this->driver->findElement(WebDriverBy::id('text-simple'));
@@ -33,7 +33,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::getAttribute
      */
-    public function testShouldGetAttributeValue()
+    public function testShouldGetAttributeValue(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -48,7 +48,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::getDomProperty
      */
-    public function testShouldGetDomPropertyValue()
+    public function testShouldGetDomPropertyValue(): void
     {
         self::skipForJsonWireProtocol();
 
@@ -70,7 +70,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::getLocation
      */
-    public function testShouldGetLocation()
+    public function testShouldGetLocation(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -85,7 +85,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::getLocationOnScreenOnceScrolledIntoView
      */
-    public function testShouldGetLocationOnScreenOnceScrolledIntoView()
+    public function testShouldGetLocationOnScreenOnceScrolledIntoView(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -110,7 +110,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::getSize
      */
-    public function testShouldGetSize()
+    public function testShouldGetSize(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -125,7 +125,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::getCSSValue
      */
-    public function testShouldGetCssValue()
+    public function testShouldGetCssValue(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -145,7 +145,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::getTagName
      */
-    public function testShouldGetTagName()
+    public function testShouldGetTagName(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -157,7 +157,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::click
      */
-    public function testShouldClick()
+    public function testShouldClick(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
         $linkElement = $this->driver->findElement(WebDriverBy::id('a-form'));
@@ -180,7 +180,7 @@ class RemoteWebElementTest extends WebDriverTestCase
      * @group exclude-chrome
      * @group exclude-edge
      */
-    public function testGeckoDriverShouldClickOnBlockLevelElement()
+    public function testGeckoDriverShouldClickOnBlockLevelElement(): void
     {
         self::skipForUnmatchedBrowsers(['firefox']);
 
@@ -209,7 +209,7 @@ class RemoteWebElementTest extends WebDriverTestCase
      * @group exclude-chrome
      * @group exclude-edge
      */
-    public function testGeckoDriverShouldClickNotInteractable()
+    public function testGeckoDriverShouldClickNotInteractable(): void
     {
         self::skipForUnmatchedBrowsers(['firefox']);
 
@@ -237,7 +237,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::clear
      */
-    public function testShouldClearFormElementText()
+    public function testShouldClearFormElementText(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
 
@@ -256,7 +256,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::sendKeys
      */
-    public function testShouldSendKeysToFormElement()
+    public function testShouldSendKeysToFormElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
 
@@ -294,7 +294,7 @@ class RemoteWebElementTest extends WebDriverTestCase
      * @covers \Facebook\WebDriver\Remote\RemoteWebDriver::execute
      * @covers \Facebook\WebDriver\Support\IsElementDisplayedAtom
      */
-    public function testShouldDetectElementDisplayedness()
+    public function testShouldDetectElementDisplayedness(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -310,7 +310,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::isEnabled
      */
-    public function testShouldDetectEnabledInputs()
+    public function testShouldDetectEnabledInputs(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
 
@@ -324,7 +324,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::isSelected
      */
-    public function testShouldSelectedInputsOrOptions()
+    public function testShouldSelectedInputsOrOptions(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
 
@@ -352,7 +352,7 @@ class RemoteWebElementTest extends WebDriverTestCase
      * @covers ::submit
      * @group exclude-edge
      */
-    public function testShouldSubmitFormBySubmitEventOnForm()
+    public function testShouldSubmitFormBySubmitEventOnForm(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
 
@@ -370,7 +370,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::submit
      */
-    public function testShouldSubmitFormBySubmitEventOnFormInputElement()
+    public function testShouldSubmitFormBySubmitEventOnFormInputElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
 
@@ -388,7 +388,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::click
      */
-    public function testShouldSubmitFormByClickOnSubmitInput()
+    public function testShouldSubmitFormByClickOnSubmitInput(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
 
@@ -406,7 +406,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::equals
      */
-    public function testShouldCompareEqualsElement()
+    public function testShouldCompareEqualsElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
@@ -425,7 +425,7 @@ class RemoteWebElementTest extends WebDriverTestCase
     /**
      * @covers ::findElement
      */
-    public function testShouldThrowExceptionIfChildElementCannotBeFound()
+    public function testShouldThrowExceptionIfChildElementCannotBeFound(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
         $element = $this->driver->findElement(WebDriverBy::cssSelector('ul.list'));
@@ -434,7 +434,7 @@ class RemoteWebElementTest extends WebDriverTestCase
         $element->findElement(WebDriverBy::id('not_existing'));
     }
 
-    public function testShouldFindChildElementIfExistsOnAPage()
+    public function testShouldFindChildElementIfExistsOnAPage(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
         $element = $this->driver->findElement(WebDriverBy::cssSelector('ul.list'));
@@ -446,7 +446,7 @@ class RemoteWebElementTest extends WebDriverTestCase
         $this->assertSame('First', $childElement->getText());
     }
 
-    public function testShouldReturnEmptyArrayIfChildElementsCannotBeFound()
+    public function testShouldReturnEmptyArrayIfChildElementsCannotBeFound(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
         $element = $this->driver->findElement(WebDriverBy::cssSelector('ul.list'));
@@ -457,7 +457,7 @@ class RemoteWebElementTest extends WebDriverTestCase
         $this->assertCount(0, $childElements);
     }
 
-    public function testShouldFindMultipleChildElements()
+    public function testShouldFindMultipleChildElements(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
         $element = $this->driver->findElement(WebDriverBy::cssSelector('ul.list'));
@@ -476,7 +476,7 @@ class RemoteWebElementTest extends WebDriverTestCase
      * @covers \Facebook\WebDriver\Support\ScreenshotHelper
      * @group exclude-saucelabs
      */
-    public function testShouldTakeAndSaveElementScreenshot()
+    public function testShouldTakeAndSaveElementScreenshot(): void
     {
         self::skipForJsonWireProtocol('Take element screenshot is only part of W3C protocol');
 

--- a/tests/functional/ReportSauceLabsStatusListener.php
+++ b/tests/functional/ReportSauceLabsStatusListener.php
@@ -82,7 +82,7 @@ class ReportSauceLabsStatusListener implements TestListener
      * @param int $testStatus
      * @return bool
      */
-    private function testWasSkippedOrIncomplete($testStatus)
+    private function testWasSkippedOrIncomplete($testStatus): bool
     {
         if ($testStatus === \PHPUnit\Runner\BaseTestRunner::STATUS_SKIPPED
             || $testStatus === \PHPUnit\Runner\BaseTestRunner::STATUS_INCOMPLETE) {
@@ -96,7 +96,7 @@ class ReportSauceLabsStatusListener implements TestListener
      * @param string $url
      * @param array $data
      */
-    private function submitToSauceLabs($url, array $data)
+    private function submitToSauceLabs($url, array $data): void
     {
         $curl = curl_init($url);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');

--- a/tests/functional/ReportSauceLabsStatusListener.php
+++ b/tests/functional/ReportSauceLabsStatusListener.php
@@ -78,10 +78,6 @@ class ReportSauceLabsStatusListener implements TestListener
     {
     }
 
-    /**
-     * @param int $testStatus
-     * @return bool
-     */
     private function testWasSkippedOrIncomplete(int $testStatus): bool
     {
         if ($testStatus === \PHPUnit\Runner\BaseTestRunner::STATUS_SKIPPED
@@ -92,10 +88,6 @@ class ReportSauceLabsStatusListener implements TestListener
         return false;
     }
 
-    /**
-     * @param string $url
-     * @param array $data
-     */
     private function submitToSauceLabs(string $url, array $data): void
     {
         $curl = curl_init($url);

--- a/tests/functional/ReportSauceLabsStatusListener.php
+++ b/tests/functional/ReportSauceLabsStatusListener.php
@@ -82,7 +82,7 @@ class ReportSauceLabsStatusListener implements TestListener
      * @param int $testStatus
      * @return bool
      */
-    private function testWasSkippedOrIncomplete($testStatus): bool
+    private function testWasSkippedOrIncomplete(int $testStatus): bool
     {
         if ($testStatus === \PHPUnit\Runner\BaseTestRunner::STATUS_SKIPPED
             || $testStatus === \PHPUnit\Runner\BaseTestRunner::STATUS_INCOMPLETE) {
@@ -96,7 +96,7 @@ class ReportSauceLabsStatusListener implements TestListener
      * @param string $url
      * @param array $data
      */
-    private function submitToSauceLabs($url, array $data): void
+    private function submitToSauceLabs(string $url, array $data): void
     {
         $curl = curl_init($url);
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');

--- a/tests/functional/RetrieveEventsTrait.php
+++ b/tests/functional/RetrieveEventsTrait.php
@@ -9,17 +9,11 @@ trait RetrieveEventsTrait
     /** @var RemoteWebDriver $driver */
     public $driver;
 
-    /**
-     * @return array
-     */
     private function retrieveLoggedKeyboardEvents(): array
     {
         return $this->retrieveLoggerEvents(WebDriverBy::id('keyboardEventsLog'));
     }
 
-    /**
-     * @return array
-     */
     private function retrieveLoggedMouseEvents(): array
     {
         return $this->retrieveLoggerEvents(WebDriverBy::id('mouseEventsLog'));

--- a/tests/functional/RetrieveEventsTrait.php
+++ b/tests/functional/RetrieveEventsTrait.php
@@ -12,7 +12,7 @@ trait RetrieveEventsTrait
     /**
      * @return array
      */
-    private function retrieveLoggedKeyboardEvents()
+    private function retrieveLoggedKeyboardEvents(): array
     {
         return $this->retrieveLoggerEvents(WebDriverBy::id('keyboardEventsLog'));
     }
@@ -20,7 +20,7 @@ trait RetrieveEventsTrait
     /**
      * @return array
      */
-    private function retrieveLoggedMouseEvents()
+    private function retrieveLoggedMouseEvents(): array
     {
         return $this->retrieveLoggerEvents(WebDriverBy::id('mouseEventsLog'));
     }

--- a/tests/functional/ShadowDomTest.php
+++ b/tests/functional/ShadowDomTest.php
@@ -20,7 +20,7 @@ class ShadowDomTest extends WebDriverTestCase
         parent::setUp();
     }
 
-    public function testShouldGetShadowRoot()
+    public function testShouldGetShadowRoot(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
 
@@ -31,7 +31,7 @@ class ShadowDomTest extends WebDriverTestCase
         $this->assertInstanceOf(ShadowRoot::class, $shadowRoot);
     }
 
-    public function testShouldThrowExceptionWhenGettingShadowRootWithElementNotHavingShadowRoot()
+    public function testShouldThrowExceptionWhenGettingShadowRootWithElementNotHavingShadowRoot(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
 
@@ -46,7 +46,7 @@ class ShadowDomTest extends WebDriverTestCase
      *        https://bugzilla.mozilla.org/show_bug.cgi?id=1700097
      *        Finding elements in shadow DOM is not implemented in Geckodriver
      */
-    public function testShouldFindElementUnderShadowRoot()
+    public function testShouldFindElementUnderShadowRoot(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
 
@@ -66,7 +66,7 @@ class ShadowDomTest extends WebDriverTestCase
      *        https://bugzilla.mozilla.org/show_bug.cgi?id=1700097
      *        Finding elements in shadow DOM is not implemented in Geckodriver
      */
-    public function testShouldReferenceTheSameShadowRootAsFromExecuteScript()
+    public function testShouldReferenceTheSameShadowRootAsFromExecuteScript(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
 

--- a/tests/functional/WebDriverActionsTest.php
+++ b/tests/functional/WebDriverActionsTest.php
@@ -25,7 +25,7 @@ class WebDriverActionsTest extends WebDriverTestCase
 {
     use RetrieveEventsTrait;
 
-    public function testShouldClickOnElement()
+    public function testShouldClickOnElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::EVENTS));
 
@@ -47,7 +47,7 @@ class WebDriverActionsTest extends WebDriverTestCase
         $this->assertSame($logs, $loggedEvents);
     }
 
-    public function testShouldClickAndHoldOnElementAndRelease()
+    public function testShouldClickAndHoldOnElementAndRelease(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::EVENTS));
 
@@ -72,7 +72,7 @@ class WebDriverActionsTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldContextClickOnElement()
+    public function testShouldContextClickOnElement(): void
     {
         if ($this->desiredCapabilities->getBrowserName() === WebDriverBrowserType::MICROSOFT_EDGE) {
             $this->markTestSkipped('Getting stuck in EdgeDriver');
@@ -97,7 +97,7 @@ class WebDriverActionsTest extends WebDriverTestCase
      * @group exclude-safari
      *        https://github.com/webdriverio/webdriverio/issues/231
      */
-    public function testShouldDoubleClickOnElement()
+    public function testShouldDoubleClickOnElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::EVENTS));
 
@@ -113,7 +113,7 @@ class WebDriverActionsTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldSendKeysUpAndDown()
+    public function testShouldSendKeysUpAndDown(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::EVENTS));
 
@@ -142,7 +142,7 @@ class WebDriverActionsTest extends WebDriverTestCase
      * @group exclude-safari
      *        https://developer.apple.com/forums/thread/662677
      */
-    public function testShouldMoveToElement()
+    public function testShouldMoveToElement(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::SORTABLE));
 
@@ -165,7 +165,7 @@ class WebDriverActionsTest extends WebDriverTestCase
      * @group exclude-safari
      *        https://developer.apple.com/forums/thread/662677
      */
-    public function testShouldMoveByOffset()
+    public function testShouldMoveByOffset(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::SORTABLE));
 
@@ -188,7 +188,7 @@ class WebDriverActionsTest extends WebDriverTestCase
      *        https://developer.apple.com/forums/thread/662677
      * @group exclude-saucelabs
      */
-    public function testShouldDragAndDrop()
+    public function testShouldDragAndDrop(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::SORTABLE));
 
@@ -221,7 +221,7 @@ class WebDriverActionsTest extends WebDriverTestCase
      *        https://developer.apple.com/forums/thread/662677
      *        it does not work even with Python Selenium, looks like Safaridriver does not implements Interaction API
      */
-    public function testShouldDragAndDropBy()
+    public function testShouldDragAndDropBy(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::SORTABLE));
 
@@ -253,7 +253,7 @@ class WebDriverActionsTest extends WebDriverTestCase
     /**
      * @return array
      */
-    private function retrieveListContent()
+    private function retrieveListContent(): array
     {
         return [
             $this->retrieveLoggerEvents(WebDriverBy::cssSelector('#sortable1')),

--- a/tests/functional/WebDriverActionsTest.php
+++ b/tests/functional/WebDriverActionsTest.php
@@ -250,9 +250,6 @@ class WebDriverActionsTest extends WebDriverTestCase
         );
     }
 
-    /**
-     * @return array
-     */
     private function retrieveListContent(): array
     {
         return [

--- a/tests/functional/WebDriverAlertTest.php
+++ b/tests/functional/WebDriverAlertTest.php
@@ -18,7 +18,7 @@ class WebDriverAlertTest extends WebDriverTestCase
         $this->driver->get($this->getTestPageUrl(TestPage::ALERT));
     }
 
-    public function testShouldAcceptAlert()
+    public function testShouldAcceptAlert(): void
     {
         // Open alert (it is delayed for 1 second, to make sure following wait for alertIsPresent works properly)
         $this->driver->findElement(WebDriverBy::id('open-alert-delayed'))->click();
@@ -39,7 +39,7 @@ class WebDriverAlertTest extends WebDriverTestCase
         $this->driver->switchTo()->alert()->accept();
     }
 
-    public function testShouldAcceptAndDismissConfirmation()
+    public function testShouldAcceptAndDismissConfirmation(): void
     {
         // Open confirmation
         $this->driver->findElement(WebDriverBy::id('open-confirm'))->click();
@@ -61,7 +61,7 @@ class WebDriverAlertTest extends WebDriverTestCase
         $this->assertSame('dismissed', $this->getResultText());
     }
 
-    public function testShouldSubmitPromptText()
+    public function testShouldSubmitPromptText(): void
     {
         // Open confirmation
         $this->driver->findElement(WebDriverBy::id('open-prompt'))->click();
@@ -77,7 +77,7 @@ class WebDriverAlertTest extends WebDriverTestCase
         $this->assertSame('Text entered to prompt', $this->getResultText());
     }
 
-    private function getResultText()
+    private function getResultText(): string
     {
         return $this->driver
             ->findElement(WebDriverBy::id('result'))

--- a/tests/functional/WebDriverByTest.php
+++ b/tests/functional/WebDriverByTest.php
@@ -12,10 +12,6 @@ class WebDriverByTest extends WebDriverTestCase
 {
     /**
      * @dataProvider provideTextElements
-     * @param string $webDriverByLocatorMethod
-     * @param string $webDriverByLocatorValue
-     * @param string $expectedText
-     * @param string $expectedAttributeValue
      */
     public function testShouldFindTextElementByLocator(
         string $webDriverByLocatorMethod,

--- a/tests/functional/WebDriverByTest.php
+++ b/tests/functional/WebDriverByTest.php
@@ -18,10 +18,10 @@ class WebDriverByTest extends WebDriverTestCase
      * @param string $expectedAttributeValue
      */
     public function testShouldFindTextElementByLocator(
-        $webDriverByLocatorMethod,
-        $webDriverByLocatorValue,
-        $expectedText = null,
-        $expectedAttributeValue = null
+        string $webDriverByLocatorMethod,
+        string $webDriverByLocatorValue,
+        string $expectedText = null,
+        string $expectedAttributeValue = null
     ): void {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 

--- a/tests/functional/WebDriverByTest.php
+++ b/tests/functional/WebDriverByTest.php
@@ -22,7 +22,7 @@ class WebDriverByTest extends WebDriverTestCase
         $webDriverByLocatorValue,
         $expectedText = null,
         $expectedAttributeValue = null
-    ) {
+    ): void {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 
         $by = call_user_func([WebDriverBy::class, $webDriverByLocatorMethod], $webDriverByLocatorValue);
@@ -42,7 +42,7 @@ class WebDriverByTest extends WebDriverTestCase
     /**
      * @return array[]
      */
-    public function provideTextElements()
+    public function provideTextElements(): array
     {
         return [
             'id' => ['id', 'id_test', 'Test by ID'],

--- a/tests/functional/WebDriverCheckboxesTest.php
+++ b/tests/functional/WebDriverCheckboxesTest.php
@@ -125,9 +125,6 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
 
     /**
      * @dataProvider provideSelectByVisibleTextData
-     *
-     * @param string $text
-     * @param string $value
      */
     public function testSelectByVisibleText(string $text, string $value): void
     {
@@ -153,9 +150,6 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
 
     /**
      * @dataProvider provideSelectByVisiblePartialTextData
-     *
-     * @param string $text
-     * @param string $value
      */
     public function testSelectByVisiblePartialText(string $text, string $value): void
     {

--- a/tests/functional/WebDriverCheckboxesTest.php
+++ b/tests/functional/WebDriverCheckboxesTest.php
@@ -18,7 +18,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->driver->get($this->getTestPageUrl(TestPage::FORM_CHECKBOX_RADIO));
     }
 
-    public function testIsMultiple()
+    public function testIsMultiple(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -27,7 +27,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertTrue($checkboxes->isMultiple());
     }
 
-    public function testGetOptions()
+    public function testGetOptions(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//form[2]//input[@type="checkbox"]'))
@@ -36,7 +36,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertNotEmpty($checkboxes->getOptions());
     }
 
-    public function testGetFirstSelectedOption()
+    public function testGetFirstSelectedOption(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -47,7 +47,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertSame('j2a', $checkboxes->getFirstSelectedOption()->getAttribute('value'));
     }
 
-    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentForm()
+    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentForm(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@id="j5b"]'))
@@ -56,7 +56,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertEquals('j5b', $checkboxes->getFirstSelectedOption()->getAttribute('value'));
     }
 
-    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentFormWithoutId()
+    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentFormWithoutId(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@id="j5d"]'))
@@ -65,7 +65,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertEquals('j5c', $checkboxes->getFirstSelectedOption()->getAttribute('value'));
     }
 
-    public function testSelectByValue()
+    public function testSelectByValue(): void
     {
         $selectedOptions = ['j2b', 'j2c'];
 
@@ -83,7 +83,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertSame($selectedOptions, $selectedValues);
     }
 
-    public function testSelectByValueInvalid()
+    public function testSelectByValueInvalid(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -94,7 +94,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $checkboxes->selectByValue('notexist');
     }
 
-    public function testSelectByIndex()
+    public function testSelectByIndex(): void
     {
         $selectedOptions = [1 => 'j2b', 2 => 'j2c'];
 
@@ -112,7 +112,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertSame(array_values($selectedOptions), $selectedValues);
     }
 
-    public function testSelectByIndexInvalid()
+    public function testSelectByIndexInvalid(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -129,7 +129,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisibleText($text, $value)
+    public function testSelectByVisibleText($text, $value): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -143,7 +143,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
     /**
      * @return array[]
      */
-    public function provideSelectByVisibleTextData()
+    public function provideSelectByVisibleTextData(): array
     {
         return [
             ['J 2 B', 'j2b'],
@@ -157,7 +157,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisiblePartialText($text, $value)
+    public function testSelectByVisiblePartialText($text, $value): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -171,7 +171,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
     /**
      * @return array[]
      */
-    public function provideSelectByVisiblePartialTextData()
+    public function provideSelectByVisiblePartialTextData(): array
     {
         return [
             ['2 B', 'j2b'],
@@ -179,7 +179,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         ];
     }
 
-    public function testDeselectAll()
+    public function testDeselectAll(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -191,7 +191,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertEmpty($checkboxes->getAllSelectedOptions());
     }
 
-    public function testDeselectByIndex()
+    public function testDeselectByIndex(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -203,7 +203,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertEmpty($checkboxes->getAllSelectedOptions());
     }
 
-    public function testDeselectByValue()
+    public function testDeselectByValue(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -215,7 +215,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertEmpty($checkboxes->getAllSelectedOptions());
     }
 
-    public function testDeselectByVisibleText()
+    public function testDeselectByVisibleText(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -227,7 +227,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
         $this->assertEmpty($checkboxes->getAllSelectedOptions());
     }
 
-    public function testDeselectByVisiblePartialText()
+    public function testDeselectByVisiblePartialText(): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))

--- a/tests/functional/WebDriverCheckboxesTest.php
+++ b/tests/functional/WebDriverCheckboxesTest.php
@@ -129,7 +129,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisibleText($text, $value): void
+    public function testSelectByVisibleText(string $text, string $value): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))
@@ -157,7 +157,7 @@ class WebDriverCheckboxesTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisiblePartialText($text, $value): void
+    public function testSelectByVisiblePartialText(string $text, string $value): void
     {
         $checkboxes = new WebDriverCheckboxes(
             $this->driver->findElement(WebDriverBy::xpath('//input[@type="checkbox"]'))

--- a/tests/functional/WebDriverNavigationTest.php
+++ b/tests/functional/WebDriverNavigationTest.php
@@ -11,7 +11,7 @@ class WebDriverNavigationTest extends WebDriverTestCase
      * @covers ::__construct
      * @covers ::to
      */
-    public function testShouldNavigateToUrl()
+    public function testShouldNavigateToUrl(): void
     {
         $this->driver->navigate()->to($this->getTestPageUrl(TestPage::INDEX));
 
@@ -22,7 +22,7 @@ class WebDriverNavigationTest extends WebDriverTestCase
      * @covers ::back
      * @covers ::forward
      */
-    public function testShouldNavigateBackAndForward()
+    public function testShouldNavigateBackAndForward(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
         $linkElement = $this->driver->findElement(WebDriverBy::id('a-form'));
@@ -51,7 +51,7 @@ class WebDriverNavigationTest extends WebDriverTestCase
     /**
      * @covers ::refresh
      */
-    public function testShouldRefreshPage()
+    public function testShouldRefreshPage(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
 

--- a/tests/functional/WebDriverOptionsCookiesTest.php
+++ b/tests/functional/WebDriverOptionsCookiesTest.php
@@ -16,7 +16,7 @@ class WebDriverOptionsCookiesTest extends WebDriverTestCase
         $this->driver->get($this->getTestPageUrl(TestPage::INDEX));
     }
 
-    public function testShouldSetGetAndDeleteCookies()
+    public function testShouldSetGetAndDeleteCookies(): void
     {
         $cookie1 = new Cookie('cookie1', 'cookie1Value');
         $cookie2 = new Cookie('cookie2', 'cookie2Value');

--- a/tests/functional/WebDriverRadiosTest.php
+++ b/tests/functional/WebDriverRadiosTest.php
@@ -19,14 +19,14 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $this->driver->get($this->getTestPageUrl(TestPage::FORM_CHECKBOX_RADIO));
     }
 
-    public function testIsMultiple()
+    public function testIsMultiple(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
         $this->assertFalse($radios->isMultiple());
     }
 
-    public function testGetOptions()
+    public function testGetOptions(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
         $values = [];
@@ -37,7 +37,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $this->assertSame(['j3a', 'j3b', 'j3c'], $values);
     }
 
-    public function testGetFirstSelectedOption()
+    public function testGetFirstSelectedOption(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
@@ -46,14 +46,14 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $this->assertSame('j3a', $radios->getFirstSelectedOption()->getAttribute('value'));
     }
 
-    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentForm()
+    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentForm(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@id="j4b"]')));
 
         $this->assertEquals('j4b', $radios->getFirstSelectedOption()->getAttribute('value'));
     }
 
-    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentFormWithoutId()
+    public function testShouldGetFirstSelectedOptionConsideringOnlyElementsAssociatedWithCurrentFormWithoutId(): void
     {
         $radios = new WebDriverRadios(
             $this->driver->findElement(WebDriverBy::xpath('//input[@id="j4c"]'))
@@ -62,7 +62,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $this->assertEquals('j4c', $radios->getFirstSelectedOption()->getAttribute('value'));
     }
 
-    public function testSelectByValue()
+    public function testSelectByValue(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
         $radios->selectByValue('j3b');
@@ -73,7 +73,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $this->assertSame('j3b', $selectedOptions[0]->getAttribute('value'));
     }
 
-    public function testSelectByValueInvalid()
+    public function testSelectByValueInvalid(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
@@ -82,7 +82,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $radios->selectByValue('notexist');
     }
 
-    public function testSelectByIndex()
+    public function testSelectByIndex(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
         $radios->selectByIndex(1);
@@ -92,7 +92,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $this->assertSame('j3b', $allSelectedOptions[0]->getAttribute('value'));
     }
 
-    public function testSelectByIndexInvalid()
+    public function testSelectByIndexInvalid(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
@@ -107,7 +107,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisibleText($text, $value)
+    public function testSelectByVisibleText($text, $value): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
         $radios->selectByVisibleText($text);
@@ -117,7 +117,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
     /**
      * @return array[]
      */
-    public function provideSelectByVisibleTextData()
+    public function provideSelectByVisibleTextData(): array
     {
         return [
             ['J 3 B', 'j3b'],
@@ -131,7 +131,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisiblePartialText($text, $value)
+    public function testSelectByVisiblePartialText($text, $value): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
         $radios->selectByVisiblePartialText($text);
@@ -141,7 +141,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
     /**
      * @return array[]
      */
-    public function provideSelectByVisiblePartialTextData()
+    public function provideSelectByVisiblePartialTextData(): array
     {
         return [
             ['3 B', 'j3b'],
@@ -149,7 +149,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         ];
     }
 
-    public function testDeselectAllRadio()
+    public function testDeselectAllRadio(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
@@ -158,7 +158,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $radios->deselectAll();
     }
 
-    public function testDeselectByIndexRadio()
+    public function testDeselectByIndexRadio(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
@@ -167,7 +167,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $radios->deselectByIndex(0);
     }
 
-    public function testDeselectByValueRadio()
+    public function testDeselectByValueRadio(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
@@ -176,7 +176,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $radios->deselectByValue('val');
     }
 
-    public function testDeselectByVisibleTextRadio()
+    public function testDeselectByVisibleTextRadio(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 
@@ -185,7 +185,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
         $radios->deselectByVisibleText('AB');
     }
 
-    public function testDeselectByVisiblePartialTextRadio()
+    public function testDeselectByVisiblePartialTextRadio(): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
 

--- a/tests/functional/WebDriverRadiosTest.php
+++ b/tests/functional/WebDriverRadiosTest.php
@@ -107,7 +107,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisibleText($text, $value): void
+    public function testSelectByVisibleText(string $text, string $value): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
         $radios->selectByVisibleText($text);
@@ -131,7 +131,7 @@ class WebDriverRadiosTest extends WebDriverTestCase
      * @param string $text
      * @param string $value
      */
-    public function testSelectByVisiblePartialText($text, $value): void
+    public function testSelectByVisiblePartialText(string $text, string $value): void
     {
         $radios = new WebDriverRadios($this->driver->findElement(WebDriverBy::xpath('//input[@type="radio"]')));
         $radios->selectByVisiblePartialText($text);

--- a/tests/functional/WebDriverRadiosTest.php
+++ b/tests/functional/WebDriverRadiosTest.php
@@ -103,9 +103,6 @@ class WebDriverRadiosTest extends WebDriverTestCase
 
     /**
      * @dataProvider provideSelectByVisibleTextData
-     *
-     * @param string $text
-     * @param string $value
      */
     public function testSelectByVisibleText(string $text, string $value): void
     {
@@ -127,9 +124,6 @@ class WebDriverRadiosTest extends WebDriverTestCase
 
     /**
      * @dataProvider provideSelectByVisiblePartialTextData
-     *
-     * @param string $text
-     * @param string $value
      */
     public function testSelectByVisiblePartialText(string $text, string $value): void
     {

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -20,7 +20,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
     }
 
-    public function testShouldCreateNewInstanceForSelectElementAndDetectIfItIsMultiple()
+    public function testShouldCreateNewInstanceForSelectElementAndDetectIfItIsMultiple(): void
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select'));
         $originalMultipleElement = $this->driver->findElement(WebDriverBy::cssSelector('#select-multiple'));
@@ -35,7 +35,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertTrue($selectMultiple->isMultiple());
     }
 
-    public function testShouldThrowExceptionWhenNotInstantiatedOnSelectElement()
+    public function testShouldThrowExceptionWhenNotInstantiatedOnSelectElement(): void
     {
         $notSelectElement = $this->driver->findElement(WebDriverBy::cssSelector('textarea'));
 
@@ -48,7 +48,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @dataProvider provideSelectSelector
      * @param string $selector
      */
-    public function testShouldGetOptionsOfSelect($selector)
+    public function testShouldGetOptionsOfSelect($selector): void
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector($selector));
         $select = new WebDriverSelect($originalElement);
@@ -62,7 +62,7 @@ class WebDriverSelectTest extends WebDriverTestCase
     /**
      * @return array[]
      */
-    public function provideSelectSelector()
+    public function provideSelectSelector(): array
     {
         return [
             'simple <select>' => ['#select'],
@@ -70,7 +70,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         ];
     }
 
-    public function testShouldDefaultSelectedOptionOfSimpleSelect()
+    public function testShouldDefaultSelectedOptionOfSimpleSelect(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -85,7 +85,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertSame('First', $firstSelectedOption->getText());
     }
 
-    public function testShouldReturnEmptyArrayIfNoOptionsOfMultipleSelectSelected()
+    public function testShouldReturnEmptyArrayIfNoOptionsOfMultipleSelectSelected(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
 
@@ -94,7 +94,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertSame([], $selectedOptions);
     }
 
-    public function testShouldThrowExceptionIfThereIsNoFirstSelectedOptionOfMultipleSelect()
+    public function testShouldThrowExceptionIfThereIsNoFirstSelectedOptionOfMultipleSelect(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
 
@@ -103,7 +103,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->getFirstSelectedOption();
     }
 
-    public function testShouldSelectOptionOfSimpleSelectByIndex()
+    public function testShouldSelectOptionOfSimpleSelectByIndex(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
         $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
@@ -120,7 +120,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldSelectOptionOfMultipleSelectByIndex()
+    public function testShouldSelectOptionOfMultipleSelectByIndex(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $this->assertSame([], $select->getAllSelectedOptions());
@@ -138,7 +138,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['second', 'fourth', 'fifth'], $select->getAllSelectedOptions());
     }
 
-    public function testShouldThrowExceptionIfThereIsNoOptionIndexToSelect()
+    public function testShouldThrowExceptionIfThereIsNoOptionIndexToSelect(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -147,7 +147,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->selectByIndex(1337);
     }
 
-    public function testShouldSelectOptionOfSimpleSelectByValue()
+    public function testShouldSelectOptionOfSimpleSelectByValue(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
         $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
@@ -164,7 +164,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldSelectOptionOfMultipleSelectByValue()
+    public function testShouldSelectOptionOfMultipleSelectByValue(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $this->assertSame([], $select->getAllSelectedOptions());
@@ -182,7 +182,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['second', 'fourth', 'fifth'], $select->getAllSelectedOptions());
     }
 
-    public function testShouldThrowExceptionIfThereIsNoOptionValueToSelect()
+    public function testShouldThrowExceptionIfThereIsNoOptionValueToSelect(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -191,7 +191,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->selectByValue(1337);
     }
 
-    public function testShouldSelectOptionOfSimpleSelectByVisibleText()
+    public function testShouldSelectOptionOfSimpleSelectByVisibleText(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
         $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
@@ -208,7 +208,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldSelectOptionOfMultipleSelectByVisibleText()
+    public function testShouldSelectOptionOfMultipleSelectByVisibleText(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $this->assertSame([], $select->getAllSelectedOptions());
@@ -226,7 +226,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['second', 'fourth', 'fifth'], $select->getAllSelectedOptions());
     }
 
-    public function testShouldThrowExceptionIfThereIsNoOptionVisibleTextToSelect()
+    public function testShouldThrowExceptionIfThereIsNoOptionVisibleTextToSelect(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -235,7 +235,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->selectByVisibleText('second'); // the option is "This is second option"
     }
 
-    public function testShouldSelectOptionOfSimpleSelectByVisiblePartialText()
+    public function testShouldSelectOptionOfSimpleSelectByVisiblePartialText(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
         $this->assertSame('first', $select->getFirstSelectedOption()->getAttribute('value'));
@@ -252,7 +252,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldSelectOptionOfMultipleSelectByVisiblePartialText()
+    public function testShouldSelectOptionOfMultipleSelectByVisiblePartialText(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $this->assertSame([], $select->getAllSelectedOptions());
@@ -273,7 +273,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         );
     }
 
-    public function testShouldThrowExceptionIfThereIsNoOptionVisiblePartialTextToSelect()
+    public function testShouldThrowExceptionIfThereIsNoOptionVisiblePartialTextToSelect(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -282,7 +282,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->selectByVisiblePartialText('Not existing option');
     }
 
-    public function testShouldThrowExceptionWhenDeselectingOnSimpleSelect()
+    public function testShouldThrowExceptionWhenDeselectingOnSimpleSelect(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -295,7 +295,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldDeselectAllOptionsOnMultipleSelect()
+    public function testShouldDeselectAllOptionsOnMultipleSelect(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
 
@@ -313,7 +313,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldDeselectOptionOnMultipleSelectByIndex()
+    public function testShouldDeselectOptionOnMultipleSelectByIndex(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $select->selectByValue('fourth'); // index 3
@@ -326,7 +326,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
     }
 
-    public function testShouldThrowExceptionIfDeselectingSimpleSelectByIndex()
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByIndex(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -339,7 +339,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldDeselectOptionOnMultipleSelectByValue()
+    public function testShouldDeselectOptionOnMultipleSelectByValue(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $select->selectByValue('third');
@@ -352,7 +352,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['first'], $select->getAllSelectedOptions());
     }
 
-    public function testShouldThrowExceptionIfDeselectingSimpleSelectByValue()
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByValue(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -365,7 +365,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldDeselectOptionOnMultipleSelectByVisibleText()
+    public function testShouldDeselectOptionOnMultipleSelectByVisibleText(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $select->selectByValue('fourth'); // text 'Fourth  with   spaces   inside'
@@ -380,7 +380,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['second'], $select->getAllSelectedOptions());
     }
 
-    public function testShouldThrowExceptionIfDeselectingSimpleSelectByVisibleText()
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByVisibleText(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -393,7 +393,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @group exclude-edge
      * https://connect.microsoft.com/IE/feedback/details/2020772/-microsoft-edge-webdriver-cannot-select-multiple-on-select-html-tag
      */
-    public function testShouldDeselectOptionOnMultipleSelectByVisiblePartialText()
+    public function testShouldDeselectOptionOnMultipleSelectByVisiblePartialText(): void
     {
         $select = $this->getWebDriverSelectForMultipleSelect();
         $select->selectByValue('fourth'); // text 'Fourth  with   spaces   inside'
@@ -414,7 +414,7 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->assertContainsOptionsWithValues(['first'], $select->getAllSelectedOptions());
     }
 
-    public function testShouldThrowExceptionIfDeselectingSimpleSelectByVisiblePartialText()
+    public function testShouldThrowExceptionIfDeselectingSimpleSelectByVisiblePartialText(): void
     {
         $select = $this->getWebDriverSelectForSimpleSelect();
 
@@ -426,7 +426,7 @@ class WebDriverSelectTest extends WebDriverTestCase
     /**
      * @return WebDriverSelect
      */
-    protected function getWebDriverSelectForSimpleSelect()
+    protected function getWebDriverSelectForSimpleSelect(): WebDriverSelect
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select'));
 
@@ -436,7 +436,7 @@ class WebDriverSelectTest extends WebDriverTestCase
     /**
      * @return WebDriverSelect
      */
-    protected function getWebDriverSelectForMultipleSelect()
+    protected function getWebDriverSelectForMultipleSelect(): WebDriverSelect
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select-multiple'));
 
@@ -447,7 +447,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @param string[] $expectedValues
      * @param array $options
      */
-    private function assertContainsOptionsWithValues(array $expectedValues, array $options)
+    private function assertContainsOptionsWithValues(array $expectedValues, array $options): void
     {
         $expectedCount = count($expectedValues);
         $this->assertContainsOnlyInstancesOf(WebDriverElement::class, $options);

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -48,7 +48,7 @@ class WebDriverSelectTest extends WebDriverTestCase
      * @dataProvider provideSelectSelector
      * @param string $selector
      */
-    public function testShouldGetOptionsOfSelect($selector): void
+    public function testShouldGetOptionsOfSelect(string $selector): void
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector($selector));
         $select = new WebDriverSelect($originalElement);

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -46,7 +46,6 @@ class WebDriverSelectTest extends WebDriverTestCase
 
     /**
      * @dataProvider provideSelectSelector
-     * @param string $selector
      */
     public function testShouldGetOptionsOfSelect(string $selector): void
     {
@@ -423,9 +422,6 @@ class WebDriverSelectTest extends WebDriverTestCase
         $select->deselectByVisiblePartialText('First');
     }
 
-    /**
-     * @return WebDriverSelect
-     */
     protected function getWebDriverSelectForSimpleSelect(): WebDriverSelect
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select'));
@@ -433,9 +429,6 @@ class WebDriverSelectTest extends WebDriverTestCase
         return new WebDriverSelect($originalElement);
     }
 
-    /**
-     * @return WebDriverSelect
-     */
     protected function getWebDriverSelectForMultipleSelect(): WebDriverSelect
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select-multiple'));
@@ -445,7 +438,6 @@ class WebDriverSelectTest extends WebDriverTestCase
 
     /**
      * @param string[] $expectedValues
-     * @param array $options
      */
     private function assertContainsOptionsWithValues(array $expectedValues, array $options): void
     {

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -135,7 +135,7 @@ class WebDriverTestCase extends TestCase
      * @param string[] $browsers List of browsers for this test
      * @param string|null $message
      */
-    public static function skipForUnmatchedBrowsers($browsers = [], $message = null): void
+    public static function skipForUnmatchedBrowsers(array $browsers = [], ?string $message = null): void
     {
         $browserName = (string) getenv('BROWSER_NAME');
         if (!in_array($browserName, $browsers, true)) {
@@ -178,7 +178,7 @@ class WebDriverTestCase extends TestCase
      * @param string $path
      * @return string
      */
-    protected function getTestPageUrl($path): string
+    protected function getTestPageUrl(string $path): string
     {
         $host = 'http://localhost:8000';
         if ($alternateHost = getenv('FIXTURES_HOST')) {

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -94,17 +94,11 @@ class WebDriverTestCase extends TestCase
         }
     }
 
-    /**
-     * @return bool
-     */
     public static function isSauceLabsBuild(): bool
     {
         return getenv('SAUCELABS') ? true : false;
     }
 
-    /**
-     * @return bool
-     */
     public static function isW3cProtocolBuild(): bool
     {
         return getenv('DISABLE_W3C_PROTOCOL') !== '1';
@@ -133,7 +127,6 @@ class WebDriverTestCase extends TestCase
      * Mark a test as skipped if the current browser is not in the list of browsers.
      *
      * @param string[] $browsers List of browsers for this test
-     * @param string|null $message
      */
     public static function skipForUnmatchedBrowsers(array $browsers = [], ?string $message = null): void
     {
@@ -174,9 +167,6 @@ class WebDriverTestCase extends TestCase
 
     /**
      * Get the URL of given test HTML on running webserver.
-     *
-     * @param string $path
-     * @return string
      */
     protected function getTestPageUrl(string $path): string
     {

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -97,7 +97,7 @@ class WebDriverTestCase extends TestCase
     /**
      * @return bool
      */
-    public static function isSauceLabsBuild()
+    public static function isSauceLabsBuild(): bool
     {
         return getenv('SAUCELABS') ? true : false;
     }
@@ -105,7 +105,7 @@ class WebDriverTestCase extends TestCase
     /**
      * @return bool
      */
-    public static function isW3cProtocolBuild()
+    public static function isW3cProtocolBuild(): bool
     {
         return getenv('DISABLE_W3C_PROTOCOL') !== '1';
     }
@@ -115,14 +115,14 @@ class WebDriverTestCase extends TestCase
         return getenv('SELENIUM_SERVER') === '1';
     }
 
-    public static function skipForW3cProtocol($message = 'Not supported by W3C specification')
+    public static function skipForW3cProtocol($message = 'Not supported by W3C specification'): void
     {
         if (static::isW3cProtocolBuild()) {
             static::markTestSkipped($message);
         }
     }
 
-    public static function skipForJsonWireProtocol($message = 'Not supported by JsonWire protocol')
+    public static function skipForJsonWireProtocol($message = 'Not supported by JsonWire protocol'): void
     {
         if (!static::isW3cProtocolBuild()) {
             static::markTestSkipped($message);
@@ -135,7 +135,7 @@ class WebDriverTestCase extends TestCase
      * @param string[] $browsers List of browsers for this test
      * @param string|null $message
      */
-    public static function skipForUnmatchedBrowsers($browsers = [], $message = null)
+    public static function skipForUnmatchedBrowsers($browsers = [], $message = null): void
     {
         $browserName = (string) getenv('BROWSER_NAME');
         if (!in_array($browserName, $browsers, true)) {
@@ -178,7 +178,7 @@ class WebDriverTestCase extends TestCase
      * @param string $path
      * @return string
      */
-    protected function getTestPageUrl($path)
+    protected function getTestPageUrl($path): string
     {
         $host = 'http://localhost:8000';
         if ($alternateHost = getenv('FIXTURES_HOST')) {
@@ -188,7 +188,7 @@ class WebDriverTestCase extends TestCase
         return $host . '/' . $path;
     }
 
-    protected function setUpSauceLabs()
+    protected function setUpSauceLabs(): void
     {
         $this->serverUrl = sprintf(
             'http://%s:%s@ondemand.saucelabs.com/wd/hub',
@@ -240,7 +240,7 @@ class WebDriverTestCase extends TestCase
         }
     }
 
-    protected function createWebDriver()
+    protected function createWebDriver(): void
     {
         $this->driver = RemoteWebDriver::create(
             $this->serverUrl,

--- a/tests/functional/WebDriverTimeoutsTest.php
+++ b/tests/functional/WebDriverTimeoutsTest.php
@@ -15,7 +15,7 @@ class WebDriverTimeoutsTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldFailGettingDelayedElementWithoutWait()
+    public function testShouldFailGettingDelayedElementWithoutWait(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::DELAYED_ELEMENT));
 
@@ -27,7 +27,7 @@ class WebDriverTimeoutsTest extends WebDriverTestCase
      * @covers ::__construct
      * @covers ::implicitlyWait
      */
-    public function testShouldGetDelayedElementWithImplicitWait()
+    public function testShouldGetDelayedElementWithImplicitWait(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::DELAYED_ELEMENT));
 
@@ -42,7 +42,7 @@ class WebDriverTimeoutsTest extends WebDriverTestCase
      * @covers ::__construct
      * @covers ::pageLoadTimeout
      */
-    public function testShouldFailIfPageIsLoadingLongerThanPageLoadTimeout()
+    public function testShouldFailIfPageIsLoadingLongerThanPageLoadTimeout(): void
     {
         $this->driver->manage()->timeouts()->pageLoadTimeout(1);
 

--- a/tests/functional/WebDriverWindowTest.php
+++ b/tests/functional/WebDriverWindowTest.php
@@ -10,7 +10,7 @@ class WebDriverWindowTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldGetPosition()
+    public function testShouldGetPosition(): void
     {
         $position = $this->driver->manage()
             ->window()
@@ -20,7 +20,7 @@ class WebDriverWindowTest extends WebDriverTestCase
         $this->assertGreaterThanOrEqual(0, $position->getY());
     }
 
-    public function testShouldGetSize()
+    public function testShouldGetSize(): void
     {
         $size = $this->driver->manage()
             ->window()
@@ -30,7 +30,7 @@ class WebDriverWindowTest extends WebDriverTestCase
         $this->assertGreaterThan(0, $size->getHeight());
     }
 
-    public function testShouldMaximizeWindow()
+    public function testShouldMaximizeWindow(): void
     {
         $sizeBefore = $this->driver->manage()
             ->window()
@@ -52,7 +52,7 @@ class WebDriverWindowTest extends WebDriverTestCase
      * @group exclude-edge
      * @group exclude-saucelabs
      */
-    public function testShouldFullscreenWindow()
+    public function testShouldFullscreenWindow(): void
     {
         self::skipForJsonWireProtocol('"fullscreen" window is not supported in JsonWire protocol');
 
@@ -79,7 +79,7 @@ class WebDriverWindowTest extends WebDriverTestCase
      * @group exclude-safari
      * @group exclude-saucelabs
      */
-    public function testShouldMinimizeWindow()
+    public function testShouldMinimizeWindow(): void
     {
         self::skipForJsonWireProtocol('"minimize" window is not supported in JsonWire protocol');
 
@@ -95,7 +95,7 @@ class WebDriverWindowTest extends WebDriverTestCase
     /**
      * @group exclude-saucelabs
      */
-    public function testShouldSetSize()
+    public function testShouldSetSize(): void
     {
         $sizeBefore = $this->driver->manage()
             ->window()
@@ -118,7 +118,7 @@ class WebDriverWindowTest extends WebDriverTestCase
     /**
      * @todo Skip when running headless mode
      */
-    public function testShouldSetWindowPosition()
+    public function testShouldSetWindowPosition(): void
     {
         $this->driver->manage()
             ->window()

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -31,7 +31,6 @@ class CookieTest extends TestCase
 
     /**
      * @depends testShouldSetAllProperties
-     * @param Cookie $cookie
      */
     public function testShouldBeConvertibleToArray(Cookie $cookie): void
     {
@@ -75,7 +74,6 @@ class CookieTest extends TestCase
 
     /**
      * @depends testShouldSetAllProperties
-     * @param Cookie $cookie
      */
     public function testShouldProvideArrayAccessToProperties(Cookie $cookie): void
     {

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class CookieTest extends TestCase
 {
-    public function testShouldSetAllProperties()
+    public function testShouldSetAllProperties(): Cookie
     {
         $cookie = new Cookie('cookieName', 'someValue');
         $cookie->setPath('/bar');
@@ -33,7 +33,7 @@ class CookieTest extends TestCase
      * @depends testShouldSetAllProperties
      * @param Cookie $cookie
      */
-    public function testShouldBeConvertibleToArray(Cookie $cookie)
+    public function testShouldBeConvertibleToArray(Cookie $cookie): void
     {
         $this->assertSame(
             [
@@ -59,7 +59,7 @@ class CookieTest extends TestCase
      * https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol
      * https://w3c.github.io/webdriver/#add-cookie
      */
-    public function testShouldNotContainNullValues()
+    public function testShouldNotContainNullValues(): void
     {
         $cookie = new Cookie('cookieName', 'someValue');
 
@@ -77,7 +77,7 @@ class CookieTest extends TestCase
      * @depends testShouldSetAllProperties
      * @param Cookie $cookie
      */
-    public function testShouldProvideArrayAccessToProperties(Cookie $cookie)
+    public function testShouldProvideArrayAccessToProperties(Cookie $cookie): void
     {
         $this->assertSame('cookieName', $cookie['name']);
         $this->assertSame('someValue', $cookie['value']);
@@ -94,7 +94,7 @@ class CookieTest extends TestCase
         $this->assertArrayNotHasKey('domain', $cookie);
     }
 
-    public function testShouldBeCreatableFromAnArrayWithBasicValues()
+    public function testShouldBeCreatableFromAnArrayWithBasicValues(): void
     {
         $sourceArray = [
             'name' => 'cookieName',
@@ -131,7 +131,7 @@ class CookieTest extends TestCase
         $this->assertNull($cookie->getSameSite());
     }
 
-    public function testShouldBeCreatableFromAnArrayWithAllValues()
+    public function testShouldBeCreatableFromAnArrayWithAllValues(): void
     {
         $sourceArray = [
             'name' => 'cookieName',
@@ -163,7 +163,7 @@ class CookieTest extends TestCase
      * @param string $domain
      * @param string $expectedMessage
      */
-    public function testShouldValidateCookieOnConstruction($name, $value, $domain, $expectedMessage)
+    public function testShouldValidateCookieOnConstruction($name, $value, $domain, $expectedMessage): void
     {
         if ($expectedMessage) {
             $this->expectException(LogicException::class);
@@ -181,7 +181,7 @@ class CookieTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideInvalidCookie()
+    public function provideInvalidCookie(): array
     {
         return [
             // $name, $value, $domain, $expectedMessage

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -158,13 +158,13 @@ class CookieTest extends TestCase
 
     /**
      * @dataProvider provideInvalidCookie
-     * @param string $name
-     * @param string $value
-     * @param string $domain
-     * @param string $expectedMessage
      */
-    public function testShouldValidateCookieOnConstruction($name, $value, $domain, $expectedMessage): void
-    {
+    public function testShouldValidateCookieOnConstruction(
+        ?string $name,
+        ?string $value,
+        ?string $domain,
+        ?string $expectedMessage
+    ): void {
         if ($expectedMessage) {
             $this->expectException(LogicException::class);
             $this->expectExceptionMessage($expectedMessage);

--- a/tests/unit/Exception/Internal/DriverServerDiedExceptionTest.php
+++ b/tests/unit/Exception/Internal/DriverServerDiedExceptionTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class DriverServerDiedExceptionTest extends TestCase
 {
-    public function testShouldCreateWithPreviousException()
+    public function testShouldCreateWithPreviousException(): void
     {
         $dummyPreviousException = UnexpectedResponseException::forError('CURL error');
 

--- a/tests/unit/Exception/WebDriverExceptionTest.php
+++ b/tests/unit/Exception/WebDriverExceptionTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class WebDriverExceptionTest extends TestCase
 {
-    public function testShouldStoreResultsOnInstantiation()
+    public function testShouldStoreResultsOnInstantiation(): void
     {
         $exception = new WebDriverException('exception message', ['foo', 'bar']);
 
@@ -21,7 +21,7 @@ class WebDriverExceptionTest extends TestCase
      * @param int $errorCode
      * @param string $expectedExceptionType
      */
-    public function testShouldThrowProperExceptionBasedOnWebDriverErrorCode($errorCode, $expectedExceptionType)
+    public function testShouldThrowProperExceptionBasedOnWebDriverErrorCode($errorCode, $expectedExceptionType): void
     {
         try {
             WebDriverException::throwException($errorCode, 'exception message', ['results']);
@@ -36,7 +36,43 @@ class WebDriverExceptionTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideJsonWireStatusCode()
+    public function provideW3CWebDriverErrorCode(): array
+    {
+        return [
+                ['element click intercepted', ElementClickInterceptedException::class],
+                ['element not interactable', ElementNotInteractableException::class],
+                ['element not interactable', ElementNotInteractableException::class],
+                ['insecure certificate', InsecureCertificateException::class],
+                ['invalid argument', InvalidArgumentException::class],
+                ['invalid cookie domain', InvalidCookieDomainException::class],
+                ['invalid element state', InvalidElementStateException::class],
+                ['invalid selector', InvalidSelectorException::class],
+                ['invalid session id', InvalidSessionIdException::class],
+                ['javascript error', JavascriptErrorException::class],
+                ['move target out of bounds', MoveTargetOutOfBoundsException::class],
+                ['no such alert', NoSuchAlertException::class],
+                ['no such cookie', NoSuchCookieException::class],
+                ['no such element', NoSuchElementException::class],
+                ['no such frame', NoSuchFrameException::class],
+                ['no such window', NoSuchWindowException::class],
+                ['script timeout', ScriptTimeoutException::class],
+                ['session not created', SessionNotCreatedException::class],
+                ['stale element reference', StaleElementReferenceException::class],
+                ['timeout', TimeoutException::class],
+                ['unable to set cookie', UnableToSetCookieException::class],
+                ['unable to capture screen', UnableToCaptureScreenException::class],
+                ['unexpected alert open', UnexpectedAlertOpenException::class],
+                ['unknown command', UnknownCommandException::class],
+                ['unknown error', UnknownErrorException::class],
+                ['unknown method', UnknownMethodException::class],
+                ['unsupported operation', UnsupportedOperationException::class],
+        ];
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideJsonWireStatusCode(): array
     {
         return [
             [1337, UnrecognizedExceptionException::class],
@@ -74,42 +110,6 @@ class WebDriverExceptionTest extends TestCase
             [32, InvalidSelectorException::class],
             [33, SessionNotCreatedException::class],
             [34, MoveTargetOutOfBoundsException::class],
-        ];
-    }
-
-    /**
-     * @return array[]
-     */
-    public function provideW3CWebDriverErrorCode()
-    {
-        return [
-                ['element click intercepted', ElementClickInterceptedException::class],
-                ['element not interactable', ElementNotInteractableException::class],
-                ['element not interactable', ElementNotInteractableException::class],
-                ['insecure certificate', InsecureCertificateException::class],
-                ['invalid argument', InvalidArgumentException::class],
-                ['invalid cookie domain', InvalidCookieDomainException::class],
-                ['invalid element state', InvalidElementStateException::class],
-                ['invalid selector', InvalidSelectorException::class],
-                ['invalid session id', InvalidSessionIdException::class],
-                ['javascript error', JavascriptErrorException::class],
-                ['move target out of bounds', MoveTargetOutOfBoundsException::class],
-                ['no such alert', NoSuchAlertException::class],
-                ['no such cookie', NoSuchCookieException::class],
-                ['no such element', NoSuchElementException::class],
-                ['no such frame', NoSuchFrameException::class],
-                ['no such window', NoSuchWindowException::class],
-                ['script timeout', ScriptTimeoutException::class],
-                ['session not created', SessionNotCreatedException::class],
-                ['stale element reference', StaleElementReferenceException::class],
-                ['timeout', TimeoutException::class],
-                ['unable to set cookie', UnableToSetCookieException::class],
-                ['unable to capture screen', UnableToCaptureScreenException::class],
-                ['unexpected alert open', UnexpectedAlertOpenException::class],
-                ['unknown command', UnknownCommandException::class],
-                ['unknown error', UnknownErrorException::class],
-                ['unknown method', UnknownMethodException::class],
-                ['unsupported operation', UnsupportedOperationException::class],
         ];
     }
 }

--- a/tests/unit/Exception/WebDriverExceptionTest.php
+++ b/tests/unit/Exception/WebDriverExceptionTest.php
@@ -18,11 +18,12 @@ class WebDriverExceptionTest extends TestCase
     /**
      * @dataProvider provideJsonWireStatusCode
      * @dataProvider provideW3CWebDriverErrorCode
-     * @param int $errorCode
-     * @param string $expectedExceptionType
+     * @param int|string $errorCode
      */
-    public function testShouldThrowProperExceptionBasedOnWebDriverErrorCode($errorCode, $expectedExceptionType): void
-    {
+    public function testShouldThrowProperExceptionBasedOnWebDriverErrorCode(
+        $errorCode,
+        string $expectedExceptionType
+    ): void {
         try {
             WebDriverException::throwException($errorCode, 'exception message', ['results']);
         } catch (WebDriverException $e) {

--- a/tests/unit/Firefox/FirefoxOptionsTest.php
+++ b/tests/unit/Firefox/FirefoxOptionsTest.php
@@ -13,7 +13,7 @@ class FirefoxOptionsTest extends TestCase
         FirefoxPreferences::DEVTOOLS_JSONVIEW => false,
     ];
 
-    public function testShouldBeConstructedWithDefaultOptions()
+    public function testShouldBeConstructedWithDefaultOptions(): void
     {
         $options = new FirefoxOptions();
 
@@ -25,7 +25,7 @@ class FirefoxOptionsTest extends TestCase
         );
     }
 
-    public function testShouldAddCustomOptions()
+    public function testShouldAddCustomOptions(): void
     {
         $options = new FirefoxOptions();
 
@@ -40,7 +40,7 @@ class FirefoxOptionsTest extends TestCase
         );
     }
 
-    public function testShouldOverwriteDefaultOptionsWhenSpecified()
+    public function testShouldOverwriteDefaultOptionsWhenSpecified(): void
     {
         $options = new FirefoxOptions();
 
@@ -57,7 +57,7 @@ class FirefoxOptionsTest extends TestCase
         );
     }
 
-    public function testShouldSetCustomPreference()
+    public function testShouldSetCustomPreference(): void
     {
         $options = new FirefoxOptions();
 
@@ -75,7 +75,7 @@ class FirefoxOptionsTest extends TestCase
         );
     }
 
-    public function testShouldAddArguments()
+    public function testShouldAddArguments(): void
     {
         $options = new FirefoxOptions();
 
@@ -90,7 +90,7 @@ class FirefoxOptionsTest extends TestCase
         );
     }
 
-    public function testShouldJsonSerializeToArrayObject()
+    public function testShouldJsonSerializeToArrayObject(): void
     {
         $options = new FirefoxOptions();
         $options->setOption('binary', '/usr/local/firefox/bin/firefox');
@@ -101,7 +101,7 @@ class FirefoxOptionsTest extends TestCase
         $this->assertSame('/usr/local/firefox/bin/firefox', $jsonSerialized['binary']);
     }
 
-    public function testShouldNotAllowToSetArgumentsOptionDirectly()
+    public function testShouldNotAllowToSetArgumentsOptionDirectly(): void
     {
         $options = new FirefoxOptions();
 
@@ -110,7 +110,7 @@ class FirefoxOptionsTest extends TestCase
         $options->setOption('args', []);
     }
 
-    public function testShouldNotAllowToSetPreferencesOptionDirectly()
+    public function testShouldNotAllowToSetPreferencesOptionDirectly(): void
     {
         $options = new FirefoxOptions();
 

--- a/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
@@ -25,7 +25,7 @@ class WebDriverButtonReleaseActionTest extends TestCase
         );
     }
 
-    public function testPerformSendsMouseUpCommand()
+    public function testPerformSendsMouseUpCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
@@ -25,7 +25,7 @@ class WebDriverClickActionTest extends TestCase
         );
     }
 
-    public function testPerformSendsClickCommand()
+    public function testPerformSendsClickCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
@@ -25,7 +25,7 @@ class WebDriverClickAndHoldActionTest extends TestCase
         );
     }
 
-    public function testPerformSendsMouseDownCommand()
+    public function testPerformSendsMouseDownCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
@@ -25,7 +25,7 @@ class WebDriverContextClickActionTest extends TestCase
         );
     }
 
-    public function testPerformSendsContextClickCommand()
+    public function testPerformSendsContextClickCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class WebDriverCoordinatesTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $in_view_port = function () {
             return new WebDriverPoint(0, 0);

--- a/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
@@ -25,7 +25,7 @@ class WebDriverDoubleClickActionTest extends TestCase
         );
     }
 
-    public function testPerformSendsDoubleClickCommand()
+    public function testPerformSendsDoubleClickCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
@@ -33,7 +33,7 @@ class WebDriverKeyDownActionTest extends TestCase
         );
     }
 
-    public function testPerformFocusesOnElementAndSendPressKeyCommand()
+    public function testPerformFocusesOnElementAndSendPressKeyCommand(): void
     {
         $coords = $this->createMock(WebDriverCoordinates::class);
         $this->webDriverMouse->expects($this->once())->method('click')->with($coords);

--- a/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
@@ -33,7 +33,7 @@ class WebDriverKeyUpActionTest extends TestCase
         );
     }
 
-    public function testPerformFocusesOnElementAndSendPressKeyCommand()
+    public function testPerformFocusesOnElementAndSendPressKeyCommand(): void
     {
         $coords = $this->createMock(WebDriverCoordinates::class);
         $this->webDriverMouse->expects($this->once())->method('click')->with($coords);

--- a/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
@@ -26,7 +26,7 @@ class WebDriverMouseMoveActionTest extends TestCase
         );
     }
 
-    public function testPerformFocusesOnElementAndSendPressKeyCommand()
+    public function testPerformFocusesOnElementAndSendPressKeyCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
@@ -30,7 +30,7 @@ class WebDriverMouseToOffsetActionTest extends TestCase
         );
     }
 
-    public function testPerformFocusesOnElementAndSendPressKeyCommand()
+    public function testPerformFocusesOnElementAndSendPressKeyCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
@@ -35,7 +35,7 @@ class WebDriverSendKeysActionTest extends TestCase
         );
     }
 
-    public function testPerformFocusesOnElementAndSendPressKeyCommand()
+    public function testPerformFocusesOnElementAndSendPressKeyCommand(): void
     {
         $coords = $this->getMockBuilder(WebDriverCoordinates::class)
             ->disableOriginalConstructor()->getMock();

--- a/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class WebDriverSingleKeyActionTest extends TestCase
 {
-    public function testShouldThrowExceptionWhenNotUsedForModifier()
+    public function testShouldThrowExceptionWhenNotUsedForModifier(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(

--- a/tests/unit/Remote/CustomWebDriverCommandTest.php
+++ b/tests/unit/Remote/CustomWebDriverCommandTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class CustomWebDriverCommandTest extends TestCase
 {
-    public function testShouldSetOptionsUsingConstructor()
+    public function testShouldSetOptionsUsingConstructor(): void
     {
         $command = new CustomWebDriverCommand(
             'session-id-123',
@@ -20,7 +20,7 @@ class CustomWebDriverCommandTest extends TestCase
         $this->assertSame('POST', $command->getCustomMethod());
     }
 
-    public function testCustomCommandInvalidUrlExceptionInit()
+    public function testCustomCommandInvalidUrlExceptionInit(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('URL of custom command has to start with / but is "url-without-leading-slash"');
@@ -28,7 +28,7 @@ class CustomWebDriverCommandTest extends TestCase
         new CustomWebDriverCommand('session-id-123', 'url-without-leading-slash', 'POST', []);
     }
 
-    public function testCustomCommandInvalidMethodExceptionInit()
+    public function testCustomCommandInvalidMethodExceptionInit(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Invalid custom method "invalid-method", must be one of [GET, POST]');

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class DesiredCapabilitiesTest extends TestCase
 {
-    public function testShouldInstantiateWithCapabilitiesGivenInConstructor()
+    public function testShouldInstantiateWithCapabilitiesGivenInConstructor(): void
     {
         $capabilities = new DesiredCapabilities(
             ['fooKey' => 'fooVal', WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY]
@@ -27,7 +27,7 @@ class DesiredCapabilitiesTest extends TestCase
         );
     }
 
-    public function testShouldInstantiateEmptyInstance()
+    public function testShouldInstantiateEmptyInstance(): void
     {
         $capabilities = new DesiredCapabilities();
 
@@ -35,7 +35,7 @@ class DesiredCapabilitiesTest extends TestCase
         $this->assertSame([], $capabilities->toArray());
     }
 
-    public function testShouldProvideAccessToCapabilitiesUsingSettersAndGetters()
+    public function testShouldProvideAccessToCapabilitiesUsingSettersAndGetters(): void
     {
         $capabilities = new DesiredCapabilities();
         // generic capability setter
@@ -51,7 +51,7 @@ class DesiredCapabilitiesTest extends TestCase
         $this->assertSame(333, $capabilities->getVersion());
     }
 
-    public function testShouldAccessCapabilitiesIsser()
+    public function testShouldAccessCapabilitiesIsser(): void
     {
         $capabilities = new DesiredCapabilities();
 
@@ -66,7 +66,7 @@ class DesiredCapabilitiesTest extends TestCase
         $this->assertFalse($capabilities->is('customNull'));
     }
 
-    public function testShouldNotAllowToDisableJavascriptForNonHtmlUnitBrowser()
+    public function testShouldNotAllowToDisableJavascriptForNonHtmlUnitBrowser(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('isJavascriptEnabled() is a htmlunit-only option');
@@ -76,7 +76,7 @@ class DesiredCapabilitiesTest extends TestCase
         $capabilities->setJavascriptEnabled(false);
     }
 
-    public function testShouldAllowToDisableJavascriptForHtmlUnitBrowser()
+    public function testShouldAllowToDisableJavascriptForHtmlUnitBrowser(): void
     {
         $capabilities = new DesiredCapabilities();
         $capabilities->setBrowserName(WebDriverBrowserType::HTMLUNIT);
@@ -95,7 +95,7 @@ class DesiredCapabilitiesTest extends TestCase
         $setupMethod,
         $expectedBrowser,
         $expectedPlatform
-    ) {
+    ): void {
         /** @var DesiredCapabilities $capabilities */
         $capabilities = call_user_func([DesiredCapabilities::class, $setupMethod]);
 
@@ -106,7 +106,7 @@ class DesiredCapabilitiesTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideBrowserCapabilities()
+    public function provideBrowserCapabilities(): array
     {
         return [
             ['android', WebDriverBrowserType::ANDROID, WebDriverPlatform::ANDROID],
@@ -124,7 +124,7 @@ class DesiredCapabilitiesTest extends TestCase
         ];
     }
 
-    public function testShouldSetupFirefoxWithDefaultOptions()
+    public function testShouldSetupFirefoxWithDefaultOptions(): void
     {
         $capabilitiesArray = DesiredCapabilities::firefox()->toArray();
 
@@ -137,7 +137,7 @@ class DesiredCapabilitiesTest extends TestCase
         );
     }
 
-    public function testShouldSetupFirefoxWithCustomOptions()
+    public function testShouldSetupFirefoxWithCustomOptions(): void
     {
         $firefoxOptions = new FirefoxOptions();
         $firefoxOptions->addArguments(['-headless']);
@@ -159,7 +159,7 @@ class DesiredCapabilitiesTest extends TestCase
         );
     }
 
-    public function testShouldNotOverwriteDefaultFirefoxOptionsWhenAddingFirefoxOptionAsArray()
+    public function testShouldNotOverwriteDefaultFirefoxOptionsWhenAddingFirefoxOptionAsArray(): void
     {
         $capabilities = DesiredCapabilities::firefox();
         $capabilities->setCapability('moz:firefoxOptions', ['args' => ['-headless']]);
@@ -181,7 +181,7 @@ class DesiredCapabilitiesTest extends TestCase
     public function testShouldConvertCapabilitiesToW3cCompatible(
         DesiredCapabilities $inputJsonWireCapabilities,
         array $expectedW3cCapabilities
-    ) {
+    ): void {
         $this->assertJsonStringEqualsJsonString(
             json_encode($expectedW3cCapabilities, JSON_THROW_ON_ERROR),
             json_encode($inputJsonWireCapabilities->toW3cCompatibleArray(), JSON_THROW_ON_ERROR)
@@ -191,7 +191,7 @@ class DesiredCapabilitiesTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideW3cCapabilities()
+    public function provideW3cCapabilities(): array
     {
         $chromeOptions = new ChromeOptions();
         $chromeOptions->addArguments(['--headless']);

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -92,9 +92,9 @@ class DesiredCapabilitiesTest extends TestCase
      * @param string $expectedPlatform
      */
     public function testShouldProvideShortcutSetupForCapabilitiesOfEachBrowser(
-        $setupMethod,
-        $expectedBrowser,
-        $expectedPlatform
+        string $setupMethod,
+        string $expectedBrowser,
+        string $expectedPlatform
     ): void {
         /** @var DesiredCapabilities $capabilities */
         $capabilities = call_user_func([DesiredCapabilities::class, $setupMethod]);

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -87,9 +87,6 @@ class DesiredCapabilitiesTest extends TestCase
 
     /**
      * @dataProvider provideBrowserCapabilities
-     * @param string $setupMethod
-     * @param string $expectedBrowser
-     * @param string $expectedPlatform
      */
     public function testShouldProvideShortcutSetupForCapabilitiesOfEachBrowser(
         string $setupMethod,
@@ -175,8 +172,6 @@ class DesiredCapabilitiesTest extends TestCase
 
     /**
      * @dataProvider provideW3cCapabilities
-     * @param DesiredCapabilities $inputJsonWireCapabilities
-     * @param array $expectedW3cCapabilities
      */
     public function testShouldConvertCapabilitiesToW3cCompatible(
         DesiredCapabilities $inputJsonWireCapabilities,

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -19,10 +19,6 @@ class HttpCommandExecutorTest extends TestCase
 
     /**
      * @dataProvider provideCommand
-     * @param WebDriverCommand $command
-     * @param bool $shouldResetExpectHeader
-     * @param string $expectedUrl
-     * @param string|null $expectedPostData
      */
     public function testShouldSendRequestToAssembledUrl(
         WebDriverCommand $command,

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -26,9 +26,9 @@ class HttpCommandExecutorTest extends TestCase
      */
     public function testShouldSendRequestToAssembledUrl(
         WebDriverCommand $command,
-        $shouldResetExpectHeader,
-        $expectedUrl,
-        $expectedPostData
+        bool $shouldResetExpectHeader,
+        string $expectedUrl,
+        ?string $expectedPostData
     ): void {
         $expectedCurlSetOptCalls = [
             [$this->anything(), CURLOPT_URL, $expectedUrl],

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -65,7 +65,7 @@ class HttpCommandExecutorTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideCommand()
+    public function provideCommand(): array
     {
         return [
             'POST command having :id placeholder in url' => [

--- a/tests/unit/Remote/LocalFileDetectorTest.php
+++ b/tests/unit/Remote/LocalFileDetectorTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class LocalFileDetectorTest extends TestCase
 {
-    public function testShouldDetectLocalFile()
+    public function testShouldDetectLocalFile(): void
     {
         $detector = new LocalFileDetector();
 
@@ -15,7 +15,7 @@ class LocalFileDetectorTest extends TestCase
         $this->assertSame(__FILE__, $file);
     }
 
-    public function testShouldReturnNullIfFileNotDetected()
+    public function testShouldReturnNullIfFileNotDetected(): void
     {
         $detector = new LocalFileDetector();
 

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -117,8 +117,6 @@ class RemoteWebDriverTest extends TestCase
      * @covers ::findElement
      * @covers ::findElements
      * @covers \Facebook\WebDriver\Exception\Internal\UnexpectedResponseException
-     * @param string $method
-     * @param string $expectedExceptionMessage
      * @dataProvider provideMethods
      */
     public function testShouldThrowExceptionOnUnexpectedNullValueFromRemoteEnd(

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -36,7 +36,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::manage
      */
-    public function testShouldCreateWebDriverOptionsInstance()
+    public function testShouldCreateWebDriverOptionsInstance(): void
     {
         $wait = $this->driver->manage();
 
@@ -46,7 +46,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::navigate
      */
-    public function testShouldCreateWebDriverNavigationInstance()
+    public function testShouldCreateWebDriverNavigationInstance(): void
     {
         $wait = $this->driver->navigate();
 
@@ -56,7 +56,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::switchTo
      */
-    public function testShouldCreateRemoteTargetLocatorInstance()
+    public function testShouldCreateRemoteTargetLocatorInstance(): void
     {
         $wait = $this->driver->switchTo();
 
@@ -66,7 +66,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::getMouse
      */
-    public function testShouldCreateRemoteMouseInstance()
+    public function testShouldCreateRemoteMouseInstance(): void
     {
         $wait = $this->driver->getMouse();
 
@@ -76,7 +76,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::getKeyboard
      */
-    public function testShouldCreateRemoteKeyboardInstance()
+    public function testShouldCreateRemoteKeyboardInstance(): void
     {
         $wait = $this->driver->getKeyboard();
 
@@ -86,7 +86,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::getTouch
      */
-    public function testShouldCreateRemoteTouchScreenInstance()
+    public function testShouldCreateRemoteTouchScreenInstance(): void
     {
         $wait = $this->driver->getTouch();
 
@@ -96,7 +96,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::action
      */
-    public function testShouldCreateWebDriverActionsInstance()
+    public function testShouldCreateWebDriverActionsInstance(): void
     {
         $wait = $this->driver->action();
 
@@ -106,7 +106,7 @@ class RemoteWebDriverTest extends TestCase
     /**
      * @covers ::wait
      */
-    public function testShouldCreateWebDriverWaitInstance()
+    public function testShouldCreateWebDriverWaitInstance(): void
     {
         $wait = $this->driver->wait(15, 1337);
 
@@ -121,7 +121,7 @@ class RemoteWebDriverTest extends TestCase
      * @param string $expectedExceptionMessage
      * @dataProvider provideMethods
      */
-    public function testShouldThrowExceptionOnUnexpectedNullValueFromRemoteEnd($method, $expectedExceptionMessage)
+    public function testShouldThrowExceptionOnUnexpectedNullValueFromRemoteEnd($method, $expectedExceptionMessage): void
     {
         $executorMock = $this->createMock(HttpCommandExecutor::class);
         $executorMock->expects($this->once())
@@ -136,7 +136,7 @@ class RemoteWebDriverTest extends TestCase
         call_user_func([$this->driver, $method], $this->createMock(WebDriverBy::class));
     }
 
-    public function provideMethods()
+    public function provideMethods(): array
     {
         return [
             ['findElement', 'Unexpected server response to findElement command'],

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -121,8 +121,10 @@ class RemoteWebDriverTest extends TestCase
      * @param string $expectedExceptionMessage
      * @dataProvider provideMethods
      */
-    public function testShouldThrowExceptionOnUnexpectedNullValueFromRemoteEnd($method, $expectedExceptionMessage): void
-    {
+    public function testShouldThrowExceptionOnUnexpectedNullValueFromRemoteEnd(
+        string $method,
+        string $expectedExceptionMessage
+    ): void {
         $executorMock = $this->createMock(HttpCommandExecutor::class);
         $executorMock->expects($this->once())
             ->method('execute')

--- a/tests/unit/Remote/RemoteWebElementTest.php
+++ b/tests/unit/Remote/RemoteWebElementTest.php
@@ -15,7 +15,7 @@ class RemoteWebElementTest extends TestCase
      * @covers ::__construct
      * @covers ::getId
      */
-    public function testShouldConstructNewInstance()
+    public function testShouldConstructNewInstance(): void
     {
         $executeMethod = $this->createMock(RemoteExecuteMethod::class);
         $element = new RemoteWebElement($executeMethod, 333);

--- a/tests/unit/Remote/WebDriverCommandTest.php
+++ b/tests/unit/Remote/WebDriverCommandTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class WebDriverCommandTest extends TestCase
 {
-    public function testShouldSetOptionsUsingConstructor()
+    public function testShouldSetOptionsUsingConstructor(): void
     {
         $command = new WebDriverCommand('session-id-123', 'bar-baz-name', ['foo' => 'bar']);
 
@@ -15,7 +15,7 @@ class WebDriverCommandTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $command->getParameters());
     }
 
-    public function testShouldCreateNewSessionCommand()
+    public function testShouldCreateNewSessionCommand(): void
     {
         $command = WebDriverCommand::newSession(['bar' => 'baz']);
 

--- a/tests/unit/Support/ScreenshotHelperTest.php
+++ b/tests/unit/Support/ScreenshotHelperTest.php
@@ -77,7 +77,6 @@ class ScreenshotHelperTest extends TestCase
     /**
      * @dataProvider provideInvalidData
      * @param mixed $data
-     * @param string $expectedExceptionMessage
      */
     public function testShouldThrowExceptionWhenInvalidDataReceived($data, string $expectedExceptionMessage): void
     {

--- a/tests/unit/Support/ScreenshotHelperTest.php
+++ b/tests/unit/Support/ScreenshotHelperTest.php
@@ -12,7 +12,7 @@ class ScreenshotHelperTest extends TestCase
     public const BLACK_PIXEL =
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
-    public function testShouldSavePageScreenshotToSubdirectoryIfNotExists()
+    public function testShouldSavePageScreenshotToSubdirectoryIfNotExists(): void
     {
         $fullFilePath = sys_get_temp_dir() . '/' . uniqid('php-webdriver-', true) . '/screenshot.png';
         $directoryPath = dirname($fullFilePath);
@@ -36,7 +36,7 @@ class ScreenshotHelperTest extends TestCase
         rmdir($directoryPath);
     }
 
-    public function testShouldOnlyReturnBase64IfDirectoryNotProvided()
+    public function testShouldOnlyReturnBase64IfDirectoryNotProvided(): void
     {
         $executorMock = $this->createMock(RemoteExecuteMethod::class);
         $executorMock->expects($this->once())
@@ -50,7 +50,7 @@ class ScreenshotHelperTest extends TestCase
         $this->assertSame(base64_decode(self::BLACK_PIXEL, true), $output);
     }
 
-    public function testShouldSaveElementScreenshotToSubdirectoryIfNotExists()
+    public function testShouldSaveElementScreenshotToSubdirectoryIfNotExists(): void
     {
         $fullFilePath = sys_get_temp_dir() . '/' . uniqid('php-webdriver-', true) . '/screenshot.png';
         $directoryPath = dirname($fullFilePath);
@@ -79,7 +79,7 @@ class ScreenshotHelperTest extends TestCase
      * @param mixed $data
      * @param string $expectedExceptionMessage
      */
-    public function testShouldThrowExceptionWhenInvalidDataReceived($data, $expectedExceptionMessage)
+    public function testShouldThrowExceptionWhenInvalidDataReceived($data, $expectedExceptionMessage): void
     {
         $executorMock = $this->createMock(RemoteExecuteMethod::class);
         $executorMock->expects($this->once())
@@ -94,7 +94,7 @@ class ScreenshotHelperTest extends TestCase
         $helper->takePageScreenshot();
     }
 
-    public function provideInvalidData()
+    public function provideInvalidData(): array
     {
         return [
             'empty response' => [null, 'Error taking screenshot, no data received from the remote end'],

--- a/tests/unit/Support/ScreenshotHelperTest.php
+++ b/tests/unit/Support/ScreenshotHelperTest.php
@@ -79,7 +79,7 @@ class ScreenshotHelperTest extends TestCase
      * @param mixed $data
      * @param string $expectedExceptionMessage
      */
-    public function testShouldThrowExceptionWhenInvalidDataReceived($data, $expectedExceptionMessage): void
+    public function testShouldThrowExceptionWhenInvalidDataReceived($data, string $expectedExceptionMessage): void
     {
         $executorMock = $this->createMock(RemoteExecuteMethod::class);
         $executorMock->expects($this->once())

--- a/tests/unit/Support/XPathEscaperTest.php
+++ b/tests/unit/Support/XPathEscaperTest.php
@@ -11,7 +11,7 @@ class XPathEscaperTest extends TestCase
      * @param string $input
      * @param string $expectedOutput
      */
-    public function testShouldInstantiateWithCapabilitiesGivenInConstructor($input, $expectedOutput)
+    public function testShouldInstantiateWithCapabilitiesGivenInConstructor($input, $expectedOutput): void
     {
         $output = XPathEscaper::escapeQuotes($input);
 
@@ -21,7 +21,7 @@ class XPathEscaperTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideXpath()
+    public function provideXpath(): array
     {
         return [
             'empty string encapsulate in single quotes' => ['', "''"],

--- a/tests/unit/Support/XPathEscaperTest.php
+++ b/tests/unit/Support/XPathEscaperTest.php
@@ -11,7 +11,7 @@ class XPathEscaperTest extends TestCase
      * @param string $input
      * @param string $expectedOutput
      */
-    public function testShouldInstantiateWithCapabilitiesGivenInConstructor($input, $expectedOutput): void
+    public function testShouldInstantiateWithCapabilitiesGivenInConstructor(string $input, string $expectedOutput): void
     {
         $output = XPathEscaper::escapeQuotes($input);
 

--- a/tests/unit/Support/XPathEscaperTest.php
+++ b/tests/unit/Support/XPathEscaperTest.php
@@ -8,8 +8,6 @@ class XPathEscaperTest extends TestCase
 {
     /**
      * @dataProvider provideXpath
-     * @param string $input
-     * @param string $expectedOutput
      */
     public function testShouldInstantiateWithCapabilitiesGivenInConstructor(string $input, string $expectedOutput): void
     {

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -25,7 +25,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->wait = new WebDriverWait($this->driverMock, 1, 1);
     }
 
-    public function testShouldDetectTitleIsCondition()
+    public function testShouldDetectTitleIsCondition(): void
     {
         $this->driverMock->expects($this->any())
             ->method('getTitle')
@@ -38,7 +38,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    public function testShouldDetectTitleContainsCondition()
+    public function testShouldDetectTitleContainsCondition(): void
     {
         $this->driverMock->expects($this->any())
             ->method('getTitle')
@@ -51,7 +51,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    public function testShouldDetectTitleMatchesCondition()
+    public function testShouldDetectTitleMatchesCondition(): void
     {
         $this->driverMock->expects($this->any())
             ->method('getTitle')
@@ -64,7 +64,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    public function testShouldDetectUrlIsCondition()
+    public function testShouldDetectUrlIsCondition(): void
     {
         $this->driverMock->expects($this->any())
             ->method('getCurrentURL')
@@ -77,7 +77,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    public function testShouldDetectUrlContainsCondition()
+    public function testShouldDetectUrlContainsCondition(): void
     {
         $this->driverMock->expects($this->any())
             ->method('getCurrentURL')
@@ -90,7 +90,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    public function testShouldDetectUrlMatchesCondition()
+    public function testShouldDetectUrlMatchesCondition(): void
     {
         $this->driverMock->expects($this->any())
             ->method('getCurrentURL')
@@ -103,7 +103,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    public function testShouldDetectPresenceOfElementLocatedCondition()
+    public function testShouldDetectPresenceOfElementLocatedCondition(): void
     {
         $element = new RemoteWebElement(new RemoteExecuteMethod($this->driverMock), 'id');
 
@@ -120,7 +120,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
-    public function testShouldDetectNotPresenceOfElementLocatedCondition()
+    public function testShouldDetectNotPresenceOfElementLocatedCondition(): void
     {
         $element = new RemoteWebElement(new RemoteExecuteMethod($this->driverMock), 'id');
 
@@ -140,7 +140,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    public function testShouldDetectPresenceOfAllElementsLocatedByCondition()
+    public function testShouldDetectPresenceOfAllElementsLocatedByCondition(): void
     {
         $element = $this->createMock(RemoteWebElement::class);
 
@@ -157,7 +157,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertSame([$element], $this->wait->until($condition));
     }
 
-    public function testShouldDetectVisibilityOfElementLocatedCondition()
+    public function testShouldDetectVisibilityOfElementLocatedCondition(): void
     {
         // Set-up the consecutive calls to apply() as follows:
         // Call #1: throws NoSuchElementException
@@ -181,7 +181,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
-    public function testShouldDetectVisibilityOfAnyElementLocated()
+    public function testShouldDetectVisibilityOfAnyElementLocated(): void
     {
         $elementList = [
             $this->createMock(RemoteWebElement::class),
@@ -211,7 +211,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertSame([$elementList[1], $elementList[2]], $this->wait->until($condition));
     }
 
-    public function testShouldDetectInvisibilityOfElementLocatedConditionOnNoSuchElementException()
+    public function testShouldDetectInvisibilityOfElementLocatedConditionOnNoSuchElementException(): void
     {
         $element = $this->createMock(RemoteWebElement::class);
 
@@ -232,7 +232,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
-    public function testShouldDetectInvisibilityOfElementLocatedConditionOnStaleElementReferenceException()
+    public function testShouldDetectInvisibilityOfElementLocatedConditionOnStaleElementReferenceException(): void
     {
         $element = $this->createMock(RemoteWebElement::class);
 
@@ -253,7 +253,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
-    public function testShouldDetectInvisibilityOfElementLocatedConditionWhenElementBecamesInvisible()
+    public function testShouldDetectInvisibilityOfElementLocatedConditionWhenElementBecamesInvisible(): void
     {
         $element = $this->createMock(RemoteWebElement::class);
 
@@ -274,7 +274,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
-    public function testShouldDetectVisibilityOfCondition()
+    public function testShouldDetectVisibilityOfCondition(): void
     {
         $element = $this->createMock(RemoteWebElement::class);
         $element->expects($this->exactly(2))
@@ -289,7 +289,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertSame($element, $this->wait->until($condition));
     }
 
-    public function testShouldDetectElementTextContainsCondition()
+    public function testShouldDetectElementTextContainsCondition(): void
     {
         // Set-up the consecutive calls to apply() as follows:
         // Call #1: throws NoSuchElementException
@@ -313,7 +313,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
-    public function testShouldDetectElementTextIsCondition()
+    public function testShouldDetectElementTextIsCondition(): void
     {
         // Set-up the consecutive calls to apply() as follows:
         // Call #1: throws NoSuchElementException
@@ -340,7 +340,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
-    public function testShouldDetectElementTextMatchesCondition()
+    public function testShouldDetectElementTextMatchesCondition(): void
     {
         // Set-up the consecutive calls to apply() as follows:
         // Call #1: throws NoSuchElementException
@@ -368,7 +368,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
-    public function testShouldDetectElementValueContainsCondition()
+    public function testShouldDetectElementValueContainsCondition(): void
     {
         // Set-up the consecutive calls to apply() as follows:
         // Call #1: throws NoSuchElementException
@@ -397,7 +397,7 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue($this->wait->until($condition));
     }
 
-    public function testShouldDetectNumberOfWindowsToBeCondition()
+    public function testShouldDetectNumberOfWindowsToBeCondition(): void
     {
         $this->driverMock->expects($this->any())
             ->method('getWindowHandles')
@@ -414,7 +414,7 @@ class WebDriverExpectedConditionTest extends TestCase
      * @param RemoteWebElement $element
      * @param int $expectedNumberOfFindElementCalls
      */
-    private function setupDriverToReturnElementAfterAnException($element, $expectedNumberOfFindElementCalls)
+    private function setupDriverToReturnElementAfterAnException($element, $expectedNumberOfFindElementCalls): void
     {
         $consecutiveReturn = [
             $this->throwException(new NoSuchElementException('')),

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -410,10 +410,6 @@ class WebDriverExpectedConditionTest extends TestCase
         $this->assertTrue(call_user_func($condition->getApply(), $this->driverMock));
     }
 
-    /**
-     * @param RemoteWebElement $element
-     * @param int $expectedNumberOfFindElementCalls
-     */
     private function setupDriverToReturnElementAfterAnException(
         RemoteWebElement $element,
         int $expectedNumberOfFindElementCalls

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -414,8 +414,10 @@ class WebDriverExpectedConditionTest extends TestCase
      * @param RemoteWebElement $element
      * @param int $expectedNumberOfFindElementCalls
      */
-    private function setupDriverToReturnElementAfterAnException($element, $expectedNumberOfFindElementCalls): void
-    {
+    private function setupDriverToReturnElementAfterAnException(
+        RemoteWebElement $element,
+        int $expectedNumberOfFindElementCalls
+    ): void {
         $consecutiveReturn = [
             $this->throwException(new NoSuchElementException('')),
         ];

--- a/tests/unit/WebDriverKeysTest.php
+++ b/tests/unit/WebDriverKeysTest.php
@@ -15,8 +15,11 @@ class WebDriverKeysTest extends TestCase
      * @param array $expectedOssOutput
      * @param string $expectedW3cOutput
      */
-    public function testShouldEncodeKeysToFormatOfEachProtocol($keys, $expectedOssOutput, $expectedW3cOutput): void
-    {
+    public function testShouldEncodeKeysToFormatOfEachProtocol(
+        $keys,
+        array $expectedOssOutput,
+        string $expectedW3cOutput
+    ): void {
         $this->assertSame($expectedOssOutput, WebDriverKeys::encode($keys));
         $this->assertSame($expectedW3cOutput, WebDriverKeys::encode($keys, true));
     }

--- a/tests/unit/WebDriverKeysTest.php
+++ b/tests/unit/WebDriverKeysTest.php
@@ -12,8 +12,6 @@ class WebDriverKeysTest extends TestCase
     /**
      * @dataProvider provideKeys
      * @param mixed $keys
-     * @param array $expectedOssOutput
-     * @param string $expectedW3cOutput
      */
     public function testShouldEncodeKeysToFormatOfEachProtocol(
         $keys,

--- a/tests/unit/WebDriverKeysTest.php
+++ b/tests/unit/WebDriverKeysTest.php
@@ -15,7 +15,7 @@ class WebDriverKeysTest extends TestCase
      * @param array $expectedOssOutput
      * @param string $expectedW3cOutput
      */
-    public function testShouldEncodeKeysToFormatOfEachProtocol($keys, $expectedOssOutput, $expectedW3cOutput)
+    public function testShouldEncodeKeysToFormatOfEachProtocol($keys, $expectedOssOutput, $expectedW3cOutput): void
     {
         $this->assertSame($expectedOssOutput, WebDriverKeys::encode($keys));
         $this->assertSame($expectedW3cOutput, WebDriverKeys::encode($keys, true));
@@ -24,7 +24,7 @@ class WebDriverKeysTest extends TestCase
     /**
      * @return array[]
      */
-    public function provideKeys()
+    public function provideKeys(): array
     {
         return [
             'empty string' => ['', [''], ''],

--- a/tests/unit/WebDriverOptionsTest.php
+++ b/tests/unit/WebDriverOptionsTest.php
@@ -22,7 +22,7 @@ class WebDriverOptionsTest extends TestCase
             ->getMock();
     }
 
-    public function testShouldAddCookieFromArray()
+    public function testShouldAddCookieFromArray(): void
     {
         $cookieInArray = [
             'name' => 'cookieName',
@@ -43,7 +43,7 @@ class WebDriverOptionsTest extends TestCase
         $options->addCookie($cookieInArray);
     }
 
-    public function testShouldAddCookieFromCookieObject()
+    public function testShouldAddCookieFromCookieObject(): void
     {
         $cookieObject = new Cookie('cookieName', 'someValue');
         $cookieObject->setPath('/bar');
@@ -71,7 +71,7 @@ class WebDriverOptionsTest extends TestCase
         $options->addCookie($cookieObject);
     }
 
-    public function testShouldNotAllowToCreateCookieFromDifferentObjectThanCookie()
+    public function testShouldNotAllowToCreateCookieFromDifferentObjectThanCookie(): void
     {
         $notCookie = new \stdClass();
 
@@ -82,7 +82,7 @@ class WebDriverOptionsTest extends TestCase
         $options->addCookie($notCookie);
     }
 
-    public function testShouldGetAllCookies()
+    public function testShouldGetAllCookies(): void
     {
         $this->executor->expects($this->once())
             ->method('execute')
@@ -118,7 +118,7 @@ class WebDriverOptionsTest extends TestCase
         $this->assertSame('secondCookie', $cookies[1]->getName());
     }
 
-    public function testShouldGetCookieByName()
+    public function testShouldGetCookieByName(): void
     {
         $this->executor->expects($this->once())
             ->method('execute')
@@ -157,7 +157,7 @@ class WebDriverOptionsTest extends TestCase
         $this->assertTrue($cookie->isSecure());
     }
 
-    public function testShouldReturnNullIfCookieWithNameNotFound()
+    public function testShouldReturnNullIfCookieWithNameNotFound(): void
     {
         $this->executor->expects($this->once())
             ->method('execute')
@@ -180,7 +180,7 @@ class WebDriverOptionsTest extends TestCase
         $this->assertNull($options->getCookieNamed('notExistingCookie'));
     }
 
-    public function testShouldReturnTimeoutsInstance()
+    public function testShouldReturnTimeoutsInstance(): void
     {
         $options = new WebDriverOptions($this->executor);
 
@@ -188,7 +188,7 @@ class WebDriverOptionsTest extends TestCase
         $this->assertInstanceOf(WebDriverTimeouts::class, $timeouts);
     }
 
-    public function testShouldReturnWindowInstance()
+    public function testShouldReturnWindowInstance(): void
     {
         $options = new WebDriverOptions($this->executor);
 


### PR DESCRIPTION
- Add return types to test methods
- Add typehints to test methods
- Remove superfluous phpdoc ( = phpdoc, which adds no information on top of what is already in typehint ) in the whole codebase (lib and tests)

Typehints were not added to the source code except for tests because this could cause BC break. (This is also why the rule is commented in `.php-cs-fixer.dist.php`)