### PR TITLE
Add Throwable extension to PhpWebDriverExceptionInterface

### DIFF
--- a/lib/Exception/PhpWebDriverExceptionInterface.php
+++ b/lib/Exception/PhpWebDriverExceptionInterface.php
@@ -5,6 +5,6 @@ namespace Facebook\WebDriver\Exception;
 /**
  * Common interface to identify all exceptions thrown in php-webdriver (both those of WebDriver protocol and internal).
  */
-interface PhpWebDriverExceptionInterface
+interface PhpWebDriverExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
Currently, `PhpWebDriverExceptionInterface` does not extend `\Throwable`, making it difficult to catch exceptions by the interface while still accessing common exception methods like `getMessage()`, etc. This PR fixes that by extending `\Throwable`, so exceptions can be handled more easily.