### PR TITLE
Disable search engine selection pop-up in tests for chrome 127+ 

### DIFF
--- a/tests/functional/Chrome/ChromeDriverTest.php
+++ b/tests/functional/Chrome/ChromeDriverTest.php
@@ -87,7 +87,7 @@ class ChromeDriverTest extends TestCase
 
         // Add --no-sandbox as a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
         $chromeOptions = new ChromeOptions();
-        $chromeOptions->addArguments(['--no-sandbox', '--headless=new']);
+        $chromeOptions->addArguments(['--no-sandbox', '--headless=new', '--disable-search-engine-choice-screen']);
         $chromeOptions->setExperimentalOption('w3c', $w3cDialect);
         $desiredCapabilities = DesiredCapabilities::chrome();
         $desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -46,12 +46,12 @@ class WebDriverTestCase extends TestCase
 
             if ($browserName === WebDriverBrowserType::CHROME) {
                 $chromeOptions = new ChromeOptions();
-                // --no-sandbox is a workaround for Chrome crashing: https://github.com/SeleniumHQ/selenium/issues/4961
                 $chromeOptions->addArguments([
                     '--headless=new',
                     '--window-size=1024,768',
-                    '--no-sandbox',
+                    '--no-sandbox', // workaround for https://github.com/SeleniumHQ/selenium/issues/4961
                     '--force-color-profile=srgb',
+                    '--disable-search-engine-choice-screen',
                 ]);
 
                 if (!static::isW3cProtocolBuild()) {


### PR DESCRIPTION
The pop-up windows starts to appear with Chrome 127+ in EU and EEA and it blocks view on the tested page (but the tests run ok, just the view is blocked by the pop-up).
