### PR TITLE
Add support for Symfony Process 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "ext-json": "*",
     "ext-zip": "*",
     "symfony/polyfill-mbstring": "^1.12",
-    "symfony/process": "^5.0 || ^6.0"
+    "symfony/process": "^5.0 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.20.0",


### PR DESCRIPTION
Symfony 7 should be available next month (November 2023): https://symfony.com/releases/7.0 and it would be great if we can start testing `php-webdriver` using upcoming Symfony 7.