### PR TITLE
Fix shadow dom tests

### DIFF
--- a/tests/functional/ShadowDomTest.php
+++ b/tests/functional/ShadowDomTest.php
@@ -41,11 +41,6 @@ class ShadowDomTest extends WebDriverTestCase
         $element->getShadowRoot();
     }
 
-    /**
-     * @group exclude-firefox
-     *        https://bugzilla.mozilla.org/show_bug.cgi?id=1700097
-     *        Finding elements in shadow DOM is not implemented in Geckodriver
-     */
     public function testShouldFindElementUnderShadowRoot(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));
@@ -61,11 +56,6 @@ class ShadowDomTest extends WebDriverTestCase
         $this->assertCount(2, $elementsInShadow);
     }
 
-    /**
-     * @group exclude-firefox
-     *        https://bugzilla.mozilla.org/show_bug.cgi?id=1700097
-     *        Finding elements in shadow DOM is not implemented in Geckodriver
-     */
     public function testShouldReferenceTheSameShadowRootAsFromExecuteScript(): void
     {
         $this->driver->get($this->getTestPageUrl(TestPage::WEB_COMPONENTS));

--- a/tests/functional/web/web_components.html
+++ b/tests/functional/web/web_components.html
@@ -16,7 +16,7 @@
 <body>
 <h1>WebComponents and Shadow DOM tests</h1>
 
-<div><label>Input out of Shadow DOM: <input id="no-shadow-root"/></label></div>
+<p id="no-shadow-root">Element out of Shadow DOM</p>
 <div>
     <custom-checkbox-element></custom-checkbox-element>
 </div>


### PR DESCRIPTION
Chromedriver now provides implicit access to shadow root for all input elements in a closed mode (instead of throwing an NoSuchShadowRootException).  This breaks our tests. See https://issues.chromium.org/issues/372834222

Also Geckodriver already supports Shadow dom, meaning we can enable these tests. See https://github.com/mozilla/geckodriver/issues/2005