### PR TITLE
Clarify and fix timeout value type

### DIFF
--- a/lib/WebDriverTimeouts.php
+++ b/lib/WebDriverTimeouts.php
@@ -28,7 +28,7 @@ class WebDriverTimeouts
     /**
      * Specify the amount of time the driver should wait when searching for an element if it is not immediately present.
      *
-     * @param int $seconds Wait time in second.
+     * @param float $seconds Wait time in seconds.
      * @return WebDriverTimeouts The current instance.
      */
     public function implicitlyWait($seconds)
@@ -36,7 +36,7 @@ class WebDriverTimeouts
         if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::IMPLICITLY_WAIT,
-                ['implicit' => $seconds * 1000]
+                ['implicit' => floor($seconds * 1000)]
             );
 
             return $this;
@@ -44,7 +44,7 @@ class WebDriverTimeouts
 
         $this->executor->execute(
             DriverCommand::IMPLICITLY_WAIT,
-            ['ms' => $seconds * 1000]
+            ['ms' => floor($seconds * 1000)]
         );
 
         return $this;
@@ -53,7 +53,7 @@ class WebDriverTimeouts
     /**
      * Set the amount of time to wait for an asynchronous script to finish execution before throwing an error.
      *
-     * @param int $seconds Wait time in second.
+     * @param float $seconds Wait time in seconds.
      * @return WebDriverTimeouts The current instance.
      */
     public function setScriptTimeout($seconds)
@@ -61,7 +61,7 @@ class WebDriverTimeouts
         if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::SET_SCRIPT_TIMEOUT,
-                ['script' => $seconds * 1000]
+                ['script' => floor($seconds * 1000)]
             );
 
             return $this;
@@ -69,7 +69,7 @@ class WebDriverTimeouts
 
         $this->executor->execute(
             DriverCommand::SET_SCRIPT_TIMEOUT,
-            ['ms' => $seconds * 1000]
+            ['ms' => floor($seconds * 1000)]
         );
 
         return $this;
@@ -78,7 +78,7 @@ class WebDriverTimeouts
     /**
      * Set the amount of time to wait for a page load to complete before throwing an error.
      *
-     * @param int $seconds Wait time in second.
+     * @param float $seconds Wait time in seconds.
      * @return WebDriverTimeouts The current instance.
      */
     public function pageLoadTimeout($seconds)
@@ -86,7 +86,7 @@ class WebDriverTimeouts
         if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::SET_SCRIPT_TIMEOUT,
-                ['pageLoad' => $seconds * 1000]
+                ['pageLoad' => floor($seconds * 1000)]
             );
 
             return $this;
@@ -94,7 +94,7 @@ class WebDriverTimeouts
 
         $this->executor->execute(DriverCommand::SET_TIMEOUT, [
             'type' => 'page load',
-            'ms' => $seconds * 1000,
+            'ms' => floor($seconds * 1000),
         ]);
 
         return $this;

--- a/lib/WebDriverTimeouts.php
+++ b/lib/WebDriverTimeouts.php
@@ -28,7 +28,7 @@ class WebDriverTimeouts
     /**
      * Specify the amount of time the driver should wait when searching for an element if it is not immediately present.
      *
-     * @param float $seconds Wait time in seconds.
+     * @param null|int|float $seconds Wait time in seconds.
      * @return WebDriverTimeouts The current instance.
      */
     public function implicitlyWait($seconds)
@@ -36,12 +36,15 @@ class WebDriverTimeouts
         if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::IMPLICITLY_WAIT,
-                ['implicit' => floor($seconds * 1000)]
+                ['implicit' => $seconds === null ? null : floor($seconds * 1000)]
             );
 
             return $this;
         }
 
+        if ($seconds === null) {
+            throw new \InvalidArgumentException('JsonWire Protocol timeout value cannot be null');
+        }
         $this->executor->execute(
             DriverCommand::IMPLICITLY_WAIT,
             ['ms' => floor($seconds * 1000)]
@@ -53,7 +56,7 @@ class WebDriverTimeouts
     /**
      * Set the amount of time to wait for an asynchronous script to finish execution before throwing an error.
      *
-     * @param float $seconds Wait time in seconds.
+     * @param null|int|float $seconds Wait time in seconds.
      * @return WebDriverTimeouts The current instance.
      */
     public function setScriptTimeout($seconds)
@@ -61,12 +64,15 @@ class WebDriverTimeouts
         if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::SET_SCRIPT_TIMEOUT,
-                ['script' => floor($seconds * 1000)]
+                ['script' => $seconds === null ? null : floor($seconds * 1000)]
             );
 
             return $this;
         }
 
+        if ($seconds === null) {
+            throw new \InvalidArgumentException('JsonWire Protocol timeout value cannot be null');
+        }
         $this->executor->execute(
             DriverCommand::SET_SCRIPT_TIMEOUT,
             ['ms' => floor($seconds * 1000)]
@@ -78,7 +84,7 @@ class WebDriverTimeouts
     /**
      * Set the amount of time to wait for a page load to complete before throwing an error.
      *
-     * @param float $seconds Wait time in seconds.
+     * @param null|int|float $seconds Wait time in seconds.
      * @return WebDriverTimeouts The current instance.
      */
     public function pageLoadTimeout($seconds)
@@ -86,12 +92,15 @@ class WebDriverTimeouts
         if ($this->isW3cCompliant) {
             $this->executor->execute(
                 DriverCommand::SET_SCRIPT_TIMEOUT,
-                ['pageLoad' => floor($seconds * 1000)]
+                ['pageLoad' => $seconds === null ? null : floor($seconds * 1000)]
             );
 
             return $this;
         }
 
+        if ($seconds === null) {
+            throw new \InvalidArgumentException('JsonWire Protocol timeout value cannot be null');
+        }
         $this->executor->execute(DriverCommand::SET_TIMEOUT, [
             'type' => 'page load',
             'ms' => floor($seconds * 1000),


### PR DESCRIPTION
Thanks to PHPStan, I noticed something "off" when on the client side we divide timeouts by 1000 (resulting in a float) but then this library multiplies them back by 1000 (timeouts on our side are in ms).

This library does not ensure that the correct timeout value type is passed, for example W3C does not allow float, but at the same time this library does not handle nulls.

With this PR, I'm trying to fix the following problems:
- For *JsonWire Protocol* we should allow `int|float` ("numbers"): https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidtimeouts
- For *W3C Protocol* we should allow `null|int`: https://www.w3.org/TR/webdriver2/#timeouts
- The PHPDoc is updated as applicable
