### PR TITLE
Fix path to chromedriver in tests on latest Ubuntu

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -160,7 +160,7 @@ jobs:
           # When running directly against Firefox, we test only using geckodriver (not against legacy Firefox =<45), so we must declare GECKODRIVER=1
           GECKODRIVER: "${{ (matrix.browser == 'firefox' && !matrix.selenium-server) && '1' || '0' }}"
           # Provide CHROMEDRIVER_PATH and GECKODRIVER_PATH so that tests for local web drivers are able to start the browser
-          CHROMEDRIVER_PATH: "${{ (matrix.browser == 'chrome' && !matrix.selenium-server) && '/usr/local/share/chrome_driver/chromedriver' || '' }}"
+          CHROMEDRIVER_PATH: "${{ (matrix.browser == 'chrome' && !matrix.selenium-server) && '/usr/local/share/chromedriver-linux64/chromedriver' || '' }}"
           GECKODRIVER_PATH: "${{ (matrix.browser == 'firefox' && !matrix.selenium-server) && '/usr/local/share/gecko_driver/geckodriver' || '' }}"
           DISABLE_W3C_PROTOCOL: "${{ matrix.w3c && '0' || '1' }}"
           SELENIUM_SERVER: "${{ matrix.selenium-server && '1' || '0' }}"

--- a/lib/Interactions/Internal/WebDriverCoordinates.php
+++ b/lib/Interactions/Internal/WebDriverCoordinates.php
@@ -11,7 +11,8 @@ use Facebook\WebDriver\WebDriverPoint;
 class WebDriverCoordinates
 {
     /**
-     * @var null
+     * @var mixed
+     * @todo remove in next major version (if it is unused)
      */
     private $onScreen;
     /**
@@ -28,7 +29,7 @@ class WebDriverCoordinates
     private $auxiliary;
 
     /**
-     * @param null $on_screen
+     * @param mixed $on_screen
      * @param string $auxiliary
      */
     public function __construct($on_screen, callable $in_view_port, callable $on_page, $auxiliary)

--- a/lib/Local/LocalWebDriver.php
+++ b/lib/Local/LocalWebDriver.php
@@ -12,17 +12,7 @@ use Facebook\WebDriver\Remote\RemoteWebDriver;
  */
 abstract class LocalWebDriver extends RemoteWebDriver
 {
-    /**
-     * @param string $selenium_server_url
-     * @param null $desired_capabilities
-     * @param null $connection_timeout_in_ms
-     * @param null $request_timeout_in_ms
-     * @param null $http_proxy
-     * @param null $http_proxy_port
-     * @throws LogicException
-     * @return RemoteWebDriver
-     * @todo Remove in next major version (should not be inherited)
-     */
+    // @todo Remove in next major version (should not be inherited)
     public static function create(
         $selenium_server_url = 'http://localhost:4444/wd/hub',
         $desired_capabilities = null,
@@ -35,15 +25,7 @@ abstract class LocalWebDriver extends RemoteWebDriver
         throw LogicException::forError('Use start() method to start local WebDriver.');
     }
 
-    /**
-     * @param string $session_id
-     * @param string $selenium_server_url
-     * @param null $connection_timeout_in_ms
-     * @param null $request_timeout_in_ms
-     * @throws LogicException
-     * @return RemoteWebDriver
-     * @todo Remove in next major version (should not be inherited)
-     */
+    // @todo Remove in next major version (should not be inherited)
     public static function createBySessionID(
         $session_id,
         $selenium_server_url = 'http://localhost:4444/wd/hub',


### PR DESCRIPTION
The path [is now different](https://github.com/actions/runner-images/blob/ubuntu22/20230724.1/images/linux/Ubuntu2204-Readme.md#environment-variables-1) and the tests are now failing with
`Facebook\WebDriver\Exception\Internal\IOException: File is not executable. Make sure the path is correct or use environment variable to specify location of the executable. ("/usr/local/share/chrome_driver/chromedriver")`