### PR TITLE
Test: Remove SauceLabs workaround for MS Edge

### DIFF
--- a/tests/functional/RemoteWebDriverCreateTest.php
+++ b/tests/functional/RemoteWebDriverCreateTest.php
@@ -140,9 +140,6 @@ class RemoteWebDriverCreateTest extends WebDriverTestCase
 
         $expectedBrowserName = $this->desiredCapabilities->getBrowserName();
 
-        if ($this->isSauceLabsBuild() && $expectedBrowserName === 'MicrosoftEdge') {
-            $expectedBrowserName = 'msedge'; // SauceLabs for some reason reports MicrosoftEdge as msedge
-        }
         $this->assertEqualsIgnoringCase(
             $expectedBrowserName,
             $returnedCapabilities->getBrowserName()


### PR DESCRIPTION
Looks like SauceLabs fixed the issue, so we need to remove the workaround.
https://github.com/php-webdriver/php-webdriver/actions/runs/7852184530/job/21430248871#step:7:36