### PR TITLE
Test: Use strict types in tests

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,6 +18,7 @@ return (new PhpCsFixer\Config())
         'compact_nullable_typehint' => true,
         'concat_space' => ['spacing' => 'one'],
         'declare_equal_normalize' => true,
+        //'declare_strict_types' => true, // TODO: used only in tests, use in lib in next major version
         'fopen_flag_order' => true,
         'fopen_flags' => true,
         'full_opening_tag' => true,
@@ -101,11 +102,11 @@ return (new PhpCsFixer\Config())
         'phpdoc_scalar' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
-        //'phpdoc_to_param_type' => true,
-        //'phpdoc_to_return_type' => true,
+        //'phpdoc_to_param_type' => true, // TODO: used only in tests, use in lib in next major version
+        //'phpdoc_to_return_type' => true, // TODO: used only in tests, use in lib in next major version
         'phpdoc_types' => true,
         'phpdoc_var_annotation_correct_order' => true,
-        //'pow_to_exponentiation' => true,
+        'pow_to_exponentiation' => true,
         'psr_autoloading' => true,
         'random_api_migration' => true,
         'self_accessor' => true,
@@ -126,7 +127,7 @@ return (new PhpCsFixer\Config())
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'visibility_required' => ['elements' => ['method', 'property', 'const']],
-        //'void_return' => true,
+        //'void_return' => true, // TODO: used only in tests, use in lib in next major version
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
     ])

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,3 @@
-<?php
+<?php declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/functional/Chrome/ChromeDevToolsDriverTest.php
+++ b/tests/functional/Chrome/ChromeDevToolsDriverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Chrome;
 

--- a/tests/functional/Chrome/ChromeDriverServiceTest.php
+++ b/tests/functional/Chrome/ChromeDriverServiceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Chrome;
 

--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Chrome;
 

--- a/tests/functional/FileUploadTest.php
+++ b/tests/functional/FileUploadTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/Firefox/FirefoxDriverServiceTest.php
+++ b/tests/functional/Firefox/FirefoxDriverServiceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Firefox;
 

--- a/tests/functional/Firefox/FirefoxDriverTest.php
+++ b/tests/functional/Firefox/FirefoxDriverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Firefox;
 

--- a/tests/functional/Firefox/FirefoxProfileTest.php
+++ b/tests/functional/Firefox/FirefoxProfileTest.php
@@ -1,17 +1,4 @@
-<?php
-// Copyright 2004-present Facebook. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Firefox;
 

--- a/tests/functional/RemoteKeyboardTest.php
+++ b/tests/functional/RemoteKeyboardTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/RemoteTargetLocatorTest.php
+++ b/tests/functional/RemoteTargetLocatorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/RemoteWebDriverFindElementTest.php
+++ b/tests/functional/RemoteWebDriverFindElementTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/RemoteWebDriverTest.php
+++ b/tests/functional/RemoteWebDriverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/RemoteWebElementTest.php
+++ b/tests/functional/RemoteWebElementTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/ReportSauceLabsStatusListener.php
+++ b/tests/functional/ReportSauceLabsStatusListener.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/RetrieveEventsTrait.php
+++ b/tests/functional/RetrieveEventsTrait.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/ShadowDomTest.php
+++ b/tests/functional/ShadowDomTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/TestPage.php
+++ b/tests/functional/TestPage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverActionsTest.php
+++ b/tests/functional/WebDriverActionsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverAlertTest.php
+++ b/tests/functional/WebDriverAlertTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverByTest.php
+++ b/tests/functional/WebDriverByTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverCheckboxesTest.php
+++ b/tests/functional/WebDriverCheckboxesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverNavigationTest.php
+++ b/tests/functional/WebDriverNavigationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverOptionsCookiesTest.php
+++ b/tests/functional/WebDriverOptionsCookiesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverRadiosTest.php
+++ b/tests/functional/WebDriverRadiosTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 
@@ -89,7 +89,7 @@ class WebDriverTestCase extends TestCase
 
             if (getenv('BROWSER_NAME') === 'safari') {
                 // The Safari instance is already paired with another WebDriver session
-                usleep(2e5); // 200ms
+                usleep(200000); // 200ms
             }
         }
     }

--- a/tests/functional/WebDriverTimeoutsTest.php
+++ b/tests/functional/WebDriverTimeoutsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/WebDriverWindowTest.php
+++ b/tests/functional/WebDriverWindowTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/functional/web/slow_pixel.png.php
+++ b/tests/functional/web/slow_pixel.png.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 sleep(5);
 

--- a/tests/functional/web/submit.php
+++ b/tests/functional/web/submit.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 ?><!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/functional/web/upload.php
+++ b/tests/functional/web/upload.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 ?><!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/unit/CookieTest.php
+++ b/tests/unit/CookieTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/unit/Exception/Internal/DriverServerDiedExceptionTest.php
+++ b/tests/unit/Exception/Internal/DriverServerDiedExceptionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Exception\Internal;
 

--- a/tests/unit/Exception/WebDriverExceptionTest.php
+++ b/tests/unit/Exception/WebDriverExceptionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Exception;
 

--- a/tests/unit/Firefox/FirefoxOptionsTest.php
+++ b/tests/unit/Firefox/FirefoxOptionsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Firefox;
 

--- a/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverButtonReleaseActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverClickAndHoldActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverContextClickActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverCoordinatesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverDoubleClickActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyDownActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverKeyUpActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseMoveActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverMouseToOffsetActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSendKeysActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
+++ b/tests/unit/Interactions/Internal/WebDriverSingleKeyActionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Interactions\Internal;
 

--- a/tests/unit/Remote/CustomWebDriverCommandTest.php
+++ b/tests/unit/Remote/CustomWebDriverCommandTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Remote;
 

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Remote;
 

--- a/tests/unit/Remote/HttpCommandExecutorTest.php
+++ b/tests/unit/Remote/HttpCommandExecutorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Remote;
 

--- a/tests/unit/Remote/LocalFileDetectorTest.php
+++ b/tests/unit/Remote/LocalFileDetectorTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Remote;
 

--- a/tests/unit/Remote/RemoteWebDriverTest.php
+++ b/tests/unit/Remote/RemoteWebDriverTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Remote;
 

--- a/tests/unit/Remote/RemoteWebElementTest.php
+++ b/tests/unit/Remote/RemoteWebElementTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Remote;
 

--- a/tests/unit/Remote/WebDriverCommandTest.php
+++ b/tests/unit/Remote/WebDriverCommandTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Remote;
 

--- a/tests/unit/Support/ScreenshotHelperTest.php
+++ b/tests/unit/Support/ScreenshotHelperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Support;
 

--- a/tests/unit/Support/XPathEscaperTest.php
+++ b/tests/unit/Support/XPathEscaperTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver\Support;
 

--- a/tests/unit/WebDriverExpectedConditionTest.php
+++ b/tests/unit/WebDriverExpectedConditionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/unit/WebDriverKeysTest.php
+++ b/tests/unit/WebDriverKeysTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 

--- a/tests/unit/WebDriverOptionsTest.php
+++ b/tests/unit/WebDriverOptionsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Facebook\WebDriver;
 


### PR DESCRIPTION
Used only in tests - it could cause BC break in the lib part of codebase.