### PR TITLE
Replace ChromeOptions::CAPABILITY with W3C compatible value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This project versioning adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Capability key `ChromeOptions::CAPABILITY_W3C` used to set ChromeOptions is now deprecated in favor of `ChromeOptions::CAPABILITY`, which now also contains the W3C compatible value (`goog:chromeOptions`).
+- ChromeOptions are now passed to the driver always as a W3C compatible key `goog:chromeOptions`, even in the deprecated OSS JsonWire payload (as ChromeDriver [supports](https://bugs.chromium.org/p/chromedriver/issues/detail?id=1786) this since 2017).
 
 ## 1.14.0 - 2023-02-09
 ### Added

--- a/lib/Chrome/ChromeOptions.php
+++ b/lib/Chrome/ChromeOptions.php
@@ -14,14 +14,13 @@ use ReturnTypeWillChange;
 class ChromeOptions implements JsonSerializable
 {
     /**
-     * The key of chromeOptions in desired capabilities (in legacy OSS JsonWire protocol)
-     * @todo Replace value with 'goog:chromeOptions' after JsonWire protocol support is removed
+     * The key of chromeOptions in desired capabilities
      */
-    public const CAPABILITY = 'chromeOptions';
+    public const CAPABILITY = 'goog:chromeOptions';
     /**
-     * The key of chromeOptions in desired capabilities (in W3C compatible protocol)
+     * @deprecated Use CAPABILITY instead
      */
-    public const CAPABILITY_W3C = 'goog:chromeOptions';
+    public const CAPABILITY_W3C = self::CAPABILITY;
     /**
      * @var array
      */

--- a/lib/Remote/DesiredCapabilities.php
+++ b/lib/Remote/DesiredCapabilities.php
@@ -20,7 +20,6 @@ class DesiredCapabilities implements WebDriverCapabilities
         WebDriverCapabilityType::PLATFORM => 'platformName',
         WebDriverCapabilityType::VERSION => 'browserVersion',
         WebDriverCapabilityType::ACCEPT_SSL_CERTS => 'acceptInsecureCerts',
-        ChromeOptions::CAPABILITY => ChromeOptions::CAPABILITY_W3C,
     ];
 
     public function __construct(array $capabilities = [])
@@ -250,16 +249,7 @@ class DesiredCapabilities implements WebDriverCapabilities
 
         // Convert ChromeOptions
         if (array_key_exists(ChromeOptions::CAPABILITY, $ossCapabilities)) {
-            if (array_key_exists(ChromeOptions::CAPABILITY_W3C, $ossCapabilities)) {
-                $w3cCapabilities[ChromeOptions::CAPABILITY_W3C] = new \ArrayObject(
-                    array_merge_recursive(
-                        (array) $ossCapabilities[ChromeOptions::CAPABILITY],
-                        (array) $ossCapabilities[ChromeOptions::CAPABILITY_W3C]
-                    )
-                );
-            } else {
-                $w3cCapabilities[ChromeOptions::CAPABILITY_W3C] = $ossCapabilities[ChromeOptions::CAPABILITY];
-            }
+            $w3cCapabilities[ChromeOptions::CAPABILITY] = $ossCapabilities[ChromeOptions::CAPABILITY];
         }
 
         // Convert Firefox profile

--- a/tests/unit/Remote/DesiredCapabilitiesTest.php
+++ b/tests/unit/Remote/DesiredCapabilitiesTest.php
@@ -280,23 +280,6 @@ class DesiredCapabilitiesTest extends TestCase
                     ),
                 ],
             ],
-            'chromeOptions should be merged if already defined' => [
-                new DesiredCapabilities([
-                    ChromeOptions::CAPABILITY => $chromeOptions,
-                    ChromeOptions::CAPABILITY_W3C => [
-                        'debuggerAddress' => '127.0.0.1:38947',
-                        'args' => ['window-size=1024,768'],
-                    ],
-                ]),
-                [
-                    'goog:chromeOptions' => new \ArrayObject(
-                        [
-                            'args' => ['--headless', 'window-size=1024,768'],
-                            'debuggerAddress' => '127.0.0.1:38947',
-                        ]
-                    ),
-                ],
-            ],
             'firefox_profile should be converted' => [
                 new DesiredCapabilities([
                     FirefoxDriver::PROFILE => $firefoxProfileEncoded,


### PR DESCRIPTION
We already have `ChromeOptions::CAPABILITY_W3C` and we convert ChromeOptions::CAPABILITY and ChromeOptions::CAPABILITY_W3C differently for OSS and W3C NewSession payload.

However, this breaks things in new ChromeDriver (#1061), so we will now use W3C compatible `goog:chromeOptions` for both and we will no longer attempt to merge the values. This should not break anything, as this is supported by Chrome since 2017, see https://bugs.chromium.org/p/chromedriver/issues/detail?id=1786 .