### PR TITLE
Allow running tests in headfull mode (useful for testing)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -69,7 +69,7 @@ composer all
 composer test -- --testsuite functional
 ```
 
-If you want to run tests in different browser then "htmlunit" (Chrome or Firefox), you need to setup the browser driver (Chromedriver/Geckodriver), as it is [explained in wiki](https://github.com/php-webdriver/php-webdriver/wiki/Chrome)
+If you want to run tests in different browser then "htmlunit" (Chrome or Firefox), you need to set up the browser driver (Chromedriver/Geckodriver), as it is [explained in wiki](https://github.com/php-webdriver/php-webdriver/wiki/Chrome)
 and then the `BROWSER_NAME` environment variable:
 
 ```sh
@@ -83,5 +83,12 @@ To test with Firefox/Geckodriver, you must also set `GECKODRIVER` environment va
 ```sh
 export GECKODRIVER=1
 export BROWSER_NAME="firefox"
+composer all
+```
+
+To see the tests as they are happening (in the browser window), you can disable headless mode. This is useful eg. when debugging the tests or writing a new one:
+
+```sh
+export DISABLE_HEADLESS="1"
 composer all
 ```

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -162,6 +162,7 @@ jobs:
           CHROMEDRIVER_PATH: "${{ (matrix.browser == 'chrome' && !matrix.selenium-server) && '/usr/local/share/chromedriver-linux64/chromedriver' || '' }}"
           GECKODRIVER_PATH: "${{ (matrix.browser == 'firefox' && !matrix.selenium-server) && '/usr/local/share/gecko_driver/geckodriver' || '' }}"
           DISABLE_W3C_PROTOCOL: "${{ matrix.w3c && '0' || '1' }}"
+          DISABLE_HEADLESS: '0' # We always run headless tests on GitHub Actions
           SELENIUM_SERVER: "${{ matrix.selenium-server && '1' || '0' }}"
         run: |
           if [ "$BROWSER_NAME" = "chrome" ]; then EXCLUDE_GROUP+="exclude-chrome,"; fi

--- a/tests/functional/WebDriverTestCase.php
+++ b/tests/functional/WebDriverTestCase.php
@@ -38,6 +38,7 @@ class WebDriverTestCase extends TestCase
             $this->setUpSauceLabs();
         } else {
             $browserName = getenv('BROWSER_NAME');
+            $disableHeadless = filter_var(getenv('DISABLE_HEADLESS') ?: '', FILTER_VALIDATE_BOOLEAN);
             if ($browserName === '' || $browserName === false) {
                 $this->markTestSkipped(
                     'To execute functional tests browser name must be provided in BROWSER_NAME environment variable'
@@ -46,13 +47,17 @@ class WebDriverTestCase extends TestCase
 
             if ($browserName === WebDriverBrowserType::CHROME) {
                 $chromeOptions = new ChromeOptions();
+
                 $chromeOptions->addArguments([
-                    '--headless=new',
                     '--window-size=1024,768',
                     '--no-sandbox', // workaround for https://github.com/SeleniumHQ/selenium/issues/4961
                     '--force-color-profile=srgb',
                     '--disable-search-engine-choice-screen',
                 ]);
+
+                if (!$disableHeadless) {
+                    $chromeOptions->addArguments(['--headless=new']);
+                }
 
                 if (!static::isW3cProtocolBuild()) {
                     $chromeOptions->setExperimentalOption('w3c', false);
@@ -61,7 +66,11 @@ class WebDriverTestCase extends TestCase
                 $this->desiredCapabilities->setCapability(ChromeOptions::CAPABILITY, $chromeOptions);
             } elseif ($browserName === WebDriverBrowserType::FIREFOX) {
                 $firefoxOptions = new FirefoxOptions();
-                $firefoxOptions->addArguments(['-headless']);
+
+                if (!$disableHeadless) {
+                    $firefoxOptions->addArguments(['-headless']);
+                }
+
                 $this->desiredCapabilities->setCapability(FirefoxOptions::CAPABILITY, $firefoxOptions);
             }
 


### PR DESCRIPTION
- defines new env var (`DISABLE_HEADLESS`) to specifically enable/disable headless mode
- by default headless is enabled (for BC reasons)
- documented in the same place `BROWSER_NAME` is documented