### PR TITLE
Update WebDriverSelect test to support multiple selectors

### DIFF
--- a/lib/WebDriverSelect.php
+++ b/lib/WebDriverSelect.php
@@ -26,7 +26,14 @@ class WebDriverSelect implements WebDriverSelectInterface
         }
         $this->element = $element;
         $value = $element->getAttribute('multiple');
-        $this->isMulti = $value === 'true';
+
+        /**
+         * There is a bug in safari webdriver that returns 'multiple' instead of 'true' which does not match the spec.
+         * Apple Feedback #FB12760673
+         *
+         * @see https://www.w3.org/TR/webdriver2/#get-element-attribute
+         */
+        $this->isMulti = $value === 'true' || $value === 'multiple';
     }
 
     public function isMultiple()

--- a/tests/functional/WebDriverSelectTest.php
+++ b/tests/functional/WebDriverSelectTest.php
@@ -20,10 +20,13 @@ class WebDriverSelectTest extends WebDriverTestCase
         $this->driver->get($this->getTestPageUrl(TestPage::FORM));
     }
 
-    public function testShouldCreateNewInstanceForSelectElementAndDetectIfItIsMultiple(): void
+    /**
+     * @dataProvider multipleSelectDataProvider
+     */
+    public function testShouldCreateNewInstanceForSelectElementAndDetectIfItIsMultiple(string $selector): void
     {
         $originalElement = $this->driver->findElement(WebDriverBy::cssSelector('#select'));
-        $originalMultipleElement = $this->driver->findElement(WebDriverBy::cssSelector('#select-multiple'));
+        $originalMultipleElement = $this->driver->findElement(WebDriverBy::cssSelector($selector));
 
         $select = new WebDriverSelect($originalElement);
         $selectMultiple = new WebDriverSelect($originalMultipleElement);
@@ -33,6 +36,15 @@ class WebDriverSelectTest extends WebDriverTestCase
 
         $this->assertInstanceOf(WebDriverSelect::class, $selectMultiple);
         $this->assertTrue($selectMultiple->isMultiple());
+    }
+
+    public static function multipleSelectDataProvider(): array
+    {
+        return [
+            ['#select-multiple'],
+            ['#select-multiple-2'],
+            ['#select-multiple-3'],
+        ];
     }
 
     public function testShouldThrowExceptionWhenNotInstantiatedOnSelectElement(): void

--- a/tests/functional/web/form.html
+++ b/tests/functional/web/form.html
@@ -48,6 +48,22 @@
             <option value="fourth">Fourth  with   spaces   inside</option>
             <option value="fifth">   Fifth surrounded by spaces    </option>
         </select>
+        <label for="select-multiple-2"></label>
+        <select name="select-multiple-2" id="select-multiple-2" multiple="multiple">
+            <option value="first">First</option>
+            <option value="second">This is second option</option>
+            <option value="third">This is not second option</option>
+            <option value="fourth">Fourth  with   spaces   inside</option>
+            <option value="fifth">   Fifth surrounded by spaces    </option>
+        </select>
+        <label for="select-multiple-3"></label>
+        <select name="select-multiple-3" id="select-multiple-3" multiple="">
+            <option value="first">First</option>
+            <option value="second">This is second option</option>
+            <option value="third">This is not second option</option>
+            <option value="fourth">Fourth  with   spaces   inside</option>
+            <option value="fifth">   Fifth surrounded by spaces    </option>
+        </select>
         <br>
 
         <fieldset>


### PR DESCRIPTION
This commit updates WebDriverSelectTest.php to provide support for selecting multiple selectors. 
It extends the testShouldCreateNewInstanceForSelectElementAndDetectIfItIsMultiple() function with a data provider to test multiple select elements.
The changes also include corrections to WebDriverSelect.php to properly adhere to spec for Boolean attributes, by ensuring that the attribute value is 'true' or 'multiple'. 
Additional select options have also been added to the form.html file to support the new tests.

https://html.spec.whatwg.org/#boolean-attributes