### PR TITLE
Use new Chrome headless mode instead of old chrome-headless-shell

### DIFF
--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -87,7 +87,7 @@ class ChromeDriverTest extends TestCase
 
         // Add --no-sandbox as a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
         $chromeOptions = new ChromeOptions();
-        $chromeOptions->addArguments(['--no-sandbox', '--headless']);
+        $chromeOptions->addArguments(['--no-sandbox', '--headless=new']);
         $chromeOptions->setExperimentalOption('w3c', $w3cDialect);
         $desiredCapabilities = DesiredCapabilities::chrome();
         $desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -48,7 +48,7 @@ class WebDriverTestCase extends TestCase
                 $chromeOptions = new ChromeOptions();
                 // --no-sandbox is a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
                 $chromeOptions->addArguments([
-                    '--headless',
+                    '--headless=new',
                     '--window-size=1024,768',
                     '--no-sandbox',
                     '--force-color-profile=srgb',


### PR DESCRIPTION
https://developer.chrome.com/blog/chrome-headless-shell

This fixes failing builds, because the "old" headless chrome reports its name as "chrome-headless-shell", not chrome, breaking some tests.